### PR TITLE
[CNTOOLS] Wallet/Pool selection filter & quick navigation

### DIFF
--- a/scripts/cnode-helper-scripts/cntools.config
+++ b/scripts/cnode-helper-scripts/cntools.config
@@ -31,6 +31,9 @@ POOL_PLEDGECERT_FILENAME="pledge.cert"
 POOL_CURRENT_KES_START="kes.start"
 POOL_DEREGCERT_FILENAME="pool.dereg"
 
+# limit for extended wallet selection menu filtering (balance check and delegation status)
+# if more wallets exist than limit set these checks will be disabled to improve performance
+WALLET_SELECTION_FILTER_LIMIT=10
 
 # log cntools activities (comment out to disable)
 CNTOOLS_LOG="${CNODE_HOME}/logs/cntools-history.log"

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -116,7 +116,7 @@ function selectOption {
   cursor_blink_off() { printf "$ESC[?25l"; }
   cursor_to()        { printf "$ESC[$1;${2:-1}H"; }
   print_option()     { printf "  $1 "; }
-  print_selected()   { printf " $ESC[7m $1 $ESC[27m"; }
+  print_selected()   { printf " $ESC[7m $1 $ESC[27m$2"; }
   get_cursor_row()   { IFS=';' read -sdR -p $'\E[6n' ROW COL; echo ${ROW#*[}; }
   key_input()        { read -rsn1 key   # get 1 character
                        if [[ $key == $ESC ]]; then
@@ -127,6 +127,7 @@ function selectOption {
                        elif [[ $key = ""   ]]; then echo enter;
                        else echo $key; fi; }
   opt_shortcut()     { [[ "$1" =~ ^\[([[:alnum:]])\].* ]] && echo ${BASH_REMATCH[1]}; }
+  opt_firstchar()    { printf "${1:0:1}" | tr '[:upper:]' '[:lower:]'; }
 
   # initially print empty new lines (scroll down if at bottom of screen)
   for opt; do printf "\n"; done
@@ -145,11 +146,18 @@ function selectOption {
     # print options by overwriting the last lines
     local idx=0
     for opt; do
+      opt_part2=""
+      if [[ "$opt" =~ ^(.*)[[:space:]](\(.*) ]]; then 
+        opt_part1="${BASH_REMATCH[1]}"
+        opt_part2=" ${BASH_REMATCH[2]}"
+      else
+        opt_part1="$opt"
+      fi
       cursor_to $(($startrow + $idx))
       if [ $idx -eq $selected ]; then
-        print_selected "$opt"
+        print_selected "$opt_part1" "$opt_part2"
       else
-        print_option "$opt"
+        print_option "$opt_part1$opt_part2"
       fi
       ((idx++))
     done
@@ -164,12 +172,19 @@ function selectOption {
              if [ $selected -lt 0 ]; then selected=$(($# - 1)); fi;;
       down)  ((selected++));
              if [ $selected -ge $# ]; then selected=0; fi;;
-      *)     i=0
+      *)     # shortcut available for selected key?
+             i=0
              for opt; do
-               shortcut=$(opt_shortcut "$opt")
-               [[ ${key_pressed} = ${shortcut} ]] && selected=${i} && shortcut_found="yes" && break
+               [[ ${key_pressed} = $(opt_shortcut "$opt") ]] && selected=${i} && shortcut_found="yes" && break
                ((i++))
-             done;;
+             done
+             # If no shortcut is found, lets see if it matches the first char of any of the options
+             j=0
+             for opt; do
+               [[ "${shortcut_found}" != "yes" && ${key_pressed} = $(opt_firstchar "$opt") ]] && selected=${j} && break
+               ((j++))
+             done
+             ;;
     esac
   done
 
@@ -187,59 +202,39 @@ function select_opt {
   return $answer
 }
 
-# Command    : selectDir [path to folder]
-# Description: A helper function to selectOption() specifically for directory selection 
-# Parameters : path to folder    >   full path to folder, subdirs of this folder added to select menu
-# Return     : populates ${dir_name} variable, 'Cancel' option/value added to all selections
+
+# Command    : getDirs [path to folder]
+# Description: A helper function to get all subdirs for a directory
+# Parameters : path to folder    >   full path to folder, subdirs of this folder returned
+# Return     : populates ${dirs} array
 # Examples of Usage:
-#   >> selectDir /opt/cardano/cnode/priv/wallet
+#   >> getDirs /opt/cardano/cnode/priv/wallet
 #
-function selectDir {
+function getDirs {
+  if [[ ! -d "$1" ]]; then
+    say "${RED}ERROR${NC}: Missing folder: $1"
+    waitForInput && return 1
+  fi
   dirs=()
   while IFS= read -r -d '' dir; do
     dirs+=("$(basename ${dir})")
   done < <(find "${1}" -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
+  return 0
+}
+
+# Command    : selectDir [dir1 dir2 ...]
+# Description: A helper function to selectOption() specifically for directory selection 
+# Parameters : array of dirs    >   array of dirs to include in selection, '[c] Cancel' option added to all selections
+# Return     : populates ${dir_name} variable, 
+# Examples of Usage:
+#   >> selectDir Wallet1 Wallet2 Wallet3
+#
+function selectDir {
+  dirs=("$@")
   dirs+=("[c] Cancel")
   selectOption "${dirs[@]}" 1>&2
   dir_name=${dirs[$?]}
-}
-
-# Command    : selectWallet
-# Description: A helper function to selectDir() specifically for wallet selection 
-# Parameters : null
-# Return     : populates ${wallet_name} variable, returns 1 on cancelation
-# Examples of Usage:
-#   >> selectWallet
-#
-function selectWallet {
-  # Make sure wallet folder exist and is non-empty
-  if [[ ! -d "${WALLET_FOLDER}" || $(find "${WALLET_FOLDER}" -mindepth 1 -maxdepth 1 -type d | wc -l) -eq 0 ]]; then
-    say "${RED}ERROR${NC}: Missing or empty wallet folder, please first create a payment wallet"
-    say "Wallet folder: ${WALLET_FOLDER}"
-    waitForInput && return 1
-  fi
-  say "Select Wallet:\n"
-  selectDir "${WALLET_FOLDER}"
-  [[ "${dir_name}" = "[c] Cancel" ]] && return 1 || wallet_name="${dir_name}"
-}
-
-# Command    : selectPool
-# Description: A helper function to selectDir() specifically for pool selection 
-# Parameters : null
-# Return     : populates ${pool_name} variable, returns 1 on cancelation
-# Examples of Usage:
-#   >> selectPool
-#
-function selectPool {
-  # Make sure pool folder exist and is non-empty
-  if [[ ! -d "${POOL_FOLDER}" || $(find "${POOL_FOLDER}" -mindepth 1 -maxdepth 1 -type d | wc -l) -eq 0 ]]; then
-    say "${RED}ERROR${NC}: Missing or empty pool folder, please first create a pool"
-    say "Pool folder: ${POOL_FOLDER}"
-    waitForInput && return 1
-  fi
-  say "Select Pool:\n"
-  selectDir "${POOL_FOLDER}"
-  [[ "${dir_name}" = "[c] Cancel" ]] && return 1 || pool_name="${dir_name}"
+  [[ "${dir_name}" = "[c] Cancel" ]] && return 1 || return 0
 }
 
 

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -491,12 +491,13 @@ getBalance() {
 }
 
 
-# Command    : getBalanceAllAddr [path to wallet]
+# Command    : getBalanceAllAddr [path to wallet] [inkl rewards]
 # Description: check balance for all wallet addresses
 # Parameters : path to wallet   >   Full path to wallet folder
+#              inkl rewards     >   'yes' = do rewards check, else skipped
 # Return     : populates $<addr_type>_lovelace & $<addr_type>_ada
 # Examples of Usage:
-#   >> getBalanceAllAddr /opt/cardano/cnode/priv/wallet/MyWallet
+#   >> getBalanceAllAddr "/opt/cardano/cnode/priv/wallet/MyWallet" "yes"
 getBalanceAllAddr() {
   payment_lovelace=0
   payment_ada=0
@@ -520,15 +521,17 @@ getBalanceAllAddr() {
   fi
   if [ -f "${base_addr_file}" ]; then
     base_addr=$(cat "${base_addr_file}")
-    stake_addr=$(cat "${stake_addr_file}")
     getBalance ${base_addr} >/dev/null
     base_lovelace=${TOTALBALANCE}
     base_ada=${totalBalanceADA}
     cp -f ${TMP_FOLDER}/fullUtxo.out ${TMP_FOLDER}/fullUtxo_base.out
     cp -f ${TMP_FOLDER}/balance.out ${TMP_FOLDER}/balance_base.out
-    reward_lovelace=$(${CCLI} shelley query stake-address-info --testnet-magic ${NWMAGIC} --address ${stake_addr} | jq -r '.[].rewardAccountBalance // empty')
-    [[ "${reward_lovelace}" =~ ^[0-9]+$ ]] || reward_lovelace=0
-    reward_ada=$(lovelacetoADA ${reward_lovelace})
+    if [[ $2 = "yes" && -f "${stake_addr_file}" ]]; then
+      stake_addr=$(cat "${stake_addr_file}")
+      reward_lovelace=$(${CCLI} shelley query stake-address-info --testnet-magic ${NWMAGIC} --address ${stake_addr} | jq -r '.[].rewardAccountBalance // empty')
+      [[ "${reward_lovelace}" =~ ^[0-9]+$ ]] || reward_lovelace=0
+      reward_ada=$(lovelacetoADA ${reward_lovelace})
+    fi
   fi
 }
 

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -647,7 +647,7 @@ case $OPERATION in
       pay_payment_sk_file="${WALLET_FOLDER}/${dir}/${WALLET_PAY_SK_FILENAME}"
       [[ ! -f "${base_addr_file}" || ! -f "${stake_addr_file}" || ! -f "${stake_sk_file}" || ! -f "${stake_vk_file}" || ! -f "${pay_payment_sk_file}" ]] && continue
       if [[ ${wallet_count} -le ${WALLET_SELECTION_FILTER_LIMIT} ]]; then
-        reward_lovelace=$(${CCLI} shelley query stake-address-info --testnet-magic ${NWMAGIC} --address $(cat "${stake_addr_file}") | jq -r '.[].rewardAccountBalance // empty')
+        reward_lovelace=$(${CCLI} shelley query stake-address-info --testnet-magic ${NWMAGIC} --address "$(cat ${stake_addr_file})" | jq -r '.[].rewardAccountBalance // empty')
         [[ "${reward_lovelace}" =~ ^[0-9]+$ ]] || reward_lovelace=0
         [[ ${reward_lovelace} -le 0 ]] && continue
         reward_ada=$(lovelacetoADA ${reward_lovelace})


### PR DESCRIPTION
* Wallet & pool selection helper functions removed and getDirs() added. This to be able to do custom wallet and pool selection menu filtering in cntools.

* Relevant wallet balance and delegation status added directly to menu for each wallet entry.

* Only wallets and pools that should be selectable are now displayed.

* Quick navigation added, first shortcut key match is checked. If no shortcut key match is found it will see if there is an entry where the first letter match pressed key and if so jumps to that location.

The extra information and filtering does put some extra load before menu can be displayed. Have to check if this extra time is acceptable or not when there are lots of wallet and pools to display.