### PR TITLE
Add default values for relay on pool modify and re-registration

### DIFF
--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -5,7 +5,7 @@
 # Variables to keep counter for versions                   #
 ############################################################
 CNTOOLS_MAJOR_VERSION=0 # Any breaking changes (eg: that requires change of cntools.config, env or a change in priv folder would be considered breaking and will be exempt from auto-update)
-CNTOOLS_MINOR_VERSION=1 # Changes that can be applied without breaking existing functionality that can be applied from within CNTools
+CNTOOLS_MINOR_VERSION=2 # Changes that can be applied without breaking existing functionality that can be applied from within CNTools
 CNTOOLS_VERSION="$CNTOOLS_MAJOR_VERSION.$CNTOOLS_MINOR_VERSION"
 
 ############################################################


### PR DESCRIPTION
* A new parameter added to pools config file for relays, type. Containing either IPv4 or DNS_A currently.

* Old relays table on modify/registration redone to include type. Also put together a little different to handle null values and omit quotation marks.

* Pool show updated to show type for relay

* On pool re-registration or modification the old relay valus are now read from pool config. If selection of type match old values the default values are set to old config.

* Minor alignment fix of main menu header