### PR TITLE
Update Genesis: reduce securityParam, troubleshooting rewards

### DIFF
--- a/files/ptn0/files/genesis.json
+++ b/files/ptn0/files/genesis.json
@@ -27,8 +27,8 @@
     "tau": 0.1,
     "a0": 0.4
   },
-  "protocolMagicId": 4002,
-  "systemStart": "2020-06-04T01:30:00.00Z",
+  "protocolMagicId": 4003,
+  "systemStart": "2020-06-04T07:10:00.00Z",
   "genDelegs": {
     "7e4c9656274afdd4d41a282b5573b7d24e343a436f1baf7aea6fae4ec8230c64": "e14e834b692b1a42917927751d77f19e904e8b8e6f79a38db363d0b0a23b1c21",
     "a2da5b6ae89cbbb592d2ed14df932fb182dad922d172439568dace944499dbba": "038fb60f021b41d510a901630e210ba09b07463056bd7ed96487b92c7df741a2"
@@ -64,11 +64,11 @@
     "60896d73f2aeae8bc4be55b2070a48834de84ebb356d5fd9c82ae3f5d49a37313d": 1000000000000
   },
   "maxLovelaceSupply": 5e+18,
-  "networkMagic": 4002,
+  "networkMagic": 4003,
   "epochLength": 900,
   "staking": null,
   "slotsPerKESPeriod": 14400,
   "slotLength": 2,
   "maxKESEvolutions": 2240,
-  "securityParam": 500
+  "securityParam": 36
 }


### PR DESCRIPTION
Logic being ( epochLength * activeSlotCoEff * (potential lower limit of d) ).
Thus, 900 * 0.4 *0.1 = 36

This is part of troubleshooting to see if that's what prevents rewards from being distributed