### PR TITLE
Update Genesis: higher rho and securityParam

### DIFF
--- a/files/ptn0/files/genesis.json
+++ b/files/ptn0/files/genesis.json
@@ -22,13 +22,13 @@
     "keyDeposit": 1000,
     "keyDecayRate": 0,
     "nOpt": 5,
-    "rho": 1.78650067e-7,
+    "rho": 1.78650067e-6,
     "poolMinRefund": 0,
     "tau": 0.1,
     "a0": 0.4
   },
-  "protocolMagicId": 4004,
-  "systemStart": "2020-06-05T05:35:00.00Z",
+  "protocolMagicId": 4005,
+  "systemStart": "2020-06-09T02:15:00.00Z",
   "genDelegs": {
         "b18d6e32c2fb1c0ae7e9a16757a728fc14f2694c6d4c90c0ff3a8d241a4daa4a": {
             "delegate": "ff74c4b0ec688de34e1089a22d97badfd1c20afec65c07c82fd180a2491462b7",
@@ -70,11 +70,11 @@
     "60896d73f2aeae8bc4be55b2070a48834de84ebb356d5fd9c82ae3f5d49a37313d": 1000000000000
   },
   "maxLovelaceSupply": 1e+15,
-  "networkMagic": 4004,
+  "networkMagic": 4005,
   "epochLength": 900,
   "staking": null,
   "slotsPerKESPeriod": 14400,
   "slotLength": 2,
   "maxKESEvolutions": 2240,
-  "securityParam": 36
+  "securityParam": 108
 }


### PR DESCRIPTION
assuming 0.3 as minimal value for d, epochSlots * active slot co-efficient * 0.3 = 108 as securityParam

Also, increasing rho to be 10 times or previous genesis (where rewards were found to be too low)