### PR TITLE
Updated genesis

### DIFF
--- a/files/ptn0/files/genesis.json
+++ b/files/ptn0/files/genesis.json
@@ -9,26 +9,26 @@
     },
     "minUTxOValue": 0,
     "decentralisationParam": 0.5,
-    "maxTxSize": 2048,
+    "maxTxSize": 16384,
     "minFeeA": 50,
-    "maxBlockBodySize": 2097152,
+    "maxBlockBodySize": 65536,
     "keyMinRefund": 50,
     "minFeeB": 0,
-    "eMax": 0,
+    "eMax": 100,
     "extraEntropy": {
       "tag": "NeutralNonce"
     },
     "maxBlockHeaderSize": 8192,
     "keyDeposit": 1000,
     "keyDecayRate": 0,
-    "nOpt": 100,
-    "rho": 0,
-    "poolMinRefund": 1000,
-    "tau": 0,
-    "a0": 0.5
+    "nOpt": 5,
+    "rho": 1.78650067e-3,
+    "poolMinRefund": 0,
+    "tau": 0.1,
+    "a0": 0.4
   },
-  "protocolMagicId": 838299402,
-  "systemStart": "2020-05-29T07:20:00.00Z",
+  "protocolMagicId": 4002,
+  "systemStart": "2020-06-04T01:30:00.00Z",
   "genDelegs": {
     "7e4c9656274afdd4d41a282b5573b7d24e343a436f1baf7aea6fae4ec8230c64": "e14e834b692b1a42917927751d77f19e904e8b8e6f79a38db363d0b0a23b1c21",
     "a2da5b6ae89cbbb592d2ed14df932fb182dad922d172439568dace944499dbba": "038fb60f021b41d510a901630e210ba09b07463056bd7ed96487b92c7df741a2"
@@ -64,11 +64,11 @@
     "60896d73f2aeae8bc4be55b2070a48834de84ebb356d5fd9c82ae3f5d49a37313d": 1000000000000
   },
   "maxLovelaceSupply": 5e+18,
-  "networkMagic": 4001,
+  "networkMagic": 4002,
   "epochLength": 900,
   "staking": null,
   "slotsPerKESPeriod": 14400,
   "slotLength": 2,
-  "maxKESEvolutions": 22400,
+  "maxKESEvolutions": 2240,
   "securityParam": 500
 }


### PR DESCRIPTION
Update Genesis to match IOHK QA for some bits:
- Reduce max Block Size (since most blocks go empty, makes little sense to have huge blocks)
-  Increase Transaction Size (allows more input/outputs, and potentially more certs)
- Reduce nOpt (to see the effects of going beyond more pools than optimal desired)
- Add rho and tau constants to match QA (it wasnt set before)
- Match protocolMagicId and networkMagic (not clear why they're still present), update them so that ones on older genesis do not connect to new one
