### PR TITLE
Added libsodium-dev to "sudo apt-get install" for "Debian/Ubuntu"

### DIFF
--- a/docs/Setup-Node.md
+++ b/docs/Setup-Node.md
@@ -33,10 +33,10 @@ cardano-node run \
           --host-addr 0.0.0.0 \
           --port 5001 \
           --socket-path $CNODE_HOME/sockets/node0.socket \
-          --topology $CNODE_HOME/files/topology.json
-          --shelley-kes-key $CNODE_HOME/priv/pool/$POOLNAME/Hot.skey
-          --shelley-vrf-key $CNODE_HOME/priv/pool/$POOLNAME/Vrf.skey
-          --shelley-operational-certificate $CNODE_HOME/priv/pool/$POOLNAME/opcert
+          --topology $CNODE_HOME/files/topology.json \
+          --shelley-kes-key $CNODE_HOME/priv/pool/$POOLNAME/hot.skey \
+          --shelley-vrf-key $CNODE_HOME/priv/pool/$POOLNAME/vrf.skey \
+          --shelley-operational-certificate $CNODE_HOME/priv/pool/$POOLNAME/op.cert
 ```
 
 Note that if you do not want your node to be publicly available, you can change `--host-addr` to `127.0.0.1`

--- a/files/ptn0/scripts/prereqs.sh
+++ b/files/ptn0/scripts/prereqs.sh
@@ -97,10 +97,10 @@ if [ "$WANT_BUILD_DEPS" = 'Y' ]; then
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | $sudo tee /etc/apt/sources.list.d/yarn.list > /dev/null
     $sudo apt-get -y update > /dev/null
     echo "  Installing missing prerequisite packages, if any.."
-    $sudo apt-get -y install python3 build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev systemd libsystemd-dev zlib1g-dev yarn make g++ tmux git jq wget libncursesw5 gnupg aptitude > /dev/null;rc=$?
+    $sudo apt-get -y install python3 build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev systemd libsystemd-dev zlib1g-dev yarn make g++ tmux git jq wget libncursesw5 gnupg aptitude libsodium-dev > /dev/null;rc=$?
     if [ $rc != 0 ]; then
       echo "An error occurred while installing the prerequisite packages, please investigate by using the command below:"
-      echo "sudo apt-get -y install python3 build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev systemd libsystemd-dev zlib1g-dev npm yarn make g++ tmux git jq wget libncursesw5 gnupg"
+      echo "sudo apt-get -y install python3 build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev systemd libsystemd-dev zlib1g-dev yarn make g++ tmux git jq wget libncursesw5 gnupg aptitude libsodium-dev"
       echo "It would be best if you could submit an issue at https://github.com/cardano-community/guild-operators with the details to tackle in future, as some errors may be due to external/already present dependencies"
       exit;
     else


### PR DESCRIPTION
Added libsodium-dev to "sudo apt-get install" for "Debian/Ubuntu" section in readiness for compilation of cardano-node 1.14.0.

I'm not sure EXACTLY what the equivalent package name(s) are for CentOS/RHEL/Fedora so haven't added these. However, I think they might be called:

Fedora - libsodium-devel
CentOS / RHEL - epel-release libsodium-devel

Not sure why the "Fixed 'typos'" typos pull is also showing here as it has been merged already?

matticus 🥝