### PR TITLE
Add descriptions for Ticker values, add libtool to prereqs for 1.14, …

### DIFF
--- a/docs/Build/node-cli.md
+++ b/docs/Build/node-cli.md
@@ -10,6 +10,7 @@ Run the commands below to clone the Cardano Node git repository and build the bi
 cd ~/git
 git clone https://github.com/input-output-hk/cardano-node
 cd cardano-node
+### Please ensure you have run the *UPDATED* prereqs.sh (see link at top of this document) before continuing
 echo -e "package cardano-crypto-praos\n  flags: -external-libsodium-vrf" > cabal.project.local
 $CNODE_HOME/scripts/cabal-build-all.sh
 ```

--- a/files/ptn0/scripts/prereqs.sh
+++ b/files/ptn0/scripts/prereqs.sh
@@ -97,10 +97,10 @@ if [ "$WANT_BUILD_DEPS" = 'Y' ]; then
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | $sudo tee /etc/apt/sources.list.d/yarn.list > /dev/null
     $sudo apt-get -y update > /dev/null
     echo "  Installing missing prerequisite packages, if any.."
-    $sudo apt-get -y install python3 build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev systemd libsystemd-dev libsodium-dev zlib1g-dev yarn make g++ tmux git jq wget libncursesw5 gnupg aptitude > /dev/null;rc=$?
+    $sudo apt-get -y install python3 build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev systemd libsystemd-dev libsodium-dev zlib1g-dev yarn make g++ tmux git jq wget libncursesw5 gnupg aptitude libtool autoconf > /dev/null;rc=$?
     if [ $rc != 0 ]; then
       echo "An error occurred while installing the prerequisite packages, please investigate by using the command below:"
-      echo "sudo apt-get -y install python3 build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev systemd libsystemd-dev libsodium-dev zlib1g-dev npm yarn make g++ tmux git jq wget libncursesw5 gnupg"
+      echo "sudo apt-get -y install python3 build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev systemd libsystemd-dev libsodium-dev zlib1g-dev npm yarn make g++ tmux git jq wget libncursesw5 gnupg libtool autoconf"
       echo "It would be best if you could submit an issue at https://github.com/cardano-community/guild-operators with the details to tackle in future, as some errors may be due to external/already present dependencies"
       exit;
     else
@@ -115,10 +115,10 @@ if [ "$WANT_BUILD_DEPS" = 'Y' ]; then
     $sudo rpm --import https://dl.yarnpkg.com/rpm/pubkey.gpg > /dev/null
     $sudo yum -y update > /dev/null
     echo "  Installing missing prerequisite packages, if any.."
-    $sudo yum -y install python3 coreutils-single pkgconfig libffi-devel gmp-devel openssl-devel ncurses-libs ncurses-compat-libs systemd systemd-devel libsodium-devel zlib-devel npm yarn make gcc-c++ tmux git wget epel-release jq gnupg > /dev/null;rc=$?
+    $sudo yum -y install python3 coreutils pkgconfig libffi-devel gmp-devel openssl-devel ncurses-libs ncurses-compat-libs systemd systemd-devel libsodium-devel zlib-devel npm yarn make gcc-c++ tmux git wget epel-release jq gnupg libtool autoconf > /dev/null;rc=$?
     if [ $rc != 0 ]; then
       echo "An error occurred while installing the prerequisite packages, please investigate by using the command below:"
-      echo "sudo yum -y install coreutils-single python3 pkgconfig libffi-devel gmp-devel openssl-devel ncurses-libs ncurses-compat-libs systemd systemd-devel libsodium-devel zlib-devel npm yarn make gcc-c++ tmux git wget epel-release jq gnupg"
+      echo "sudo yum -y install coreutils python3 pkgconfig libffi-devel gmp-devel openssl-devel ncurses-libs ncurses-compat-libs systemd systemd-devel libsodium-devel zlib-devel npm yarn make gcc-c++ tmux git wget epel-release jq gnupg libtool autoconf"
       echo "It would be best if you could submit an issue at https://github.com/cardano-community/guild-operators with the details to tackle in future, as some errors may be due to external/already present dependencies"
       exit;
     fi
@@ -172,11 +172,27 @@ else
   . "${HOME}/.bashrc"
 fi
 
+mkdir "${HOME}/git" > /dev/null 2>&1 # To hold git repositories that will be used for building binaries
+
+# This part is commented out as if-and-when libsodium at system causes a conflict with fork, IOHK would need to fix this in a more acceptable manner.
+
+# if grep -q "/usr/local/lib:$LD_LIBRARY_PATH" ~/.bashrc; then
+#   echo "Load Library Paths already set up!"
+# else
+#   echo "export LD_LIBRARY_PATH=/usr/lib64\:\$LD_LIBRARY_PATH" >> ~/.bashrc
+#   cd "$HOME/git" || return
+#   git clone https://github.com/input-output-hk/libsodium >/dev/null 2>&1
+#   cd libsodium
+#   git checkout 66f017f1
+#   ./autogen.sh > autogen.log 2&1
+#   ./configure > configure.log 2&1
+#   make > make.log 2>&1
+#   $sudo make install > install.log 2>&1
+# fi
+
 $sudo mkdir -p "$CNODE_HOME"/files "$CNODE_HOME"/db "$CNODE_HOME"/logs "$CNODE_HOME"/scripts "$CNODE_HOME"/sockets "$CNODE_HOME"/priv
 $sudo chown -R "$U_ID":"$G_ID" "$CNODE_HOME"
 chmod -R 755 "$CNODE_HOME"
-
-mkdir -p ~/git # To hold git repositories that will be used for building binaries
 
 cd "$CNODE_HOME/files" || return
 

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -1263,14 +1263,16 @@ case $OPERATION in
       meta_description=$(jq -r .description "${pool_meta_file}")
     fi
     if [[ -f "${pool_config}" ]]; then
-      meta_json_url=$(jq -r .json_url "${pool_config}")
+      if [[ -z "$(jq -r .json_url ${pool_config})" ]]; then
+        meta_json_url=$(jq -r .json_url "${pool_config}")
+      fi
     fi
     echo "" && read -r -p "Enter Pool's Name (default: ${meta_name}): " name_enter
     name_enter=${name_enter//[^[:alnum:]]/_}
     if [[ -n "${name_enter}" ]]; then
       meta_name="${name_enter}"
     fi
-    echo "" && read -r -p "Enter Pool's Ticker (default: ${meta_ticker}): " ticker_enter
+    echo "" && read -r -p "Enter Pool's Ticker , should be between 3-5 characters (default: ${meta_ticker}): " ticker_enter
     ticker_enter=${ticker_enter//[^[:alnum:]]/_}
     if [[ -n "${ticker_enter}" ]]; then
       meta_ticker="${ticker_enter}"
@@ -1287,7 +1289,7 @@ case $OPERATION in
       meta_homepage="${homepage_enter}"
     #else #TODO: URL validation
     fi
-    echo "" && read -r -p "Enter Pool's JSON URL to host metadata file (default: ${meta_json_url}): " json_url_enter
+    echo "" && read -r -p "Enter Pool's JSON URL to host metadata file - URL length should be less than 64 chars (default: ${meta_json_url}): " json_url_enter
     json_url_enter="${json_url_enter}"
     if [[ -n "${json_url_enter}" ]]; then
       meta_json_url="${json_url_enter}"


### PR DESCRIPTION
Doco:
- Emphasize again the need to run prereqs.sh when following node-cli.md

CNTools:
- Add descriptions for Ticker values length
- Ensure default value for JSON_URL is retrieved
- Add description for JSON value length

Pre-Reqs:
- Centos:
  - Revert coreutils-single to coreutils , until appropriate fix is available, closes #240 
- Add libtool and autoconf for cardano-node 1.14.1
