### PR TITLE
CNTools wallet redesign [breaking change]

### DIFF
--- a/docs/Scripts/cntools-common.md
+++ b/docs/Scripts/cntools-common.md
@@ -4,15 +4,15 @@ CNTools contains more functionality not described here.
 
 Step by Step guide to create a pool with CNTools
 
-* [Stake Wallet](#stake-wallet)  
-a stake wallet is needed for delegation/pledge
+* [Create Wallet](#create-wallet)  
+a wallet is needed for pledge and to pay for pool registration fee
 * [Create Pool](#create-pool)  
 create the necessary pool keys 
 * [Register Pool](#create-pool)  
 register the pool on-chain
 
 
-#### Stake Wallet
+#### Create Wallet
 
 **1.** `Choose Wallet [w]` and you will be presented with the following menu:
 ```
@@ -20,7 +20,7 @@ register the pool on-chain
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  Wallet Management
 
- ) New      -  create a new payment wallet or upgrade existing to a stake wallet
+ ) New      -  create a new wallet
  ) List     -  list all available wallets in a compact view
  ) Show     -  show detailed view of a specific wallet
  ) Remove   -  remove a wallet
@@ -37,56 +37,25 @@ register the pool on-chain
   [e] Encrypt
   [h] Home
 ```
-**2.** Choose `New [n]` to go to submenu for creating a new wallet
+**2.** Choose `New [n]` to create a new wallet
+**3.** Give the wallet a name  
+**4.** CNTools will give you the wallet address.  For example:
 ```
  >> WALLET >> NEW
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- Wallet Type
-
- ) Payment  -  First step for a new wallet
-               A payment wallet can send and receive funds but not delegate/pledge.
-
- ) Stake    -  Upgrade existing payment wallet to a stake wallet
-               Make sure there are funds available in payment wallet before upgrade
-               as this is needed to pay for the stake wallet registration fee.
-               A stake wallet is needed to be able to delegate and pledge to a pool.
-               All funds from payment address will be moved to base address.
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
- Choose wallet type
-
-  [p] Payment
-  [s] Stake
-  [h] Home
-```
-**3.** Choose `Payment [p]` type of wallet  
-**4.** Give the wallet a name  
-**5.** CNTools will give you your payment address.  For example:
-```
- >> WALLET >> NEW >> PAYMENT
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Name of new wallet: bob
 
-New Wallet: bob
-Payment Address: 60f8a4bed2e379cf8ee5aa28bb7b227362b38694368b767b270720760503132fc5
+New Wallet : bob
+Address    : 00cf9ad54b7f6beac642cd460589e5b42ea40d6848aeeafa5e905855ed249d3d7693cb75605a8bc8edc8cca63cee97a3afb5502d0e8c46d212
+
+You can now send and receive ADA using this address.
+Wallet will be automatically registered on chain if you
+choose to delegate or pledge wallet when registering a stake pool.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
-**6.**  Send some money to this wallet. Either through the faucet or have a friend send you some.  
+**5.**  Send some money to this wallet. Either through the faucet or have a friend send you some.  
 **IMPORTANT** - The wallet must have funds in it before you can proceed.  
-**7.**  From the main menu choose `Wallet >> New` and then this time choose `Stake [s]` to upgrade your wallet  
-**8.**  CNTools will give you a list of wallets you can upgrade. Choose the wallet you created in step 4. In this example case, that wallet is called `bob`. This will send a transaction to the blockchain to upgrade your wallet to a staking wallet. The result should look something like this:
-```
-New block was created - 23386
-New Stake Wallet : bob
-Payment Address  : 60f8a4bed2e379cf8ee5aa28bb7b227362b38694368b767b270720760503132fc5
-Payment Balance  : 0 ADA
-Base Address     : 00f8a4bed2e379cf8ee5aa28bb7b227362b38694368b767b270720760503132fc545bdb48005781a47a864347843654fd58c1363695453697b5b59fd7ca2af3dc8
-Base Balance     : 99.428691 ADA
-Reward Address   : 5821e045bdb48005781a47a864347843654fd58c1363695453697b5b59fd7ca2af3dc8
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-```
-The total balance is 0 for the payment address because ALL funds have been moved to the base address.  
 
 
 #### Create Pool
@@ -136,7 +105,7 @@ Start cardano node with the following run arguments:
 --shelley-operational-certificate /opt/cardano/cnode/priv/pool/LOVE/op.cert
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
-4.  Start or restart your cardano-node with the parameters as shown.  This will ensure your node has all the information necessary to create blocks.  
+**4.**  Start or restart your cardano-node with the parameters as shown.  This will ensure your node has all the information necessary to create blocks.  
 **IMPORTANT** - If you do not start your node with these parameters you won't be able to make blocks.
 
 
@@ -144,23 +113,33 @@ Start cardano node with the following run arguments:
 
 **1.**  From the main menu select `Pool [p]`  
 **2.**  Select `Register [r]`  
-**3.**  Select the pool you just created in step 11 above  
-**4.**  CNTools will give you prompts to set metadata, pledge, margin and cost. Enter values that are useful to you.  
+**3.**  Select the pool you just created  
+**4.**  CNTools will give you prompts to set pledge, margin, cost, metadata, and relays. Enter values that are useful to you.  
 **IMPORTANT** - Make sure you set your pledge low enough to insure your funds in your wallet will cover pledge plus pool registration fees.  
+**5.**  Select wallet to use as pledge wallet, `bob` in our case.  
+As this is a newly created wallet you will be prompted to press a key to continue with wallet registration.  
+When complete and if successful, both wallet and pool will be registered on-chain.
 
 It will look something like this:
 ```
  >> POOL >> REGISTER
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Dumping ledger-state from node, can take a while on larger networks...
+
 Select Pool:
 
   LOVE
   [c] Cancel
 
+ -- Pool Parameters --
+
 Pledge (in ADA, default: 50000): 899
 Margin (in %, default: 7.5): 10
 Cost (in ADA, default: 256): 500
+
+ -- Pool Metadata --
+
 Enter Pool's Name (default: LOVE):
 Enter Pool's Ticker , should be between 3-5 characters (default: LOVE):
 Enter Pool's Description (default: No Description): My custom description
@@ -168,15 +147,35 @@ Enter Pool's Homepage (default: https://foo.com): https://love.fake.com
 Enter Pool's JSON URL to host metadata file - URL length should be less than 64 chars (default: https://foo.bat/poolmeta.json): https://love.fake.com/poolmeta.json
 
 Please make sure you host your metadata JSON file (with contents as below) at https://love.fake.com/poolmeta.json :
+
 {
   "name": "LOVE",
   "ticker": "LOVE",
   "description": "My custom description",
   "homepage": "https://love.fake.com"
 }
+
+ -- Pool Relay Registration --
+
+  [d] A or AAAA DNS record  (single)
+  [4] IPv4 address (multiple)
+  [c] Cancel
+
+Enter relays's DNS record, only A or AAAA DNS records (default: ): relay1.love.fake.com
+Enter relays's port (default: ): 3001
+
+Select Pledge Wallet:
+
+  bob  (1000.991236 ADA)
+  [c] Cancel
+
+Funds in pledge wallet: 1000.991236 ADA
+
+Wallet not registered on chain, press any key to continue with registration
+
+... *wallet registration and pool registration output* ... 
 ```
-**5.**  Select the wallet you want to register the pool with.  
-**6.**  DONE!  
+**7.**  DONE!  
 
 The final output on successful registration should look something like this:
 ```

--- a/scripts/cnode-helper-scripts/cntools.config
+++ b/scripts/cnode-helper-scripts/cntools.config
@@ -9,6 +9,7 @@ POOL_FOLDER="$CNODE_HOME/priv/pool"
 # standardized names for all wallet/pool related files
 WALLET_PAY_VK_FILENAME="payment.vkey"
 WALLET_PAY_SK_FILENAME="payment.skey"
+WALLET_PAY_ADDR_FILENAME="payment.addr"
 WALLET_BASE_ADDR_FILENAME="base.addr"
 WALLET_STAKE_VK_FILENAME="stake.vkey"
 WALLET_STAKE_SK_FILENAME="stake.skey"

--- a/scripts/cnode-helper-scripts/cntools.config
+++ b/scripts/cnode-helper-scripts/cntools.config
@@ -9,7 +9,6 @@ POOL_FOLDER="$CNODE_HOME/priv/pool"
 # standardized names for all wallet/pool related files
 WALLET_PAY_VK_FILENAME="payment.vkey"
 WALLET_PAY_SK_FILENAME="payment.skey"
-WALLET_PAY_ADDR_FILENAME="payment.addr"
 WALLET_BASE_ADDR_FILENAME="base.addr"
 WALLET_STAKE_VK_FILENAME="stake.vkey"
 WALLET_STAKE_SK_FILENAME="stake.skey"

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -500,8 +500,10 @@ fractionToPCT() {
 # Return     : populates $pay_addr
 getPayAddress() {
   payment_vk_file="${WALLET_FOLDER}/${1}/${WALLET_PAY_VK_FILENAME}"
+  payment_addr_file="${WALLET_FOLDER}/${1}/${WALLET_PAY_ADDR_FILENAME}"
   if [[ -f "${payment_vk_file}" ]]; then
-    pay_addr=$(${CCLI} shelley address build --payment-verification-key-file "${payment_vk_file}" --testnet-magic ${NWMAGIC} 2>/dev/null)
+    ${CCLI} shelley address build --payment-verification-key-file "${payment_vk_file}"  --out-file "${payment_addr_file}" --testnet-magic ${NWMAGIC}
+    pay_addr=$(cat "${payment_addr_file}")
     if [[ -z ${pay_addr} ]]; then
       return 1
     fi
@@ -519,7 +521,7 @@ getBaseAddress() {
   base_addr_file="${WALLET_FOLDER}/${1}/${WALLET_BASE_ADDR_FILENAME}"
   if [[ -f "${payment_vk_file}" && -f "${stake_vk_file}" ]]; then
     ${CCLI} shelley address build --payment-verification-key-file "${payment_vk_file}" --stake-verification-key-file "${stake_vk_file}" --out-file "${base_addr_file}" --testnet-magic ${NWMAGIC}
-    base_addr=$(cat ${base_addr_file})
+    base_addr=$(cat "${base_addr_file}")
   else
     return 1
   fi
@@ -533,7 +535,7 @@ getRewardAddress() {
   stake_addr_file="${WALLET_FOLDER}/${1}/${WALLET_STAKE_ADDR_FILENAME}"
   if [[ -f "${stake_vk_file}" ]]; then
     ${CCLI} shelley stake-address build --stake-verification-key-file "${stake_vk_file}" --out-file "${stake_addr_file}" --testnet-magic ${NWMAGIC}
-    reward_addr=$(cat ${stake_addr_file})
+    reward_addr=$(cat "${stake_addr_file}")
   else
     return 1
   fi

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -502,12 +502,14 @@ getPayAddress() {
   payment_vk_file="${WALLET_FOLDER}/${1}/${WALLET_PAY_VK_FILENAME}"
   payment_addr_file="${WALLET_FOLDER}/${1}/${WALLET_PAY_ADDR_FILENAME}"
   if [[ -f "${payment_vk_file}" ]]; then
-    ${CCLI} shelley address build --payment-verification-key-file "${payment_vk_file}"  --out-file "${payment_addr_file}" --testnet-magic ${NWMAGIC}
-    pay_addr=$(cat "${payment_addr_file}")
-    if [[ -z ${pay_addr} ]]; then
+    if ${CCLI} shelley address build --payment-verification-key-file "${payment_vk_file}" --out-file "${payment_addr_file}" --testnet-magic ${NWMAGIC} 2>/dev/null; then
+      pay_addr=$(cat "${payment_addr_file}")
+    else
+      pay_addr=""
       return 1
     fi
   else
+    pay_addr=""
     return 1
   fi
 }
@@ -523,6 +525,7 @@ getBaseAddress() {
     ${CCLI} shelley address build --payment-verification-key-file "${payment_vk_file}" --stake-verification-key-file "${stake_vk_file}" --out-file "${base_addr_file}" --testnet-magic ${NWMAGIC}
     base_addr=$(cat "${base_addr_file}")
   else
+    base_addr=""
     return 1
   fi
 }
@@ -537,6 +540,7 @@ getRewardAddress() {
     ${CCLI} shelley stake-address build --stake-verification-key-file "${stake_vk_file}" --out-file "${stake_addr_file}" --testnet-magic ${NWMAGIC}
     reward_addr=$(cat "${stake_addr_file}")
   else
+    reward_addr=""
     return 1
   fi
 }
@@ -548,6 +552,8 @@ getBalance() {
   lovelace=0
   ada=0
   utx0_count=0
+  
+  [[ -z $1 ]] && return 1
 
   ${CCLI} shelley query utxo --testnet-magic "${NWMAGIC}" --address "${1}" > ${TMP_FOLDER}/fullUtxo.out
   tail -n +3 ${TMP_FOLDER}/fullUtxo.out | sort -k3 -nr > ${TMP_FOLDER}/balance.out
@@ -602,6 +608,8 @@ sendADA() {
   ttlValue=$(( currSlot + 1000 ))
   say "TN Magic is ${NWMAGIC}" "log"
   say "Current slot is ${currSlot}, setting ttl to ${ttlValue}" "log"
+  
+  getBalance ${sAddr}
 
   balance=0
   utxoCount=0

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -503,10 +503,6 @@ getPayAddress() {
   if [[ -f "${payment_vk_file}" ]]; then
     pay_addr=$(${CCLI} shelley address build --payment-verification-key-file "${payment_vk_file}" --testnet-magic ${NWMAGIC} 2>/dev/null)
     if [[ -z ${pay_addr} ]]; then
-      # try genesis address instead
-      pay_addr=$(${CCLI} shelley genesis initial-addr --verification-key-file "${payment_vk_file}" --testnet-magic ${NWMAGIC} 2>/dev/null)
-    fi
-    if [[ -z ${pay_addr} ]]; then
       return 1
     fi
   else

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -734,8 +734,11 @@ isWalletRegistered() {
 registerStakeWallet() {
   
   echo ""
-  say " -- Register Wallet ${GREEN}${1}${NC} on Chain --"
   waitForInput "Wallet not registered on chain, press any key to continue with registration"
+  
+  echo ""
+  say " ## Register Stake Wallet ${GREEN}${1}${NC} on Chain ##" "log"
+  echo ""
 
   # Wallet key filenames
   payment_sk_file="${WALLET_FOLDER}/${1}/${WALLET_PAY_SK_FILENAME}"
@@ -743,7 +746,9 @@ registerStakeWallet() {
   stake_vk_file="${WALLET_FOLDER}/${1}/${WALLET_STAKE_VK_FILENAME}"
   stake_cert_file="${WALLET_FOLDER}/${1}/${WALLET_STAKE_CERT_FILENAME}"
   
-  say "Creating registration certificate" "log" && echo
+  echo ""
+  say " -- Creating registration certificate --" "log"
+  echo ""
   ${CCLI} shelley stake-address registration-certificate --stake-verification-key-file "${stake_vk_file}" --out-file "${stake_cert_file}"
   
   say " -- Protocol Parameters --"

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -80,7 +80,7 @@ say() {
 #   >> need_cmd "jq"
 need_cmd() {
   if ! command -v "$1" > /dev/null 2>&1; then
-    say "${RED}ERROR${NC}: need '$1' (command not found)" "try 'sudo apt install $1'" "log"
+    say "${RED}ERROR${NC}: need '$1' (command not found)" "try 'sudo apt install $1'"
     say "please install with your packet manager of choice(apt/yum etc..) and relaunch cntools"
     return 1
   fi
@@ -324,7 +324,7 @@ getPassword() {
 encryptFile() {
   echo "${2}" | gpg --symmetric --yes --batch --cipher-algo AES256 --passphrase-fd 0 --output "${1}.gpg" "${1}" >/dev/null && \
   rm -f "${1}" || {
-    say "${RED}ERROR${NC}: failed to encrypt ${1}" "log"
+    say "${RED}ERROR${NC}: failed to encrypt ${1}"
     return 1
   }
   say "${1} successfully encrypted" "log"
@@ -342,7 +342,7 @@ encryptFile() {
 decryptFile() {
   echo "${2}" | gpg --decrypt --batch --yes --passphrase-fd 0 --output "${1%.*}" "${1}" >/dev/null && \
   rm -f "${1}" || {
-    say "${RED}ERROR${NC}: failed to decrypt ${1}" "log"
+    say "${RED}ERROR${NC}: failed to decrypt ${1}"
     return 1
   }
   say "${1} successfully decrypted" "log"
@@ -494,10 +494,30 @@ fractionToPCT() {
   fi
 }
 
-# Command    : getAddress [wallet name]
+
+# Command    : getPayAddress [wallet name]
+# Description: create and save payment address
+# Return     : populates $pay_addr
+getPayAddress() {
+  payment_vk_file="${WALLET_FOLDER}/${1}/${WALLET_PAY_VK_FILENAME}"
+  if [[ -f "${payment_vk_file}" ]]; then
+    pay_addr=$(${CCLI} shelley address build --payment-verification-key-file "${payment_vk_file}" --testnet-magic ${NWMAGIC} 2>/dev/null)
+    if [[ -z ${pay_addr} ]]; then
+      # try genesis address instead
+      pay_addr=$(${CCLI} shelley genesis initial-addr --verification-key-file "${payment_vk_file}" --testnet-magic ${NWMAGIC} 2>/dev/null)
+    fi
+    if [[ -z ${pay_addr} ]]; then
+      return 1
+    fi
+  else
+    return 1
+  fi
+}
+
+# Command    : getBaseAddress [wallet name]
 # Description: create, store and save base address
 # Return     : populates $base_addr
-getAddress() {
+getBaseAddress() {
   payment_vk_file="${WALLET_FOLDER}/${1}/${WALLET_PAY_VK_FILENAME}"
   stake_vk_file="${WALLET_FOLDER}/${1}/${WALLET_STAKE_VK_FILENAME}"
   base_addr_file="${WALLET_FOLDER}/${1}/${WALLET_BASE_ADDR_FILENAME}"
@@ -525,10 +545,10 @@ getRewardAddress() {
 
 # Command    : getBalance [address]
 # Description: check balance for provided address
-# Return     : populates $base_lovelace & $base_ada
+# Return     : populates $lovelace & $ada
 getBalance() {
-  base_lovelace=0
-  base_ada=0
+  lovelace=0
+  ada=0
   utx0_count=0
 
   ${CCLI} shelley query utxo --testnet-magic "${NWMAGIC}" --address "${1}" > ${TMP_FOLDER}/fullUtxo.out
@@ -536,10 +556,10 @@ getBalance() {
   
   while read -r utxo; do
     utx0_count=$(( utx0_count + 1 ))
-    base_lovelace=$(( base_lovelace + $(awk '{ print $3 }' <<< "${utxo}") ))
+    lovelace=$(( lovelace + $(awk '{ print $3 }' <<< "${utxo}") ))
   done <${TMP_FOLDER}/balance.out
 
-  base_ada=$(lovelacetoADA ${base_lovelace})
+  ada=$(lovelacetoADA ${lovelace})
 }
 
 
@@ -573,7 +593,7 @@ sendADA() {
 
   # Handle script arguments
   dAddr="$1"
-  lovelace="$2"
+  amount="$2"
   sAddr="$3"
   sKey="$4"
   inclFee="$5"
@@ -595,10 +615,10 @@ sendADA() {
     utxoCount=$(( utxoCount +1))
     txIn="${txIn} --tx-in ${inAddr}#${idx}"
     balance=$(( balance + utxoBalance ))
-    [[ ${inclFee} = "yes" && ${balance} -ge ${lovelace} ]] && break
+    [[ ${inclFee} = "yes" && ${balance} -ge ${amount} ]] && break
   done <${TMP_FOLDER}/balance.out
 
-  [[ ${balance} -eq ${lovelace} ]] && outCount=1 || outCount=2
+  [[ ${balance} -eq ${amount} ]] && outCount=1 || outCount=2
 
   say ""
   say " -- Calculate fee, new amount and remaining balance --" "log"
@@ -618,35 +638,35 @@ sendADA() {
 
   # Sanity checks
   if [[ ${inclFee} = "no" ]]; then
-    if [[ ${balance} -lt $(( lovelace + minFee )) ]]; then
-      say "${RED}ERROR${NC}: Not enough Lovelace in address ($(numfmt --grouping ${balance}) < $(numfmt --grouping ${lovelace}) + $(numfmt --grouping ${minFee}))" "log"
+    if [[ ${balance} -lt $(( amount + minFee )) ]]; then
+      say "${RED}ERROR${NC}: Not enough Lovelace in address ($(numfmt --grouping ${balance}) < $(numfmt --grouping ${amount}) + $(numfmt --grouping ${minFee}))" 1>&2
       return 1
     fi
   else
-    if [[ ${lovelace} -lt ${minFee} ]]; then
-      say "${RED}ERROR${NC}: Fee deducted from ADA to send, amount can not be less than fee ($(numfmt --grouping ${lovelace}) < $(numfmt --grouping ${minFee}))" "log"
+    if [[ ${amount} -lt ${minFee} ]]; then
+      say "${RED}ERROR${NC}: Fee deducted from ADA to send, amount can not be less than fee ($(numfmt --grouping ${amount}) < $(numfmt --grouping ${minFee}))" 1>&2
       return 1
-    elif [[ ${balance} -lt ${lovelace} ]]; then
-      say "${RED}ERROR${NC}: Not enough Lovelace in address ($(numfmt --grouping ${balance}) < $(numfmt --grouping ${lovelace}))" "log"
+    elif [[ ${balance} -lt ${amount} ]]; then
+      say "${RED}ERROR${NC}: Not enough Lovelace in address ($(numfmt --grouping ${balance}) < $(numfmt --grouping ${amount}))" 1>&2
       return 1
     fi
   fi
 
   if [[ ${inclFee} = "no" ]]; then
-    txOut="--tx-out ${dAddr}+${lovelace}"
+    txOut="--tx-out ${dAddr}+${amount}"
   else
-    txOut="--tx-out ${dAddr}+$(( lovelace - minFee ))"
-    say "New amount to send in Lovelace after fee deduction is $(numfmt --grouping $(( lovelace - minFee ))) lovelaces ($(numfmt --grouping ${lovelace}) - $(numfmt --grouping ${minFee}))" "log"
+    txOut="--tx-out ${dAddr}+$(( amount - minFee ))"
+    say "New amount to send in Lovelace after fee deduction is $(numfmt --grouping $(( amount - minFee ))) lovelaces ($(numfmt --grouping ${amount}) - $(numfmt --grouping ${minFee}))" "log"
   fi
 
-  newBalance=$(( base_lovelace - lovelace ))
+  newBalance=$(( lovelace - amount ))
   if [[ ${inclFee} = "no" ]]; then
-    newBalance=$(( balance - lovelace - minFee ))
+    newBalance=$(( balance - amount - minFee ))
     txOut="${txOut} --tx-out ${sAddr}+${newBalance}"
-    say "Balance left to be returned in used UTxO's is $(numfmt --grouping ${newBalance}) lovelaces ($(numfmt --grouping ${balance}) - $(numfmt --grouping ${lovelace}) - $(numfmt --grouping ${minFee}))" "log"
+    say "Balance left to be returned in used UTxO's is $(numfmt --grouping ${newBalance}) lovelaces ($(numfmt --grouping ${balance}) - $(numfmt --grouping ${amount}) - $(numfmt --grouping ${minFee}))" "log"
   elif [[ ${outCount} -eq 2 ]]; then
-    txOut="${txOut} --tx-out ${sAddr}+$(( balance - lovelace ))"
-    say "Balance left to be returned in used UTxO's is $(numfmt --grouping $(( balance - lovelace ))) lovelaces ($(numfmt --grouping ${balance}) - $(numfmt --grouping ${lovelace}))" "log"
+    txOut="${txOut} --tx-out ${sAddr}+$(( balance - amount ))"
+    say "Balance left to be returned in used UTxO's is $(numfmt --grouping $(( balance - amount ))) lovelaces ($(numfmt --grouping ${balance}) - $(numfmt --grouping ${amount}))" "log"
   fi
 
   buildArgs=(
@@ -678,7 +698,7 @@ sendADA() {
   say "Building transaction"
   output=$(${CCLI} ${buildArgs[*]})
   if [[ -n $output ]]; then
-    say "${RED}ERROR${NC}: 1. Problem during tx creation with args ${buildArgs[*]}" "log"
+    say "${RED}ERROR${NC}: 1. Problem during tx creation with args ${buildArgs[*]}" 1>&2
     say "$output" "log"
     return 1
   fi
@@ -686,7 +706,7 @@ sendADA() {
   say "Signing transaction"
   output=$(${CCLI} ${signArgs[*]})
   if [[ -n $output ]]; then
-    say "${RED}ERROR${NC}: 2. Problem during signing with args ${signArgs[*]}" "log"
+    say "${RED}ERROR${NC}: 2. Problem during signing with args ${signArgs[*]}" 1>&2
     say "$output" "log"
     return 1
   fi
@@ -694,7 +714,7 @@ sendADA() {
   say "Sending transaction"
   output=$(${CCLI} ${submitArgs[*]})
   if [[ -n $output ]]; then
-    say "${RED}ERROR${NC}: 3. Problem during tx submission with args ${submitArgs[*]}" "log"
+    say "${RED}ERROR${NC}: 3. Problem during tx submission with args ${submitArgs[*]}" 1>&2
     say "$output" "log"
     return 1
   fi
@@ -768,15 +788,15 @@ registerStakeWallet() {
   minFee=$(${CCLI} ${minFeeArgs[*]} | awk '{ print $2 }')
   say "fee is $(numfmt --grouping ${minFee})" "log"
 
-  if [[ ${base_lovelace} -lt $(( minFee + keyDeposit )) ]]; then
-    say "${RED}ERROR${NC}: Not enough Lovelace in wallet ($(numfmt --grouping ${base_lovelace}) < $(numfmt --grouping ${minFee}) + $(numfmt --grouping ${keyDeposit}))" "log"
+  if [[ ${lovelace} -lt $(( minFee + keyDeposit )) ]]; then
+    say "${RED}ERROR${NC}: Not enough Lovelace in wallet ($(numfmt --grouping ${lovelace}) < $(numfmt --grouping ${minFee}) + $(numfmt --grouping ${keyDeposit}))"
     return 1
   fi
 
-  newBalance=$(( base_lovelace - minFee - keyDeposit ))
+  newBalance=$(( lovelace - minFee - keyDeposit ))
   tx_out="--tx-out ${base_addr}+${newBalance}"
   
-  say "New balance after tx fee and key deposit is $(numfmt --grouping ${newBalance}) lovelaces ($(numfmt --grouping ${base_lovelace}) - $(numfmt --grouping ${minFee}) - $(numfmt --grouping ${keyDeposit}))" "log"
+  say "New balance after tx fee and key deposit is $(numfmt --grouping ${newBalance}) lovelaces ($(numfmt --grouping ${lovelace}) - $(numfmt --grouping ${minFee}) - $(numfmt --grouping ${keyDeposit}))" "log"
   
   buildArgs=(
     shelley transaction build-raw
@@ -837,15 +857,15 @@ registerStakeWallet() {
       break
     fi
     getBalance ${base_addr}
-    if [[ ${base_lovelace} -ne ${newBalance} ]]; then
+    if [[ ${lovelace} -ne ${newBalance} ]]; then
       echo ""
-      say "${ORANGE}WARN${NC}: Balance mismatch, transaction not included in latest block ($(numfmt --grouping ${base_lovelace}) != $(numfmt --grouping ${newBalance}))"
+      say "${ORANGE}WARN${NC}: Balance mismatch, transaction not included in latest block ($(numfmt --grouping ${lovelace}) != $(numfmt --grouping ${newBalance}))"
     else
       break
     fi
   done
   
-  if [[ ${base_lovelace} -ne ${newBalance} ]]; then
+  if [[ ${lovelace} -ne ${newBalance} ]]; then
     say "${RED}ERROR${NC}: failed to register wallet on chain or"
     return 1
   fi
@@ -882,7 +902,7 @@ registerPool() {
   say " -- Register Pool and Pledge on Chain --" "log"
 
   if [[ ! -s ${TMP_FOLDER}/balance.out ]]; then
-    say "${RED}ERROR${NC}: wallet empty" "log"
+    say "${RED}ERROR${NC}: wallet empty"
     return 1
   fi
   
@@ -922,14 +942,14 @@ registerPool() {
   minFee=$(${CCLI} ${minFeeArgs[*]} | awk '{ print $2 }')
   say "fee is $(numfmt --grouping ${minFee})" "log"
 
-  if [[ ${base_lovelace} -lt $(( minFee + poolDeposit )) ]]; then
-    say "${RED}ERROR${NC}: Not enough Lovelace in base address ( $(numfmt --grouping ${base_lovelace}) < $(numfmt --grouping ${minFee}) + $(numfmt --grouping ${poolDeposit}) )" "log"
+  if [[ ${lovelace} -lt $(( minFee + poolDeposit )) ]]; then
+    say "${RED}ERROR${NC}: Not enough Lovelace in base address ( $(numfmt --grouping ${lovelace}) < $(numfmt --grouping ${minFee}) + $(numfmt --grouping ${poolDeposit}) )"
     return 1
   fi
 
-  newBalance=$(( base_lovelace - minFee - poolDeposit ))
+  newBalance=$(( lovelace - minFee - poolDeposit ))
   tx_out="--tx-out ${base_addr}+${newBalance}"
-  say "Balance left to be returned in used UTxO is $(numfmt --grouping ${newBalance}) lovelaces ( $(numfmt --grouping ${base_lovelace}) - $(numfmt --grouping ${minFee}) - $(numfmt --grouping ${poolDeposit}) )" "log"
+  say "Balance left to be returned in used UTxO is $(numfmt --grouping ${newBalance}) lovelaces ( $(numfmt --grouping ${lovelace}) - $(numfmt --grouping ${minFee}) - $(numfmt --grouping ${poolDeposit}) )" "log"
 
   buildArgs=(
     shelley transaction build-raw
@@ -964,7 +984,7 @@ registerPool() {
   say "Building transaction"
   output=$(${CCLI} ${buildArgs[*]})
   if [[ -n $output ]]; then
-    say "${RED}ERROR${NC}: 1. Problem during tx creation with args ${buildArgs[*]}" "log"
+    say "${RED}ERROR${NC}: 1. Problem during tx creation with args ${buildArgs[*]}"
     say "$output" "log"
     return 1
   fi
@@ -972,7 +992,7 @@ registerPool() {
   say "Signing transaction"
   output=$(${CCLI} ${signArgs[*]})
   if [[ -n $output ]]; then
-    say "${RED}ERROR${NC}: 2. Problem during signing with args ${signArgs[*]}" "log"
+    say "${RED}ERROR${NC}: 2. Problem during signing with args ${signArgs[*]}"
     say "$output" "log"
     return 1
   fi
@@ -980,7 +1000,7 @@ registerPool() {
   say "Sending transaction"
   output=$(${CCLI} ${submitArgs[*]})
   if [[ -n $output ]]; then
-    say "${RED}ERROR${NC}: 3. Problem during tx submission with args ${submitArgs[*]}" "log"
+    say "${RED}ERROR${NC}: 3. Problem during tx submission with args ${submitArgs[*]}"
     say "$output" "log"
     return 1
   fi
@@ -1011,7 +1031,7 @@ modifyPool() {
   echo ""
   say " -- Modify Pool Parameters and Update on Chain --" "log"
   if [[ ! -s ${TMP_FOLDER}/balance.out ]]; then
-    say "${RED}ERROR${NC}: wallet empty" "log"
+    say "${RED}ERROR${NC}: wallet empty"
     return 1
   fi
   
@@ -1048,14 +1068,14 @@ modifyPool() {
   minFee=$(${CCLI} ${minFeeArgs[*]} | awk '{ print $2 }')
   say "fee is $(numfmt --grouping ${minFee})" "log"
 
-  if [[ ${base_lovelace} -lt ${minFee} ]]; then
-    say "${RED}ERROR${NC}: Not enough Lovelace in base address ( $(numfmt --grouping ${base_lovelace}) < $(numfmt --grouping ${minFee}) )" "log"
+  if [[ ${lovelace} -lt ${minFee} ]]; then
+    say "${RED}ERROR${NC}: Not enough Lovelace in base address ( $(numfmt --grouping ${lovelace}) < $(numfmt --grouping ${minFee}) )"
     return 1
   fi
 
-  newBalance=$(( base_lovelace - minFee ))
+  newBalance=$(( lovelace - minFee ))
   tx_out="--tx-out ${base_addr}+${newBalance}"
-  say "Balance left to be returned in used UTxO is $(numfmt --grouping ${newBalance}) lovelaces ( $(numfmt --grouping ${base_lovelace}) - $(numfmt --grouping ${minFee}) )" "log"
+  say "Balance left to be returned in used UTxO is $(numfmt --grouping ${newBalance}) lovelaces ( $(numfmt --grouping ${lovelace}) - $(numfmt --grouping ${minFee}) )" "log"
 
   buildArgs=(
     shelley transaction build-raw
@@ -1089,7 +1109,7 @@ modifyPool() {
   say "Building transaction"
   output=$(${CCLI} ${buildArgs[*]})
   if [[ -n $output ]]; then
-    say "${RED}ERROR${NC}: 1. Problem during tx creation with args ${buildArgs[*]}" "log"
+    say "${RED}ERROR${NC}: 1. Problem during tx creation with args ${buildArgs[*]}"
     say "$output" "log"
     return 1
   fi
@@ -1097,7 +1117,7 @@ modifyPool() {
   say "Signing transaction"
   output=$(${CCLI} ${signArgs[*]})
   if [[ -n $output ]]; then
-    say "${RED}ERROR${NC}: 2. Problem during signing with args ${signArgs[*]}" "log"
+    say "${RED}ERROR${NC}: 2. Problem during signing with args ${signArgs[*]}"
     say "$output" "log"
     return 1
   fi
@@ -1105,7 +1125,7 @@ modifyPool() {
   say "Sending transaction"
   output=$(${CCLI} ${submitArgs[*]})
   if [[ -n $output ]]; then
-    say "${RED}ERROR${NC}: 3. Problem during tx submission with args ${submitArgs[*]}" "log"
+    say "${RED}ERROR${NC}: 3. Problem during tx submission with args ${submitArgs[*]}"
     say "$output" "log"
     return 1
   fi
@@ -1126,7 +1146,7 @@ withdrawRewards() {
 
   echo ""
   if [[ ! -s ${TMP_FOLDER}/balance.out ]]; then
-    say "${RED}ERROR${NC}: wallet empty" "log"
+    say "${RED}ERROR${NC}: wallet empty"
     return 1
   fi
 
@@ -1160,14 +1180,14 @@ withdrawRewards() {
   minFee=$(${CCLI} ${minFeeArgs[*]} | awk '{ print $2 }')
   say "fee is $(numfmt --grouping ${minFee})" "log"
 
-  if [[ ${base_lovelace} -lt ${minFee} ]]; then
-    error "Not enough Lovelace in wallet ( $(numfmt --grouping ${base_lovelace}) < $(numfmt --grouping ${minFee}) )"
+  if [[ ${lovelace} -lt ${minFee} ]]; then
+    error "Not enough Lovelace in wallet ( $(numfmt --grouping ${lovelace}) < $(numfmt --grouping ${minFee}) )"
     return 1
   fi
 
-  newBalance=$(( base_lovelace - minFee + reward_lovelace ))
+  newBalance=$(( lovelace - minFee + reward_lovelace ))
   tx_out="--tx-out ${base_addr}+${newBalance}"
-  say "Balance left to be returned in used UTxO is $(numfmt --grouping ${newBalance}) lovelaces ( $(numfmt --grouping ${base_lovelace}) - $(numfmt --grouping ${minFee}) )" "log"
+  say "Balance left to be returned in used UTxO is $(numfmt --grouping ${newBalance}) lovelaces ( $(numfmt --grouping ${lovelace}) - $(numfmt --grouping ${minFee}) )" "log"
 
   buildArgs=(
     shelley transaction build-raw
@@ -1275,14 +1295,14 @@ delegate() {
   minFee=$(${CCLI} ${minFeeArgs[*]} | awk '{ print $2 }')
   say "fee is $(numfmt --grouping ${minFee})" "log"
 
-  if [[ ${base_lovelace} -lt ${minFee} ]]; then
-    error "Not enough Lovelace in wallet ( $(numfmt --grouping ${base_lovelace}) < $(numfmt --grouping ${minFee}) )"
+  if [[ ${lovelace} -lt ${minFee} ]]; then
+    error "Not enough Lovelace in wallet ( $(numfmt --grouping ${lovelace}) < $(numfmt --grouping ${minFee}) )"
     return 1
   fi
 
-  newBalance=$(( base_lovelace - minFee ))
+  newBalance=$(( lovelace - minFee ))
   tx_out="--tx-out ${base_addr}+${newBalance}"
-  say "Balance left to be returned in used UTxO is $(numfmt --grouping ${newBalance}) lovelaces ( $(numfmt --grouping ${base_lovelace}) - $(numfmt --grouping ${minFee}) )" "log"
+  say "Balance left to be returned in used UTxO is $(numfmt --grouping ${newBalance}) lovelaces ( $(numfmt --grouping ${lovelace}) - $(numfmt --grouping ${minFee}) )" "log"
 
   buildArgs=(
     shelley transaction build-raw
@@ -1383,14 +1403,14 @@ deRegisterPool() {
   say "fee is $(numfmt --grouping ${minFee})" "log"
   echo ""
   
-  if [[ ${base_lovelace} -lt ${minFee} ]]; then
-    error "Not enough Lovelace in wallet ( $(numfmt --grouping ${base_lovelace}) < $(numfmt --grouping ${minFee}) )"
+  if [[ ${lovelace} -lt ${minFee} ]]; then
+    error "Not enough Lovelace in wallet ( $(numfmt --grouping ${lovelace}) < $(numfmt --grouping ${minFee}) )"
     return 1
   fi
 
-  newBalance=$(( base_lovelace - minFee ))
+  newBalance=$(( lovelace - minFee ))
   tx_out="--tx-out ${wallet_addr}+${newBalance}"
-  say "Balance left to be returned in used UTxO is $(numfmt --grouping ${newBalance}) lovelaces ( $(numfmt --grouping ${base_lovelace}) - $(numfmt --grouping ${minFee}) )" "log"
+  say "Balance left to be returned in used UTxO is $(numfmt --grouping ${newBalance}) lovelaces ( $(numfmt --grouping ${lovelace}) - $(numfmt --grouping ${minFee}) )" "log"
 
   buildArgs=(
     shelley transaction build-raw

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -672,10 +672,10 @@ sendADA() {
     --testnet-magic ${NWMAGIC}
   )
 
-  say ""
+  echo ""
   say " -- Build, Sign & Send transaction --" "log"
+  
   say "Building transaction"
-
   output=$(${CCLI} ${buildArgs[*]})
   if [[ -n $output ]]; then
     say "${RED}ERROR${NC}: 1. Problem during tx creation with args ${buildArgs[*]}" "log"
@@ -684,10 +684,7 @@ sendADA() {
   fi
 
   say "Signing transaction"
-
-  ## TODO decrypt skey
   output=$(${CCLI} ${signArgs[*]})
-  ## TODO encrypt skey
   if [[ -n $output ]]; then
     say "${RED}ERROR${NC}: 2. Problem during signing with args ${signArgs[*]}" "log"
     say "$output" "log"
@@ -695,7 +692,6 @@ sendADA() {
   fi
 
   say "Sending transaction"
-
   output=$(${CCLI} ${submitArgs[*]})
   if [[ -n $output ]]; then
     say "${RED}ERROR${NC}: 3. Problem during tx submission with args ${submitArgs[*]}" "log"
@@ -807,10 +803,10 @@ registerStakeWallet() {
     --testnet-magic ${NWMAGIC}
   )
 
-  say ""
+  echo ""
   say " -- Build, Sign & Send transaction --" "log"
+  
   say "Building transaction" "log"
-
   output=$(${CCLI} ${buildArgs[*]})
   if [[ -n $output ]]; then
     say "${RED}ERROR${NC}: 1. Problem during tx creation with args ${buildArgs[*]}"
@@ -819,7 +815,6 @@ registerStakeWallet() {
   fi
 
   say "Signing transaction" "log"
-
   output=$(${CCLI} ${signArgs[*]})
   if [[ -n $output ]]; then
     say "${RED}ERROR${NC}: 2. Problem during signing with args ${signArgs[*]}"
@@ -828,7 +823,6 @@ registerStakeWallet() {
   fi
 
   say "Sending transaction" "log"
-
   output=$(${CCLI} ${submitArgs[*]})
   if [[ -n $output ]]; then
     say "${RED}ERROR${NC}: 3. Problem during tx submission with args ${submitArgs[*]}"
@@ -964,11 +958,10 @@ registerPool() {
     --testnet-magic ${NWMAGIC}
   )
 
-  say ""
+  echo ""
   say " -- Build, Sign & Send transaction --" "log"
+  
   say "Building transaction"
-  echo ${buildArgs[*]}
-
   output=$(${CCLI} ${buildArgs[*]})
   if [[ -n $output ]]; then
     say "${RED}ERROR${NC}: 1. Problem during tx creation with args ${buildArgs[*]}" "log"
@@ -977,7 +970,6 @@ registerPool() {
   fi
 
   say "Signing transaction"
-
   output=$(${CCLI} ${signArgs[*]})
   if [[ -n $output ]]; then
     say "${RED}ERROR${NC}: 2. Problem during signing with args ${signArgs[*]}" "log"
@@ -986,7 +978,6 @@ registerPool() {
   fi
 
   say "Sending transaction"
-
   output=$(${CCLI} ${submitArgs[*]})
   if [[ -n $output ]]; then
     say "${RED}ERROR${NC}: 3. Problem during tx submission with args ${submitArgs[*]}" "log"
@@ -1092,11 +1083,10 @@ modifyPool() {
     --testnet-magic ${NWMAGIC}
   )
 
-  say ""
+  echo ""
   say " -- Build, Sign & Send transaction --" "log"
+  
   say "Building transaction"
-  echo ${buildArgs[*]}
-
   output=$(${CCLI} ${buildArgs[*]})
   if [[ -n $output ]]; then
     say "${RED}ERROR${NC}: 1. Problem during tx creation with args ${buildArgs[*]}" "log"
@@ -1105,7 +1095,6 @@ modifyPool() {
   fi
 
   say "Signing transaction"
-
   output=$(${CCLI} ${signArgs[*]})
   if [[ -n $output ]]; then
     say "${RED}ERROR${NC}: 2. Problem during signing with args ${signArgs[*]}" "log"
@@ -1114,7 +1103,6 @@ modifyPool() {
   fi
 
   say "Sending transaction"
-
   output=$(${CCLI} ${submitArgs[*]})
   if [[ -n $output ]]; then
     say "${RED}ERROR${NC}: 3. Problem during tx submission with args ${submitArgs[*]}" "log"
@@ -1321,11 +1309,10 @@ delegate() {
     --testnet-magic ${NWMAGIC}
   )
 
-  say ""
+  echo ""
   say " -- Build, Sign & Send transaction --" "log"
+  
   say "Building transaction"
-  echo ${buildArgs[*]}
-
   output=$(${CCLI} ${buildArgs[*]})
   if [[ -n $output ]]; then
     error "1. Problem during tx creation with args ${buildArgs[*]}" "$output"
@@ -1333,17 +1320,13 @@ delegate() {
   fi
 
   say "Signing transaction"
-
-  ## TODO decrypt skey
   output=$(${CCLI} ${signArgs[*]})
-  ## TODO encrypt skey
   if [[ -n $output ]]; then
     error "2. Problem during signing with args ${signArgs[*]}" "$output"
     return 1
   fi
 
   say "Sending transaction"
-
   output=$(${CCLI} ${submitArgs[*]})
   if [[ -n $output ]]; then
     error "3. Problem during tx submission with args ${submitArgs[*]}" "$output"
@@ -1436,9 +1419,8 @@ deRegisterPool() {
 
   echo ""
   say " -- Build, Sign & Send transaction --" "log"
+  
   say "Building transaction"
-  echo ${buildArgs[*]}
-
   output=$(${CCLI} ${buildArgs[*]})
   if [[ -n $output ]]; then
     error "1. Problem during tx creation with args ${buildArgs[*]}" "$output"
@@ -1446,17 +1428,13 @@ deRegisterPool() {
   fi
 
   say "Signing transaction"
-
-  ## TODO decrypt skey
   output=$(${CCLI} ${signArgs[*]})
-  ## TODO encrypt skey
   if [[ -n $output ]]; then
     error "2. Problem during signing with args ${signArgs[*]}" "$output"
     return 1
   fi
 
   say "Sending transaction"
-
   output=$(${CCLI} ${submitArgs[*]})
   if [[ -n $output ]]; then
     error "3. Problem during tx submission with args ${submitArgs[*]}" "$output"

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -5,9 +5,9 @@
 # Variables to keep counter for versions                   #
 ############################################################
 # Any breaking changes (eg: that requires change of cntools.config, env or a change in priv folder would be considered breaking and will be exempt from auto-update)
-CNTOOLS_MAJOR_VERSION=0
+CNTOOLS_MAJOR_VERSION=1
 # Changes that can be applied without breaking existing functionality that can be applied from within CNTools
-CNTOOLS_MINOR_VERSION=3
+CNTOOLS_MINOR_VERSION=0
 CNTOOLS_VERSION="$CNTOOLS_MAJOR_VERSION.$CNTOOLS_MINOR_VERSION"
 
 ############################################################
@@ -41,12 +41,17 @@ indent() {
 }
 
 
-# Command    : waitForInput
+# Command    : waitForInput [optional: message]
 # Description: wait for user keypress to continue
 waitForInput() {
   ESC=$(printf "\033")
   echo ""
-  read -rsn1 -p "press any key to return to home menu" key # get 1 character
+  if [[ -z $1 ]]; then
+    message="press any key to return to home menu"
+  else
+    message="$1"
+  fi
+  read -rsn1 -p "${message}" key # get 1 character
   if [[ $key == $ESC ]]; then
     read -rsn2 key # read 2 more chars
   fi
@@ -489,81 +494,65 @@ fractionToPCT() {
   fi
 }
 
+# Command    : getAddress [wallet name]
+# Description: create, store and save base address
+# Return     : populates $base_addr
+getAddress() {
+  payment_vk_file="${WALLET_FOLDER}/${1}/${WALLET_PAY_VK_FILENAME}"
+  stake_vk_file="${WALLET_FOLDER}/${1}/${WALLET_STAKE_VK_FILENAME}"
+  base_addr_file="${WALLET_FOLDER}/${1}/${WALLET_BASE_ADDR_FILENAME}"
+  if [[ -f "${payment_vk_file}" && -f "${stake_vk_file}" ]]; then
+    ${CCLI} shelley address build --payment-verification-key-file "${payment_vk_file}" --stake-verification-key-file "${stake_vk_file}" --out-file "${base_addr_file}" --testnet-magic ${NWMAGIC}
+    base_addr=$(cat ${base_addr_file})
+  else
+    return 1
+  fi
+}
+
+# Command    : getRewardAddress [wallet name]
+# Description: create, store and save reward address
+# Return     : populates $reward_addr
+getRewardAddress() {
+  stake_vk_file="${WALLET_FOLDER}/${1}/${WALLET_STAKE_VK_FILENAME}"
+  stake_addr_file="${WALLET_FOLDER}/${1}/${WALLET_STAKE_ADDR_FILENAME}"
+  if [[ -f "${stake_vk_file}" ]]; then
+    ${CCLI} shelley stake-address build --stake-verification-key-file "${stake_vk_file}" --out-file "${stake_addr_file}" --testnet-magic ${NWMAGIC}
+    reward_addr=$(cat ${stake_addr_file})
+  else
+    return 1
+  fi
+}
 
 # Command    : getBalance [address]
 # Description: check balance for provided address
-# Parameters : address   >   Address or path to Address file.
-# Return     : prints progress on STDOUT
-# Examples of Usage:
-#   >> getBalance 61WKMJemoBa....ssL7fzhq
+# Return     : populates $base_lovelace & $base_ada
 getBalance() {
-  TOTALBALANCE=0
-  totalBalanceADA=0
-  UTx0_COUNT=0
+  base_lovelace=0
+  base_ada=0
+  utx0_count=0
 
   ${CCLI} shelley query utxo --testnet-magic "${NWMAGIC}" --address "${1}" > ${TMP_FOLDER}/fullUtxo.out
   tail -n +3 ${TMP_FOLDER}/fullUtxo.out | sort -k3 -nr > ${TMP_FOLDER}/balance.out
-
-  if [ -s ${TMP_FOLDER}/balance.out ]; then
-    head -n 2 ${TMP_FOLDER}/fullUtxo.out
-    head -n 10 ${TMP_FOLDER}/balance.out
-  fi
-
+  
   while read -r utxo; do
-    UTx0_COUNT=$(( UTx0_COUNT + 1 ))
-    TOTALBALANCE=$(( TOTALBALANCE + $(awk '{ print $3 }' <<< "${utxo}") ))
+    utx0_count=$(( utx0_count + 1 ))
+    base_lovelace=$(( base_lovelace + $(awk '{ print $3 }' <<< "${utxo}") ))
   done <${TMP_FOLDER}/balance.out
 
-  [[ ${UTx0_COUNT} -gt 10 ]] && say "... (top 10 UTx0 with most lovelace)"
-
-  totalBalanceADA=$(lovelacetoADA ${TOTALBALANCE})
-
-  say ""
-  say "Total balance is ${GREEN}$(numfmt --grouping ${totalBalanceADA})${NC} ADA" "log"
+  base_ada=$(lovelacetoADA ${base_lovelace})
 }
 
 
-# Command    : getBalanceAllAddr [path to wallet] [inkl rewards]
-# Description: check balance for all wallet addresses
-# Parameters : path to wallet   >   Full path to wallet folder
-#              inkl rewards     >   'yes' = do rewards check, else skipped
-# Return     : populates $<addr_type>_lovelace & $<addr_type>_ada
-# Examples of Usage:
-#   >> getBalanceAllAddr "/opt/cardano/cnode/priv/wallet/MyWallet" "yes"
-getBalanceAllAddr() {
-  payment_lovelace=0
-  payment_ada=0
-  base_lovelace=0
-  base_ada=0
+# Command    : getRewards [wallet name]
+# Description: check balance of reward address
+# Return     : populates $reward_lovelace & $reward_ada
+getRewards() {
   reward_lovelace=-1
   reward_ada=-1
-  
-  # Wallet key filenames
-  payment_addr_file="${1}/${WALLET_PAY_ADDR_FILENAME}"
-  stake_addr_file="${1}/${WALLET_STAKE_ADDR_FILENAME}"
-  base_addr_file="${1}/${WALLET_BASE_ADDR_FILENAME}"
-  
-  if [ -f "${payment_addr_file}" ]; then
-    payment_addr=$(cat "${payment_addr_file}")
-    getBalance ${payment_addr} >/dev/null
-    payment_lovelace=${TOTALBALANCE}
-    payment_ada=${totalBalanceADA}
-    cp -f ${TMP_FOLDER}/fullUtxo.out ${TMP_FOLDER}/fullUtxo_payment.out
-    cp -f ${TMP_FOLDER}/balance.out ${TMP_FOLDER}/balance_payment.out
-  fi
-  if [ -f "${base_addr_file}" ]; then
-    base_addr=$(cat "${base_addr_file}")
-    getBalance ${base_addr} >/dev/null
-    base_lovelace=${TOTALBALANCE}
-    base_ada=${totalBalanceADA}
-    cp -f ${TMP_FOLDER}/fullUtxo.out ${TMP_FOLDER}/fullUtxo_base.out
-    cp -f ${TMP_FOLDER}/balance.out ${TMP_FOLDER}/balance_base.out
-    if [[ $2 = "yes" && -f "${stake_addr_file}" ]]; then
-      stake_addr=$(cat "${stake_addr_file}")
-      reward_lovelace=$(${CCLI} shelley query stake-address-info --testnet-magic ${NWMAGIC} --address ${stake_addr} | jq -r '.[].rewardAccountBalance // empty')
-      [[ "${reward_lovelace}" =~ ^[0-9]+$ ]] || reward_lovelace=0
-      reward_ada=$(lovelacetoADA ${reward_lovelace})
-    fi
+  if isWalletRegistered $1; then
+    reward_lovelace=$(jq -r '.rewardAccountBalance' <<< "${stakeAddressInfo}")
+    [[ "${reward_lovelace}" =~ ^[0-9]+$ ]] || reward_lovelace=0
+    reward_ada=$(lovelacetoADA ${reward_lovelace})
   fi
 }
 
@@ -595,15 +584,7 @@ sendADA() {
   ttlValue=$(( currSlot + 1000 ))
   say "TN Magic is ${NWMAGIC}" "log"
   say "Current slot is ${currSlot}, setting ttl to ${ttlValue}" "log"
-  
-  getBalance ${sAddr} >/dev/null
 
-  if [ ! -s ${TMP_FOLDER}/balance.out ]; then
-    say "${RED}ERROR${NC}: Failed to locate a UTxO, source wallet empty?" "log"
-    return 1
-  fi
-
-  say "Using UTxO's:" "log"
   balance=0
   utxoCount=0
   txIn=""
@@ -611,8 +592,6 @@ sendADA() {
     inAddr=$(awk '{ print $1 }' <<< "${utxo}")
     idx=$(awk '{ print $2 }' <<< "${utxo}")
     utxoBalance=$(awk '{ print $3 }' <<< "${utxo}")
-    say "TxHash: ${inAddr}#${idx}" "log"
-    say "Lovelace: $(numfmt --grouping ${utxoBalance})" "log"
     utxoCount=$(( utxoCount +1))
     txIn="${txIn} --tx-in ${inAddr}#${idx}"
     balance=$(( balance + utxoBalance ))
@@ -660,7 +639,7 @@ sendADA() {
     say "New amount to send in Lovelace after fee deduction is $(numfmt --grouping $(( lovelace - minFee ))) lovelaces ($(numfmt --grouping ${lovelace}) - $(numfmt --grouping ${minFee}))" "log"
   fi
 
-  newBalance=$(( TOTALBALANCE - lovelace ))
+  newBalance=$(( base_lovelace - lovelace ))
   if [[ ${inclFee} = "no" ]]; then
     newBalance=$(( balance - lovelace - minFee ))
     txOut="${txOut} --tx-out ${sAddr}+${newBalance}"
@@ -725,27 +704,35 @@ sendADA() {
   fi
 }
 
-# Command    : registerStakeWallet [payment address] [payment sign key] [stake sign key] [stake cert file]
+
+# Command    : isWalletRegistered [wallet name]
+# Description: check if wallet is registered on chain
+# Return     : 0 if registered, else 1
+isWalletRegistered() {
+  if getRewardAddress $1; then
+    stakeAddressInfo=$(${CCLI} shelley query stake-address-info --testnet-magic ${NWMAGIC} --address ${reward_addr} | jq -r '.[] // empty')
+    [[ -n "${stakeAddressInfo}" ]] && return 0
+  fi
+  return 1 
+}
+
+# Command    : registerStakeWallet [wallet name]
 # Description: Register stake keys on chain and move funds from payment address to payment base address
-# Parameters : payment address         >   Payment address, funds needed to pay tx fee for stake key registration
-#              base_address            >   This is the new address, all funds will be moved from payment address to this address
-#              payment sign key        >   Payment signature key
-#              stake sign key          >   Stake signature key
-#              stake cert file         >   Stake certificate
 # Return     : prints progress on STDOUT
-# Examples of Usage:
-#   >> registerStakeWallet 61WKMJemoBa....ssL7fzhq 61WKMJemoBa....ssL7fzhq "../wallet/MyWallet/payment.skey" "../wallet/MyWallet/stake.skey" "../wallet/MyWallet/stake.cert"
 registerStakeWallet() {
+  
+  echo ""
+  say " -- Register Wallet ${GREEN}${1}${NC} on Chain --"
+  waitForInput "Wallet not registered on chain, press any key to continue with registration"
 
-  # script arguments
-  payment_addr="$1"
-  base_addr="$2"
-  payment_sk="$3"
-  stake_sk="$4"
-  stake_cert="$5"
-
-  say " -- Register Stake Keys on Chain --" "log"
-  say ""
+  # Wallet key filenames
+  payment_sk_file="${WALLET_FOLDER}/${1}/${WALLET_PAY_SK_FILENAME}"
+  stake_sk_file="${WALLET_FOLDER}/${1}/${WALLET_STAKE_SK_FILENAME}"
+  stake_vk_file="${WALLET_FOLDER}/${1}/${WALLET_STAKE_VK_FILENAME}"
+  stake_cert_file="${WALLET_FOLDER}/${1}/${WALLET_STAKE_CERT_FILENAME}"
+  
+  say "Creating registration certificate" "log" && echo
+  ${CCLI} shelley stake-address registration-certificate --stake-verification-key-file "${stake_vk_file}" --out-file "${stake_cert_file}"
   
   say " -- Protocol Parameters --"
   currSlot=$(getTip slot)
@@ -756,16 +743,7 @@ registerStakeWallet() {
   say "Current slot is ${currSlot}, setting ttl to ${ttlValue}" "log"
   say ""
   
-  say "--- Balance Check Source Address -------------------------------------------------------" "log"
-  getBalance ${payment_addr}
-
-  if [ ! -s ${TMP_FOLDER}/balance.out ]; then
-    say "${RED}ERROR${NC}: Failed to locate a UTxO, payment wallet empty?" "log"
-    say "funds needed to pay tx fee for stake key registration"
-    return 1
-  fi
-  
-  # Use all available utxo in source payment address
+  # Use all available utxo in source address
   say "Using UTxO's:" "log"
   tx_in=""
   while read -r utxo; do
@@ -781,28 +759,28 @@ registerStakeWallet() {
   say " -- Calculate fee --" "log"
   minFeeArgs=(
     shelley transaction calculate-min-fee
-    --tx-in-count ${UTx0_COUNT}
+    --tx-in-count ${utx0_count}
     --tx-out-count 1
     --ttl ${ttlValue}
     --testnet-magic ${NWMAGIC}
-    --signing-key-file ${payment_sk}
-    --signing-key-file ${stake_sk}
-    --certificate-file ${stake_cert}
+    --signing-key-file ${payment_sk_file}
+    --signing-key-file ${stake_sk_file}
+    --certificate-file ${stake_cert_file}
     --protocol-params-file ${TMP_FOLDER}/protparams.json
   )
 
   minFee=$(${CCLI} ${minFeeArgs[*]} | awk '{ print $2 }')
   say "fee is $(numfmt --grouping ${minFee})" "log"
 
-  if [[ ${TOTALBALANCE} -lt $(( minFee + keyDeposit )) ]]; then
-    say "${RED}ERROR${NC}: Not enough Lovelace in payment address ($(numfmt --grouping ${TOTALBALANCE}) < $(numfmt --grouping ${minFee}) + $(numfmt --grouping ${keyDeposit}))" "log"
+  if [[ ${base_lovelace} -lt $(( minFee + keyDeposit )) ]]; then
+    say "${RED}ERROR${NC}: Not enough Lovelace in wallet ($(numfmt --grouping ${base_lovelace}) < $(numfmt --grouping ${minFee}) + $(numfmt --grouping ${keyDeposit}))" "log"
     return 1
   fi
 
-  newBalance=$(( TOTALBALANCE - minFee - keyDeposit ))
+  newBalance=$(( base_lovelace - minFee - keyDeposit ))
   tx_out="--tx-out ${base_addr}+${newBalance}"
   
-  say "Balance in new base address is $(numfmt --grouping ${newBalance}) lovelaces ($(numfmt --grouping ${TOTALBALANCE}) - $(numfmt --grouping ${minFee}) - $(numfmt --grouping ${keyDeposit}))" "log"
+  say "New balance after tx fee and key deposit is $(numfmt --grouping ${newBalance}) lovelaces ($(numfmt --grouping ${base_lovelace}) - $(numfmt --grouping ${minFee}) - $(numfmt --grouping ${keyDeposit}))" "log"
   
   buildArgs=(
     shelley transaction build-raw
@@ -810,15 +788,15 @@ registerStakeWallet() {
     ${tx_out}
     --ttl ${ttlValue}
     --fee ${minFee}
-    --certificate-file ${stake_cert}
+    --certificate-file ${stake_cert_file}
     --out-file ${TMP_FOLDER}/tx.raw
   )
 
   signArgs=(
     shelley transaction sign
     --tx-body-file ${TMP_FOLDER}/tx.raw
-    --signing-key-file ${payment_sk}
-    --signing-key-file ${stake_sk}
+    --signing-key-file ${payment_sk_file}
+    --signing-key-file ${stake_sk_file}
     --testnet-magic ${NWMAGIC}
     --out-file ${TMP_FOLDER}/tx.signed
   )
@@ -831,32 +809,55 @@ registerStakeWallet() {
 
   say ""
   say " -- Build, Sign & Send transaction --" "log"
-  say "Building transaction"
+  say "Building transaction" "log"
 
   output=$(${CCLI} ${buildArgs[*]})
   if [[ -n $output ]]; then
-    say "${RED}ERROR${NC}: 1. Problem during tx creation with args ${buildArgs[*]}" "log"
-    say "$output" "log"
+    say "${RED}ERROR${NC}: 1. Problem during tx creation with args ${buildArgs[*]}"
+    say "$output"
     return 1
   fi
 
-  say "Signing transaction"
+  say "Signing transaction" "log"
 
   output=$(${CCLI} ${signArgs[*]})
   if [[ -n $output ]]; then
-    say "${RED}ERROR${NC}: 2. Problem during signing with args ${signArgs[*]}" "log"
-    say "$output" "log"
+    say "${RED}ERROR${NC}: 2. Problem during signing with args ${signArgs[*]}"
+    say "$output"
     return 1
   fi
 
-  say "Sending transaction"
+  say "Sending transaction" "log"
 
   output=$(${CCLI} ${submitArgs[*]})
   if [[ -n $output ]]; then
-    say "${RED}ERROR${NC}: 3. Problem during tx submission with args ${submitArgs[*]}" "log"
-    say "$output" "log"
+    say "${RED}ERROR${NC}: 3. Problem during tx submission with args ${submitArgs[*]}"
+    say "$output"
     return 1
   fi
+  
+  say "\n${ORANGE}Waiting for wallet registration to be recorded on chain, if aborted, choosen action will fail${NC}"
+  
+  while true; do
+    if ! waitNewBlockCreated; then
+      break
+    fi
+    getBalance ${base_addr}
+    if [[ ${base_lovelace} -ne ${newBalance} ]]; then
+      echo ""
+      say "${ORANGE}WARN${NC}: Balance mismatch, transaction not included in latest block ($(numfmt --grouping ${base_lovelace}) != $(numfmt --grouping ${newBalance}))"
+    else
+      break
+    fi
+  done
+  
+  if [[ ${base_lovelace} -ne ${newBalance} ]]; then
+    say "${RED}ERROR${NC}: failed to register wallet on chain or"
+    return 1
+  fi
+  
+  reward_ada=0
+  reward_lovelace=0
 }
 
 
@@ -883,32 +884,24 @@ registerPool() {
   pool_pledgecert_file="$5"
   pay_payment_sk_file="$6"
   
+  echo ""
   say " -- Register Pool and Pledge on Chain --" "log"
-  say ""
-  say "--- Balance Check Base Address -------------------------------------------------------" "log"
-  getBalance ${base_addr}
 
-  tx=$(head -n 1 ${TMP_FOLDER}/balance.out)
-
-  [[ -z ${tx} ]] && say "${RED}ERROR${NC}: base address empty" "log" && return 1
-
-  say ""
-  say "Using UTxO with highest balance:" "log"
-  say "${tx}" "log"
-  say ""
+  if [[ ! -s ${TMP_FOLDER}/balance.out ]]; then
+    say "${RED}ERROR${NC}: wallet empty" "log"
+    return 1
+  fi
   
-  # Use all available utxo in pledge wallet base address
-  say "Using UTxO's:" "log"
+  # Use all available utxo in pledge wallet
   tx_in=""
   while read -r utxo; do
     in_addr=$(awk '{ print $1 }' <<< "${utxo}")
     idx=$(awk '{ print $2 }' <<< "${utxo}")
     utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
-    say "TxHash: ${in_addr}#${idx}" "log"
-    say "Lovelace: $(numfmt --grouping ${utxo_balance})" "log"
     tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
   done <${TMP_FOLDER}/balance.out
 
+  echo ""
   say " -- Protocol Parameters --"
   currSlot=$(getTip slot)
   ttlValue=$(( currSlot + 1000 ))
@@ -917,11 +910,11 @@ registerPool() {
   say "Pool Deposit is ${poolDeposit}"
   say "Current slot is ${currSlot}, setting ttl to ${ttlValue}" "log"
 
-  say ""
+  echo ""
   say " -- Calculate fee, new amount and remaining balance --" "log"
   minFeeArgs=(
     shelley transaction calculate-min-fee
-    --tx-in-count ${UTx0_COUNT}
+    --tx-in-count ${utx0_count}
     --tx-out-count 1
     --ttl ${ttlValue}
     --testnet-magic ${NWMAGIC}
@@ -935,14 +928,14 @@ registerPool() {
   minFee=$(${CCLI} ${minFeeArgs[*]} | awk '{ print $2 }')
   say "fee is $(numfmt --grouping ${minFee})" "log"
 
-  if [[ ${TOTALBALANCE} -lt $(( minFee + poolDeposit )) ]]; then
-    say "${RED}ERROR${NC}: Not enough Lovelace in base address ( $(numfmt --grouping ${TOTALBALANCE}) < $(numfmt --grouping ${minFee}) + $(numfmt --grouping ${poolDeposit}) )" "log"
+  if [[ ${base_lovelace} -lt $(( minFee + poolDeposit )) ]]; then
+    say "${RED}ERROR${NC}: Not enough Lovelace in base address ( $(numfmt --grouping ${base_lovelace}) < $(numfmt --grouping ${minFee}) + $(numfmt --grouping ${poolDeposit}) )" "log"
     return 1
   fi
 
-  newBalance=$(( TOTALBALANCE - minFee - poolDeposit ))
+  newBalance=$(( base_lovelace - minFee - poolDeposit ))
   tx_out="--tx-out ${base_addr}+${newBalance}"
-  say "Balance left to be returned in used UTxO is $(numfmt --grouping ${newBalance}) lovelaces ( $(numfmt --grouping ${TOTALBALANCE}) - $(numfmt --grouping ${minFee}) - $(numfmt --grouping ${poolDeposit}) )" "log"
+  say "Balance left to be returned in used UTxO is $(numfmt --grouping ${newBalance}) lovelaces ( $(numfmt --grouping ${base_lovelace}) - $(numfmt --grouping ${minFee}) - $(numfmt --grouping ${poolDeposit}) )" "log"
 
   buildArgs=(
     shelley transaction build-raw
@@ -1024,43 +1017,34 @@ modifyPool() {
   pool_regcert_file="$4"
   pay_payment_sk_file="$5"
   
+  echo ""
   say " -- Modify Pool Parameters and Update on Chain --" "log"
-  say ""
-  say "--- Balance Check Base Address -------------------------------------------------------" "log"
-  getBalance ${base_addr}
-
-  tx=$(head -n 1 ${TMP_FOLDER}/balance.out)
-
-  [[ -z ${tx} ]] && say "${RED}ERROR${NC}: base address empty" "log" && return 1
-
-  say ""
-  say "Using UTxO with highest balance:" "log"
-  say "${tx}" "log"
-  say ""
+  if [[ ! -s ${TMP_FOLDER}/balance.out ]]; then
+    say "${RED}ERROR${NC}: wallet empty" "log"
+    return 1
+  fi
   
   # Use all available utxo in pledge wallet base address
-  say "Using UTxO's:" "log"
   tx_in=""
   while read -r utxo; do
     in_addr=$(awk '{ print $1 }' <<< "${utxo}")
     idx=$(awk '{ print $2 }' <<< "${utxo}")
     utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
-    say "TxHash: ${in_addr}#${idx}" "log"
-    say "Lovelace: $(numfmt --grouping ${utxo_balance})" "log"
     tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
   done <${TMP_FOLDER}/balance.out
 
+  echo ""
   say " -- Protocol Parameters --"
   currSlot=$(getTip slot)
   ttlValue=$(( currSlot + 1000 ))
   say "TN Magic is ${NWMAGIC}" "log"
   say "Current slot is ${currSlot}, setting ttl to ${ttlValue}" "log"
 
-  say ""
+  echo ""
   say " -- Calculate fee, new amount and remaining balance --" "log"
   minFeeArgs=(
     shelley transaction calculate-min-fee
-    --tx-in-count ${UTx0_COUNT}
+    --tx-in-count ${utx0_count}
     --tx-out-count 1
     --ttl ${ttlValue}
     --testnet-magic ${NWMAGIC}
@@ -1073,14 +1057,14 @@ modifyPool() {
   minFee=$(${CCLI} ${minFeeArgs[*]} | awk '{ print $2 }')
   say "fee is $(numfmt --grouping ${minFee})" "log"
 
-  if [[ ${TOTALBALANCE} -lt ${minFee} ]]; then
-    say "${RED}ERROR${NC}: Not enough Lovelace in base address ( $(numfmt --grouping ${TOTALBALANCE}) < $(numfmt --grouping ${minFee}) )" "log"
+  if [[ ${base_lovelace} -lt ${minFee} ]]; then
+    say "${RED}ERROR${NC}: Not enough Lovelace in base address ( $(numfmt --grouping ${base_lovelace}) < $(numfmt --grouping ${minFee}) )" "log"
     return 1
   fi
 
-  newBalance=$(( TOTALBALANCE - minFee ))
+  newBalance=$(( base_lovelace - minFee ))
   tx_out="--tx-out ${base_addr}+${newBalance}"
-  say "Balance left to be returned in used UTxO is $(numfmt --grouping ${newBalance}) lovelaces ( $(numfmt --grouping ${TOTALBALANCE}) - $(numfmt --grouping ${minFee}) )" "log"
+  say "Balance left to be returned in used UTxO is $(numfmt --grouping ${newBalance}) lovelaces ( $(numfmt --grouping ${base_lovelace}) - $(numfmt --grouping ${minFee}) )" "log"
 
   buildArgs=(
     shelley transaction build-raw
@@ -1152,9 +1136,11 @@ withdrawRewards() {
   stake_addr="$5"
   reward_lovelace="$6"
 
-  tx=$(head -n 1 ${TMP_FOLDER}/balance.out)
-
-  [[ -z ${tx} ]] && error "payment address empty" && return 1
+  echo ""
+  if [[ ! -s ${TMP_FOLDER}/balance.out ]]; then
+    say "${RED}ERROR${NC}: wallet empty" "log"
+    return 1
+  fi
 
   # Use all available utxo in pledge wallet base address
   tx_in=""
@@ -1174,7 +1160,7 @@ withdrawRewards() {
   say " -- Calculate fee, new amount and remaining balance --" "log"
   minFeeArgs=(
     shelley transaction calculate-min-fee
-    --tx-in-count ${UTx0_COUNT}
+    --tx-in-count ${utx0_count}
     --tx-out-count 1
     --ttl ${ttlValue}
     --testnet-magic ${NWMAGIC}
@@ -1186,14 +1172,14 @@ withdrawRewards() {
   minFee=$(${CCLI} ${minFeeArgs[*]} | awk '{ print $2 }')
   say "fee is $(numfmt --grouping ${minFee})" "log"
 
-  if [[ ${TOTALBALANCE} -lt ${minFee} ]]; then
-    error "Not enough Lovelace in base address ( $(numfmt --grouping ${TOTALBALANCE}) < $(numfmt --grouping ${minFee}) )"
+  if [[ ${base_lovelace} -lt ${minFee} ]]; then
+    error "Not enough Lovelace in wallet ( $(numfmt --grouping ${base_lovelace}) < $(numfmt --grouping ${minFee}) )"
     return 1
   fi
 
-  newBalance=$(( TOTALBALANCE - minFee + reward_lovelace ))
+  newBalance=$(( base_lovelace - minFee + reward_lovelace ))
   tx_out="--tx-out ${base_addr}+${newBalance}"
-  say "Balance left to be returned in used UTxO is $(numfmt --grouping ${newBalance}) lovelaces ( $(numfmt --grouping ${TOTALBALANCE}) - $(numfmt --grouping ${minFee}) )" "log"
+  say "Balance left to be returned in used UTxO is $(numfmt --grouping ${newBalance}) lovelaces ( $(numfmt --grouping ${base_lovelace}) - $(numfmt --grouping ${minFee}) )" "log"
 
   buildArgs=(
     shelley transaction build-raw
@@ -1220,11 +1206,10 @@ withdrawRewards() {
     --testnet-magic ${NWMAGIC}
   )
 
-  say ""
+  echo ""
   say " -- Build, Sign & Send transaction --" "log"
+  
   say "Building transaction"
-  echo ${buildArgs[*]}
-
   output=$(${CCLI} ${buildArgs[*]})
   if [[ -n $output ]]; then
     error "1. Problem during tx creation with args ${buildArgs[*]}" "$output"
@@ -1232,7 +1217,6 @@ withdrawRewards() {
   fi
 
   say "Signing transaction"
-
   output=$(${CCLI} ${signArgs[*]})
   if [[ -n $output ]]; then
     error "2. Problem during signing with args ${signArgs[*]}" "$output"
@@ -1240,14 +1224,11 @@ withdrawRewards() {
   fi
 
   say "Sending transaction"
-
   output=$(${CCLI} ${submitArgs[*]})
   if [[ -n $output ]]; then
     error "3. Problem during tx submission with args ${submitArgs[*]}" "$output"
     return 1
   fi
-
-
 }
 
 # Command    : Delegate [stake vkey] [stake skey] [pay skey] [pay addr] [pool vkey] [deleg cert]
@@ -1273,21 +1254,13 @@ delegate() {
   base_addr="$4"
   pool_coldkey_vk_file="$5"
   pool_delegcert_file="$6"
-  
-  echo ""
-  say "--- Base Address Balance Check -------------------------------------------------------" "log"
-  getBalance ${base_addr}
 
-  # Use all available utxo in pledge wallet base address
-  echo ""
-  say "Using UTxO's:" "log"
+  # Use all available utxo in pledge wallet
   tx_in=""
   while read -r utxo; do
     in_addr=$(awk '{ print $1 }' <<< "${utxo}")
     idx=$(awk '{ print $2 }' <<< "${utxo}")
     utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
-    say "TxHash: ${in_addr}#${idx}" "log"
-    say "Lovelace: $(numfmt --grouping ${utxo_balance})" "log"
     tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
   done <${TMP_FOLDER}/balance.out
   
@@ -1302,7 +1275,7 @@ delegate() {
   say " -- Calculate fee, new amount and remaining balance --" "log"
   minFeeArgs=(
     shelley transaction calculate-min-fee
-    --tx-in-count ${UTx0_COUNT}
+    --tx-in-count ${utx0_count}
     --tx-out-count 1
     --ttl ${ttlValue}
     --testnet-magic ${NWMAGIC}
@@ -1314,14 +1287,14 @@ delegate() {
   minFee=$(${CCLI} ${minFeeArgs[*]} | awk '{ print $2 }')
   say "fee is $(numfmt --grouping ${minFee})" "log"
 
-  if [[ ${TOTALBALANCE} -lt ${minFee} ]]; then
-    error "Not enough Lovelace in base address ( $(numfmt --grouping ${TOTALBALANCE}) < $(numfmt --grouping ${minFee}) )"
+  if [[ ${base_lovelace} -lt ${minFee} ]]; then
+    error "Not enough Lovelace in wallet ( $(numfmt --grouping ${base_lovelace}) < $(numfmt --grouping ${minFee}) )"
     return 1
   fi
 
-  newBalance=$(( TOTALBALANCE - minFee ))
+  newBalance=$(( base_lovelace - minFee ))
   tx_out="--tx-out ${base_addr}+${newBalance}"
-  say "Balance left to be returned in used UTxO is $(numfmt --grouping ${newBalance}) lovelaces ( $(numfmt --grouping ${TOTALBALANCE}) - $(numfmt --grouping ${minFee}) )" "log"
+  say "Balance left to be returned in used UTxO is $(numfmt --grouping ${newBalance}) lovelaces ( $(numfmt --grouping ${base_lovelace}) - $(numfmt --grouping ${minFee}) )" "log"
 
   buildArgs=(
     shelley transaction build-raw
@@ -1394,33 +1367,27 @@ deRegisterPool() {
   wallet_addr="$3"
   wallet_payment_sk_file="$4"
 
-  say ""
-  say "--- Wallet Balance Check -------------------------------------------------------" "log"
-  getBalance ${wallet_addr}
-
   # Use all available utxo in wallet address
-  say "Using UTxO's:" "log"
   tx_in=""
   while read -r utxo; do
     in_addr=$(awk '{ print $1 }' <<< "${utxo}")
     idx=$(awk '{ print $2 }' <<< "${utxo}")
     utxo_balance=$(awk '{ print $3 }' <<< "${utxo}")
-    say "TxHash: ${in_addr}#${idx}" "log"
-    say "Lovelace: $(numfmt --grouping ${utxo_balance})" "log"
     tx_in="${tx_in} --tx-in ${in_addr}#${idx}"
   done <${TMP_FOLDER}/balance.out
-
+  
+  echo ""
   say " -- Protocol Parameters --"
   currSlot=$(getTip slot)
   ttlValue=$(( currSlot + 1000 ))
   say "TN Magic is ${NWMAGIC}" "log"
   say "Current slot is ${currSlot}, setting ttl to ${ttlValue}" "log"
 
-  say ""
+  echo ""
   say " -- Calculate fee, new amount and remaining balance --" "log"
   minFeeArgs=(
     shelley transaction calculate-min-fee
-    --tx-in-count ${UTx0_COUNT}
+    --tx-in-count ${utx0_count}
     --tx-out-count 1
     --ttl ${ttlValue}
     --testnet-magic ${NWMAGIC}
@@ -1433,14 +1400,14 @@ deRegisterPool() {
   say "fee is $(numfmt --grouping ${minFee})" "log"
   echo ""
   
-  if [[ ${TOTALBALANCE} -lt ${minFee} ]]; then
-    error "Not enough Lovelace in address ( $(numfmt --grouping ${TOTALBALANCE}) < $(numfmt --grouping ${minFee}) )"
+  if [[ ${base_lovelace} -lt ${minFee} ]]; then
+    error "Not enough Lovelace in wallet ( $(numfmt --grouping ${base_lovelace}) < $(numfmt --grouping ${minFee}) )"
     return 1
   fi
 
-  newBalance=$(( TOTALBALANCE - minFee ))
+  newBalance=$(( base_lovelace - minFee ))
   tx_out="--tx-out ${wallet_addr}+${newBalance}"
-  say "Balance left to be returned in used UTxO is $(numfmt --grouping ${newBalance}) lovelaces ( $(numfmt --grouping ${TOTALBALANCE}) - $(numfmt --grouping ${minFee}) )" "log"
+  say "Balance left to be returned in used UTxO is $(numfmt --grouping ${newBalance}) lovelaces ( $(numfmt --grouping ${base_lovelace}) - $(numfmt --grouping ${minFee}) )" "log"
 
   buildArgs=(
     shelley transaction build-raw

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -122,7 +122,7 @@ case $OPERATION in
     stake_vk_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_STAKE_VK_FILENAME}"
     stake_sk_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_STAKE_SK_FILENAME}"
 
-    if [[ $(ls -1 "${WALLET_FOLDER}/${wallet_name}/" | wc -l) -gt 0 ]]; then
+    if [[ $(find "${WALLET_FOLDER}/${wallet_name}" -type f -printf '.' | wc -c) -gt 0 ]]; then
       say "${RED}WARN${NC}: A wallet ${GREEN}$wallet_name${NC} already exists"
       say "      Choose another name or delete the existing one"
       waitForInput && continue
@@ -154,7 +154,7 @@ case $OPERATION in
     
     while IFS= read -r -d '' wallet; do
       wallet_name=$(basename ${wallet})
-      enc_files=$(find "${wallet}" -mindepth 1 -maxdepth 1 -type f -name *.gpg -printf '.' | wc -c)
+      enc_files=$(find "${wallet}" -mindepth 1 -maxdepth 1 -type f -name '*.gpg' -printf '.' | wc -c)
       if getAddress ${wallet_name} || [[ ${enc_files} -gt 0 ]]; then
         echo ""
         if [[ ${enc_files} -gt 0 ]]; then
@@ -205,7 +205,7 @@ case $OPERATION in
     wallet_dirs=()
     if ! getDirs "${WALLET_FOLDER}"; then continue; fi # dirs() array populated with all wallet folders
     for dir in "${dirs[@]}"; do
-      enc_files=$(find "${WALLET_FOLDER}/${dir}" -mindepth 1 -maxdepth 1 -type f -name *.gpg -printf '.' | wc -c)
+      enc_files=$(find "${WALLET_FOLDER}/${dir}" -mindepth 1 -maxdepth 1 -type f -name '*.gpg' -printf '.' | wc -c)
       if ! getAddress "${dir}" && [[ ${enc_files} -eq 0 ]]; then continue; fi
       wallet_dirs+=("${dir}")
     done
@@ -217,7 +217,7 @@ case $OPERATION in
     say "Select Wallet:\n"
     if ! selectDir "${wallet_dirs[@]}"; then continue; fi # ${dir_name} populated by selectDir function
     wallet_name=${dir_name}
-    enc_files=$(find "${WALLET_FOLDER}/${wallet_name}" -mindepth 1 -maxdepth 1 -type f -name *.gpg -printf '.' | wc -c)
+    enc_files=$(find "${WALLET_FOLDER}/${wallet_name}" -mindepth 1 -maxdepth 1 -type f -name '*.gpg' -printf '.' | wc -c)
     
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     echo ""

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -1626,8 +1626,8 @@ case $OPERATION in
       waitForInput && continue
     fi
 
-    say "\n${ORANGE}Please make sure you host your metadata JSON file (with contents as below) at ${meta_json_url} :${NC}\n"
-    say "{\n  \"name\": \"${meta_name}\",\n  \"ticker\": \"${meta_ticker}\",\n  \"description\": \"${meta_description}\",\n  \"homepage\": \"${meta_homepage}\"\n}"| tee "${pool_meta_file}"
+    say "\n${ORANGE}Please host ${pool_meta_file} file as-is at ${meta_json_url}!\n"
+    echo -e "{\n  \"name\": \"${meta_name}\",\n  \"ticker\": \"${meta_ticker}\",\n  \"description\": \"${meta_description}\",\n  \"homepage\": \"${meta_homepage}\"\n}" > "${pool_meta_file}"
 
     relay_counter=0
     relay_output=""

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -51,7 +51,7 @@ while true; do # Main loop
 find "${TMP_FOLDER:?}" -type f -not -name 'protparams.json' -delete
 
 clear
-say "$(printf "%-52s %s" " >> CNTOOLS $CNTOOLS_VERSION << " "A Guild Operators collaboration")" "log"
+say "$(printf "%-52s %s" " >> CNTools $CNTOOLS_VERSION << " "A Guild Operators collaboration")" "log"
 echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 echo " Main Menu"
 echo ""
@@ -80,7 +80,7 @@ case $OPERATION in
   echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
   echo " Wallet Management"
   echo ""
-  echo " ) New      -  create a new payment wallet or upgrade existing to a stake wallet"
+  echo " ) New      -  create a new wallet"
   echo " ) List     -  list all available wallets in a compact view"
   echo " ) Show     -  show detailed view of a specific wallet"
   echo " ) Remove   -  remove a wallet"
@@ -105,159 +105,39 @@ case $OPERATION in
     clear
     say " >> WALLET >> NEW" "log"
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    echo " Wallet Type"
     echo ""
-    echo " ) Payment  -  First step for a new wallet"
-    echo "               A payment wallet can send and receive funds but not delegate/pledge."
+    read -r -p "Name of new wallet: " wallet_name
+    # Remove unwanted characters from wallet name
+    wallet_name=${wallet_name//[^[:alnum:]]/_}
+    if [[ -z "${wallet_name}" ]]; then
+      say "${RED}ERROR${NC}: Empty wallet name, please retry!"
+      waitForInput && continue
+    fi
     echo ""
-    echo " ) Stake    -  Upgrade existing payment wallet to a stake wallet"
-    echo "               Make sure there are funds available in payment wallet before upgrade"
-    echo "               as this is needed to pay for the stake wallet registration fee."
-    echo "               A stake wallet is needed to be able to delegate and pledge to a pool."
-    echo "               All funds from payment address will be moved to base address."
-    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    echo ""
-    
-    say " Choose wallet type\n"
-    case $(select_opt "[p] Payment" "[s] Stake" "[h] Home") in
-      0) wallet_type="payment" ;;
-      1) wallet_type="stake" ;;
-      2) continue ;;
-    esac
+    mkdir -p "${WALLET_FOLDER}/${wallet_name}"
 
-    case $wallet_type in
-      payment)
+    # Wallet key filenames
+    payment_sk_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_PAY_SK_FILENAME}"
+    payment_vk_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_PAY_VK_FILENAME}"
+    stake_vk_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_STAKE_VK_FILENAME}"
+    stake_sk_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_STAKE_SK_FILENAME}"
 
-      clear
-      say " >> WALLET >> NEW >> PAYMENT" "log"
-      echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-      echo ""
-      read -r -p "Name of new wallet: " wallet_name
-      # Remove unwanted characters from wallet name
-      wallet_name=${wallet_name//[^[:alnum:]]/_}
-      if [[ -z "${wallet_name}" ]]; then
-        say "${RED}ERROR${NC}: Empty wallet name, please retry!"
-        waitForInput && continue
-      fi
-      echo ""
-      mkdir -p "${WALLET_FOLDER}/${wallet_name}"
+    if [[ $(ls -1 "${WALLET_FOLDER}/${wallet_name}/" | wc -l) -gt 0 ]]; then
+      say "${RED}WARN${NC}: A wallet ${GREEN}$wallet_name${NC} already exists"
+      say "      Choose another name or delete the existing one"
+      waitForInput && continue
+    fi
 
-      # Wallet key filenames
-      payment_vk_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_PAY_VK_FILENAME}"
-      payment_sk_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_PAY_SK_FILENAME}"
-      payment_addr_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_PAY_ADDR_FILENAME}"
+    ${CCLI} shelley address key-gen --verification-key-file "${payment_vk_file}" --signing-key-file "${payment_sk_file}"
+    ${CCLI} shelley stake-address key-gen --verification-key-file "${stake_vk_file}" --signing-key-file "${stake_sk_file}"
+    getAddress ${wallet_name}
 
-      if [[ -f "${payment_addr_file}" ]]; then
-        say "${RED}WARN${NC}: A wallet ${GREEN}$wallet_name${NC} already exists"
-        say "      Choose another name or delete the existing one"
-        waitForInput && continue
-      fi
-
-      ${CCLI} shelley address key-gen --verification-key-file "${payment_vk_file}" --signing-key-file "${payment_sk_file}"
-      ${CCLI} shelley address build --payment-verification-key-file "${payment_vk_file}" --out-file "${payment_addr_file}" --testnet-magic ${NWMAGIC}
-
-      say "New Wallet: ${GREEN}${wallet_name}${NC}" "log"
-      say "Payment Address: $(cat ${payment_addr_file})" "log"
-      echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-      waitForInput
-
-      ;; ###################################################################
-
-      stake)
-
-      clear
-      say " >> WALLET >> NEW >> STAKE" "log"
-      echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-      echo ""
-      
-      if [[ ! -f ${TMP_FOLDER}/protparams.json ]]; then
-        say "${RED}ERROR${NC}: CNTOOLS started without node access, only offline functions available!"
-        waitForInput && continue
-      fi
-      
-      wallet_dirs=()
-      if ! getDirs "${WALLET_FOLDER}"; then continue; fi # dirs() array populated with all wallet folders
-      for dir in "${dirs[@]}"; do
-        payment_sk_file="${WALLET_FOLDER}/${dir}/${WALLET_PAY_SK_FILENAME}"
-        payment_vk_file="${WALLET_FOLDER}/${dir}/${WALLET_PAY_VK_FILENAME}"
-        payment_addr_file="${WALLET_FOLDER}/${dir}/${WALLET_PAY_ADDR_FILENAME}"
-        [[ ! -f "${payment_addr_file}" || ! -f "${payment_vk_file}" || ! -f "${payment_sk_file}" ]] && continue
-        stake_addr_file="${WALLET_FOLDER}/${dir}/${WALLET_STAKE_ADDR_FILENAME}"
-        [[ -f "${stake_addr_file}" ]] && continue # already a stake wallet
-        getBalance "$(cat ${payment_addr_file})" >/dev/null
-        [[ ${TOTALBALANCE} -eq 0 ]] && continue
-        wallet_dirs+=("${dir} (${CYAN}$(numfmt --grouping ${totalBalanceADA})${NC} ADA)")
-      done
-      if [[ ${#wallet_dirs[@]} -eq 0 ]]; then
-        say "${ORANGE}WARN${NC}: No wallets available that can be upgraded!"
-        say "first create a payment wallet and fund it"
-        waitForInput && continue
-      fi
-      say "Select Wallet:\n"
-      if ! selectDir "${wallet_dirs[@]}"; then continue; fi # ${dir_name} populated by selectDir function
-      wallet_name="$(echo ${dir_name} | cut -d' ' -f1)"
-
-      # Wallet key filenames
-      payment_sk_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_PAY_SK_FILENAME}"
-      payment_vk_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_PAY_VK_FILENAME}"
-      payment_addr_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_PAY_ADDR_FILENAME}"
-      stake_vk_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_STAKE_VK_FILENAME}"
-      stake_sk_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_STAKE_SK_FILENAME}"
-      stake_addr_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_STAKE_ADDR_FILENAME}"
-      stake_cert_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_STAKE_CERT_FILENAME}"
-      base_addr_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_BASE_ADDR_FILENAME}"
-
-      ${CCLI} shelley stake-address key-gen --verification-key-file "${stake_vk_file}" --signing-key-file "${stake_sk_file}"
-      ${CCLI} shelley stake-address build --stake-verification-key-file "${stake_vk_file}" --out-file "${stake_addr_file}" --testnet-magic ${NWMAGIC}
-      # upgrade the payment address to an address that delegates to the new stake address
-      ${CCLI} shelley address build --payment-verification-key-file "${payment_vk_file}" --stake-verification-key-file "${stake_vk_file}" --out-file "${base_addr_file}" --testnet-magic ${NWMAGIC}
-
-      ${CCLI} shelley stake-address registration-certificate --stake-verification-key-file "${stake_vk_file}" --out-file "${stake_cert_file}"
-
-      payment_addr="$(cat ${payment_addr_file})"
-      base_addr="$(cat ${base_addr_file})"
-
-      # Register on chain
-      if ! registerStakeWallet "${payment_addr}" "${base_addr}" "${payment_sk_file}" "${stake_sk_file}" "${stake_cert_file}"; then
-        say "${RED}ERROR${NC}: failure during stake key registration, removing newly created stake keys"
-        rm -f "${stake_vk_file}" "${stake_sk_file}" "${stake_addr_file}" "${stake_cert_file}" "${base_addr_file}"
-        waitForInput && continue
-      fi
-
-      if ! waitNewBlockCreated; then
-        waitForInput && continue
-      fi
-
-      getBalance "${payment_addr}" >/dev/null
-
-      while [[ ${TOTALBALANCE} -ne 0 ]]; do
-        say ""
-        say "${ORANGE}WARN${NC}: Payment address balance mismatch, transaction not included in latest block ($(numfmt --grouping ${TOTALBALANCE}) != 0)"
-        if ! waitNewBlockCreated; then
-          break
-        fi
-        getBalance "${payment_addr}" >/dev/null
-      done
-      
-      if [[ ${TOTALBALANCE} -ne 0 ]]; then
-        # balance check aborted, return to main menu
-        continue
-      fi
-      
-      getBalanceAllAddr "${WALLET_FOLDER}/${wallet_name}" "no"
-
-      say "New Stake Wallet : ${GREEN}${wallet_name}${NC}" "log"
-      say "Payment Address  : ${payment_addr}" "log"
-      say "Payment Balance  : ${CYAN}$(numfmt --grouping ${payment_ada})${NC} ADA" "log"
-      say "Base Address     : ${base_addr}" "log"
-      say "Base Balance     : ${CYAN}$(numfmt --grouping ${base_ada})${NC} ADA" "log"
-      say "Reward Address   : $(cat ${stake_addr_file})" "log"
-      echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-      waitForInput
-
-      ;; ###################################################################
-
-    esac
+    say "New Wallet : ${GREEN}${wallet_name}${NC}" "log"
+    say "Address    : ${base_addr}" "log"
+    say "\nYou can now send and receive ADA using this address."
+    say "Wallet will be automatically registered on chain if you\nchoose to delegate or pledge wallet when registering a stake pool."
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    waitForInput && continue
 
     ;; ###################################################################
 
@@ -268,23 +148,30 @@ case $OPERATION in
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     
     if [[ ! -f "${TMP_FOLDER}"/protparams.json ]]; then
-      say "${RED}ERROR${NC}: CNTOOLS started without node access, only offline functions available!"
+      say "${RED}ERROR${NC}: CNTools started without node access, only offline functions available!"
       waitForInput && continue
     fi
     
     while IFS= read -r -d '' wallet; do
-      getBalanceAllAddr "${wallet}" "yes"
-      echo ""
-      say "${GREEN}$(basename ${wallet})${NC}" "log"
-      say "$(printf "%s\t${CYAN}%s${NC} ADA" "Payment"  "$(numfmt --grouping ${payment_ada})")" "log"
-      if [[ -f "${base_addr_file}" ]]; then
-        say "$(printf "%s\t${CYAN}%s${NC} ADA" "Base" "$(numfmt --grouping ${base_ada})")" "log"
+      wallet_name=$(basename ${wallet})
+      enc_files=$(find "${wallet}" -mindepth 1 -maxdepth 1 -type f -name *.gpg -printf '.' | wc -c)
+      if getAddress ${wallet_name} || [[ ${enc_files} -gt 0 ]]; then
+        echo ""
+        if [[ ${enc_files} -gt 0 ]]; then
+          say "${GREEN}${wallet_name}${NC} (${ORANGE}encrypted${NC})" "log"
+          base_addr=$(cat "${wallet}/${WALLET_BASE_ADDR_FILENAME}")
+        else
+          say "${GREEN}${wallet_name}${NC}" "log"
+        fi
+        getBalance ${base_addr}
+        say "$(printf "%s\t${CYAN}%s${NC} ADA" "Funds"  "$(numfmt --grouping ${base_ada})")" "log"
+        getRewards ${wallet_name}
         if [[ "${reward_lovelace}" -eq -1 ]]; then
-          say "${ORANGE}Not a registered stake wallet on chain${NC}"
+          say "${ORANGE}Not a registered wallet on chain${NC}"
           continue
         fi
-        say "$(printf "%s\t${CYAN}%s${NC} ADA" "Reward" "$(numfmt --grouping ${reward_ada})")" "log"
-        delegation_pool_id=$(${CCLI} shelley query stake-address-info --testnet-magic ${NWMAGIC} --address "$(cat ${stake_addr_file})" | jq -r '.[].delegation // empty')
+        say "$(printf "%s\t${CYAN}%s${NC} ADA" "Rewards" "$(numfmt --grouping ${reward_ada})")" "log"
+        delegation_pool_id=$(jq -r '.delegation // empty' <<< "${stakeAddressInfo}")
         if [[ -n ${delegation_pool_id} ]]; then
           unset poolName
           while IFS= read -r -d '' pool; do
@@ -311,17 +198,15 @@ case $OPERATION in
     echo ""
     
     if [[ ! -f ${TMP_FOLDER}/protparams.json ]]; then
-      say "${RED}ERROR${NC}: CNTOOLS started without node access, only offline functions available!"
+      say "${RED}ERROR${NC}: CNTools started without node access, only offline functions available!"
       waitForInput && continue
     fi
     
     wallet_dirs=()
     if ! getDirs "${WALLET_FOLDER}"; then continue; fi # dirs() array populated with all wallet folders
     for dir in "${dirs[@]}"; do
-      payment_sk_file="${WALLET_FOLDER}/${dir}/${WALLET_PAY_SK_FILENAME}"
-      payment_vk_file="${WALLET_FOLDER}/${dir}/${WALLET_PAY_VK_FILENAME}"
-      payment_addr_file="${WALLET_FOLDER}/${dir}/${WALLET_PAY_ADDR_FILENAME}"
-      [[ ! -f "${payment_addr_file}" || ! -f "${payment_vk_file}" || ! -f "${payment_sk_file}" ]] && continue
+      enc_files=$(find "${WALLET_FOLDER}/${dir}" -mindepth 1 -maxdepth 1 -type f -name *.gpg -printf '.' | wc -c)
+      if ! getAddress "${dir}" && [[ ${enc_files} -eq 0 ]]; then continue; fi
       wallet_dirs+=("${dir}")
     done
     if [[ ${#wallet_dirs[@]} -eq 0 ]]; then
@@ -331,51 +216,48 @@ case $OPERATION in
     fi
     say "Select Wallet:\n"
     if ! selectDir "${wallet_dirs[@]}"; then continue; fi # ${dir_name} populated by selectDir function
-    wallet_name="${dir_name}"
-
+    wallet_name=${dir_name}
+    enc_files=$(find "${WALLET_FOLDER}/${wallet_name}" -mindepth 1 -maxdepth 1 -type f -name *.gpg -printf '.' | wc -c)
+    
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     echo ""
-    say "$(printf "%-8s ${GREEN}%s${NC}" "Wallet" "${wallet_name}")" "log"
+    if [[ ${enc_files} -gt 0 ]]; then
+      base_addr=$(cat "${WALLET_FOLDER}/${wallet_name}/${WALLET_BASE_ADDR_FILENAME}")
+      say "$(printf "%-8s ${GREEN}%s${NC} ${ORANGE}%s${NC}" "Wallet" "${wallet_name}" "(encrypted)")" "log"
+    else
+      getAddress ${wallet_name}
+      say "$(printf "%-8s ${GREEN}%s${NC}" "Wallet" "${wallet_name}")" "log"
+    fi
+
+    getBalance ${base_addr}
+    if [[ -s ${TMP_FOLDER}/balance.out ]]; then
+      echo ""
+      say "${BLUE}UTxOs${NC}"
+      head -n 2 ${TMP_FOLDER}/fullUtxo.out
+      head -n 10 ${TMP_FOLDER}/balance.out
+      [[ ${utx0_count} -gt 10 ]] && say "... (top 10 UTx0 with most lovelace)"
+    fi
+    
     echo ""
-
-    getBalanceAllAddr "${WALLET_FOLDER}/${wallet_name}" "yes"
-
-    if [[ -s ${TMP_FOLDER}/balance_payment.out ]]; then
-      say "${BLUE}Payment UTxOs${NC}"
-      head -n 2 ${TMP_FOLDER}/fullUtxo_payment.out
-      head -n 10 ${TMP_FOLDER}/balance_payment.out
-      echo -e "\n"
-    fi
-    if [[ -s ${TMP_FOLDER}/balance_base.out ]]; then
-      say "${BLUE}Base UTxOs${NC}"
-      head -n 2 ${TMP_FOLDER}/fullUtxo_base.out
-      head -n 10 ${TMP_FOLDER}/balance_base.out
-      echo -e "\n"
-    fi
-    
-    say "$(printf "${BLUE}%-8s${NC} %-7s: %s" "Payment" "address" "${payment_addr}")" "log"
-    say "$(printf "%-8s %-7s: ${CYAN}%s${NC} ADA" "" "amount" "$(numfmt --grouping ${payment_ada})")" "log"
-    
-    if [[ -f "${base_addr_file}" ]]; then
-      say "$(printf "${BLUE}%-8s${NC} %-7s: %s" "Base" "address" "${base_addr}")" "log"
-      say "$(printf "%-8s %-7s: ${CYAN}%s${NC} ADA" "" "amount" "$(numfmt --grouping ${base_ada})")" "log"
-      if [[ "${reward_lovelace}" -eq -1 ]]; then
-        say "${ORANGE}Not a registered stake wallet on chain${NC}"
-      else
-        say "$(printf "${BLUE}%-8s${NC} %-7s: %s" "Reward" "address" "${stake_addr}")" "log"
-        say "$(printf "%-8s %-7s: ${CYAN}%s${NC} ADA" "" "amount" "$(numfmt --grouping ${reward_ada})")" "log"
-        delegation_pool_id=$(${CCLI} shelley query stake-address-info --testnet-magic ${NWMAGIC} --address "$(cat ${stake_addr_file})" | jq -r '.[].delegation  // empty')
-        if [[ -n ${delegation_pool_id} ]]; then
-          unset poolName
-          while IFS= read -r -d '' pool; do
-            pool_id=$(cat "${pool}/${POOL_ID_FILENAME}")
-            if [[ "${pool_id}" = "${delegation_pool_id}" ]]; then
-              poolName=$(basename ${pool}) && break
-            fi
-          done < <(find "${POOL_FOLDER}" -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
-          echo ""
-          say "${RED}Delegated to${NC} ${BLUE}${poolName}${NC} ${RED}(${delegation_pool_id})${NC}" "log"
-        fi
+    say "$(printf "%-8s : %s" "Address" "${base_addr}")" "log"
+    say "$(printf "%-8s : ${CYAN}%s${NC} ADA" "Funds" "$(numfmt --grouping ${base_ada})")" "log"
+    getRewards ${wallet_name}
+    if [[ "${reward_lovelace}" -eq -1 ]]; then
+      echo ""
+      say "${ORANGE}Not a registered wallet on chain${NC}"
+    else
+      say "$(printf "%-8s : ${CYAN}%s${NC} ADA" "Rewards" "$(numfmt --grouping ${reward_ada})")" "log"
+      delegation_pool_id=$(jq -r '.delegation  // empty' <<< "${stakeAddressInfo}")
+      if [[ -n ${delegation_pool_id} ]]; then
+        unset poolName
+        while IFS= read -r -d '' pool; do
+          pool_id=$(cat "${pool}/${POOL_ID_FILENAME}")
+          if [[ "${pool_id}" = "${delegation_pool_id}" ]]; then
+            poolName=$(basename ${pool}) && break
+          fi
+        done < <(find "${POOL_FOLDER}" -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
+        echo ""
+        say "${RED}Delegated to${NC} ${BLUE}${poolName}${NC} ${RED}(${delegation_pool_id})${NC}" "log"
       fi
     fi
     echo ""
@@ -384,7 +266,7 @@ case $OPERATION in
     
     ;; ###################################################################
 
-    remove) ## TODO - Check reward address
+    remove)
     
     clear
     say " >> WALLET >> REMOVE" "log"
@@ -392,7 +274,7 @@ case $OPERATION in
     echo ""
     
     if [[ ! -f ${TMP_FOLDER}/protparams.json ]]; then
-      say "${RED}ERROR${NC}: CNTOOLS started without node access, only offline functions available!"
+      say "${RED}ERROR${NC}: CNTools started without node access, only offline functions available!"
       waitForInput && continue
     fi
     
@@ -404,15 +286,9 @@ case $OPERATION in
     say "Select Wallet:\n"
     if ! selectDir "${dirs[@]}"; then continue; fi # ${dir_name} populated by selectDir function
     wallet_name="${dir_name}"
-
-    # Wallet key filename
-    payment_addr_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_PAY_ADDR_FILENAME}"
-    base_addr_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_BASE_ADDR_FILENAME}"
     
-    if [[ ! -f "${payment_addr_file}" && ! -f "${base_addr_file}" ]]; then
-      say "${RED}WARN${NC}: no payment or base address files found in wallet"
-      say "${payment_addr_file}"
-      say "${base_addr_file}"
+    if ! getAddress ${wallet_name}; then
+      say "${RED}WARN${NC}: unable to get address for wallet and do a balance check"
       say "\nAre you sure to delete wallet anyway?\n"
       case $(select_opt "[y] Yes" "[n] No") in
         0) rm -rf "${WALLET_FOLDER:?}/${wallet_name}"
@@ -424,9 +300,10 @@ case $OPERATION in
       waitForInput && continue
     fi
     
-    getBalanceAllAddr "${WALLET_FOLDER}/${wallet_name}" "no"
+    getBalance ${base_addr}
+    getRewards ${wallet_name}
     
-    if [[ ${payment_lovelace} -eq 0 && ${base_lovelace} -eq 0 ]]; then
+    if [[ ${base_lovelace} -eq 0 && ${reward_lovelace} -le 0 ]]; then
       say "INFO: This wallet appears to be empty"
       say "${RED}WARN${NC}: Deleting this wallet is final and you can not recover it unless you have a backup\n"
       say "Are you sure to delete wallet?\n"
@@ -439,11 +316,11 @@ case $OPERATION in
       esac
     else
       say "${RED}WARN${NC}: wallet not empty!"
-      if [[ ${payment_lovelace} -gt 0 ]]; then
-        say "Payment address balance: ${BLUE}$(numfmt --grouping ${payment_ada})${NC} ADA"
-      fi
       if [[ ${base_lovelace} -gt 0 ]]; then
-        say "Base address balance: ${BLUE}$(numfmt --grouping ${base_ada})${NC} ADA"
+        say "Funds:   ${CYAN}$(numfmt --grouping ${base_ada})${NC} ADA"
+      fi
+      if [[ ${reward_lovelace} -gt 0 ]]; then
+        say "Rewards: ${CYAN}$(numfmt --grouping ${reward_ada})${NC} ADA"
       fi
       echo ""
       say "${RED}WARN${NC}: Deleting this wallet is final and you can not recover it unless you have a backup\n"
@@ -516,7 +393,7 @@ case $OPERATION in
     if [[ ${filesUnlocked} -ne 0 || ${keysDecrypted} -ne 0 ]]; then
       echo ""
       say "${ORANGE}Wallet files are now unprotected${NC}"
-      say "Use 'WALLET >> ENCRYPT / LOCK' to re-lock"
+      say "Use 'WALLET >> ENCRYPT' to re-lock"
     fi
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 
@@ -546,9 +423,9 @@ case $OPERATION in
     filesLocked=0
     keysEncrypted=0
     
-    say " -- Encrypting sensitive pool keys with GPG --" "log"
+    say " -- Encrypting sensitive wallet keys with GPG --" "log"
     echo ""
-    say "Pool ${GREEN}${wallet_name}${NC} Password"
+    say "Wallet ${GREEN}${wallet_name}${NC} Password"
     echo ""
     if ! getPassword confirm; then # $password variable populated by getPassword function
       echo -e "\n\n" && say "${RED}ERROR${NC}: password input aborted!"
@@ -571,7 +448,7 @@ case $OPERATION in
     unset password
 
     echo ""
-    say " -- Write protecting all pool files using 'chattr +i' --" "log"
+    say " -- Write protecting all wallet files using 'chattr +i' --" "log"
     while IFS= read -r -d '' file; do
       if [[ ! $(lsattr -R "$file") =~ -i- ]]; then
         chmod 400 "${file}" && \
@@ -588,7 +465,7 @@ case $OPERATION in
     if [[ ${filesLocked} -ne 0 || ${keysEncrypted} -ne 0 ]]; then
       echo ""
       say "${BLUE}Wallet files are now protected${NC}"
-      say "Use 'WALLET >> DECRYPT / UNLOCK' to unlock"
+      say "Use 'WALLET >> DECRYPT' to unlock"
     fi
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 
@@ -629,7 +506,7 @@ case $OPERATION in
     echo ""
 
     if [[ ! -f ${TMP_FOLDER}/protparams.json ]]; then
-      say "${RED}ERROR${NC}: CNTOOLS started without node access, only offline functions available!"
+      say "${RED}ERROR${NC}: CNTools started without node access, only offline functions available!"
       waitForInput && continue
     fi
     
@@ -644,8 +521,7 @@ case $OPERATION in
       pay_payment_sk_file="${WALLET_FOLDER}/${dir}/${WALLET_PAY_SK_FILENAME}"
       [[ ! -f "${base_addr_file}" || ! -f "${stake_addr_file}" || ! -f "${stake_sk_file}" || ! -f "${stake_vk_file}" || ! -f "${pay_payment_sk_file}" ]] && continue
       if [[ ${wallet_count} -le ${WALLET_SELECTION_FILTER_LIMIT} ]]; then
-        reward_lovelace=$(${CCLI} shelley query stake-address-info --testnet-magic ${NWMAGIC} --address "$(cat ${stake_addr_file})" | jq -r '.[].rewardAccountBalance // empty')
-        [[ "${reward_lovelace}" =~ ^[0-9]+$ ]] || reward_lovelace=0
+        getRewards ${dir}
         [[ ${reward_lovelace} -le 0 ]] && continue
         reward_ada=$(lovelacetoADA ${reward_lovelace})
         wallet_dirs+=("${dir} (Rewards: ${CYAN}$(numfmt --grouping ${reward_ada})${NC} ADA)")
@@ -661,24 +537,24 @@ case $OPERATION in
     if ! selectDir "${wallet_dirs[@]}"; then continue; fi # ${dir_name} populated by selectDir function
     wallet_name="$(echo ${dir_name} | cut -d' ' -f1)"
       
-    base_addr_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_BASE_ADDR_FILENAME}"
+    getAddress ${wallet_name}
     stake_addr_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_STAKE_ADDR_FILENAME}"
     stake_sk_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_STAKE_SK_FILENAME}"
     stake_vk_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_STAKE_VK_FILENAME}"
     pay_payment_sk_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_PAY_SK_FILENAME}"
     
-    getBalanceAllAddr "${WALLET_FOLDER}/${wallet_name}" "yes"
-
-    say "$(printf "%s\t${CYAN}%s${NC} ADA" "Payment"  "$(numfmt --grouping ${payment_ada})")" "log"
-    say "$(printf "%s\t${CYAN}%s${NC} ADA" "Base"  "$(numfmt --grouping ${base_ada})")" "log"
-    say "$(printf "%s\t${CYAN}%s${NC} ADA" "Rewards"  "$(numfmt --grouping ${reward_ada})")" "log"
+    getBalance ${base_addr}
+    getRewards ${wallet_name}
     
     if [[ ${reward_lovelace} -le 0 ]]; then
       echo "Failed to locate any rewards associated with the chosen wallet, please try another one"
       waitForInput && continue
     fi
+    
+    say "$(printf "%s\t${CYAN}%s${NC} ADA" "Funds"  "$(numfmt --grouping ${base_ada})")" "log"
+    say "$(printf "%s\t${CYAN}%s${NC} ADA" "Rewards"  "$(numfmt --grouping ${reward_ada})")" "log"
 
-    if ! withdrawRewards "${stake_vk_file}" "${stake_sk_file}" "${pay_payment_sk_file}" "$(cat ${base_addr_file})" "$(cat ${stake_addr_file})" ${reward_lovelace}; then
+    if ! withdrawRewards "${stake_vk_file}" "${stake_sk_file}" "${pay_payment_sk_file}" "${base_addr}" "${reward_addr}" ${reward_lovelace}; then
       echo "" && say "${RED}ERROR${NC}: failure during withdrawal of rewards"
       waitForInput && continue
     fi
@@ -687,27 +563,25 @@ case $OPERATION in
       waitForInput && continue
     fi
     
-    getBalance "$(cat ${base_addr_file})" >/dev/null
+    getBalance ${base_addr}
 
-    while [[ ${TOTALBALANCE} -ne ${newBalance} ]]; do
+    while [[ ${base_lovelace} -ne ${newBalance} ]]; do
       echo ""
-      say "${ORANGE}WARN${NC}: Balance mismatch, transaction not included in latest block ($(numfmt --grouping ${TOTALBALANCE}) != $(numfmt --grouping ${newBalance}))"
+      say "${ORANGE}WARN${NC}: Balance mismatch, transaction not included in latest block ($(numfmt --grouping ${base_lovelace}) != $(numfmt --grouping ${newBalance}))"
       if ! waitNewBlockCreated; then
         break
       fi
-      getBalance "$(cat ${base_addr_file})" >/dev/null
+      getBalance ${base_addr}
     done
     
-    if [[ ${TOTALBALANCE} -ne ${newBalance} ]]; then
+    if [[ ${base_lovelace} -ne ${newBalance} ]]; then
       waitForInput && continue
     fi
 
-    say ""
-    say "--- Balance Check -------------------------------------------------------"
-    getBalanceAllAddr "${WALLET_FOLDER}/${wallet_name}" "yes"
+    getRewards ${wallet_name}
 
-    say "$(printf "%s\t${CYAN}%s${NC} ADA" "Payment"  "$(numfmt --grouping ${payment_ada})")" "log"
-    say "$(printf "%s\t${CYAN}%s${NC} ADA" "Base"  "$(numfmt --grouping ${base_ada})")" "log"
+    echo ""
+    say "$(printf "%s\t${CYAN}%s${NC} ADA" "Funds"  "$(numfmt --grouping ${base_ada})")" "log"
     say "$(printf "%s\t${CYAN}%s${NC} ADA" "Rewards"  "$(numfmt --grouping ${reward_ada})")" "log"
     waitForInput
     
@@ -721,7 +595,7 @@ case $OPERATION in
     echo ""
     
     if [[ ! -f ${TMP_FOLDER}/protparams.json ]]; then
-      say "${RED}ERROR${NC}: CNTOOLS started without node access, only offline functions available!"
+      say "${RED}ERROR${NC}: CNTools started without node access, only offline functions available!"
       waitForInput && continue
     fi
     
@@ -731,13 +605,15 @@ case $OPERATION in
     if ! getDirs "${WALLET_FOLDER}"; then continue; fi # dirs() array populated with all wallet folders
     wallet_count=${#dirs[@]}
     for dir in "${dirs[@]}"; do
-      s_payment_addr_file="${WALLET_FOLDER}/${dir}/${WALLET_PAY_ADDR_FILENAME}"
       s_base_addr_file="${WALLET_FOLDER}/${dir}/${WALLET_BASE_ADDR_FILENAME}"
-      [[ ! -f "${s_payment_addr_file}" ]] && continue
+      s_payment_sk_file="${WALLET_FOLDER}/${dir}/${WALLET_PAY_SK_FILENAME}"
+      [[ ! -f "${s_base_addr_file}" || ! -f "${s_payment_sk_file}" ]] && continue
       if [[ ${wallet_count} -le ${WALLET_SELECTION_FILTER_LIMIT} ]]; then
-        getBalanceAllAddr "${WALLET_FOLDER}/${dir}" "no"
-        [[ ${payment_lovelace} -eq 0 && ${base_lovelace} -eq 0 ]] && continue
-        s_wallet_dirs+=("${dir} (Payment: ${CYAN}$(numfmt --grouping ${payment_ada})${NC} ADA - Base: ${CYAN}$(numfmt --grouping ${base_ada})${NC} ADA)")
+        if getAddress ${dir}; then
+          getBalance ${base_addr}
+          [[ ${base_lovelace} -eq 0 ]] && continue
+          s_wallet_dirs+=("${dir} (${CYAN}$(numfmt --grouping ${base_ada})${NC} ADA)")
+        fi
       else
         s_wallet_dirs+=("${dir}")
       fi
@@ -749,44 +625,16 @@ case $OPERATION in
     say "Select Source Wallet:\n"
     if ! selectDir "${s_wallet_dirs[@]}"; then continue; fi # ${dir_name} populated by selectDir function
     s_wallet="$(echo ${dir_name} | cut -d' ' -f1)"
+    s_addr="$(cat ${WALLET_FOLDER}/${s_wallet}/${WALLET_BASE_ADDR_FILENAME})"
+    s_payment_sk_file="${WALLET_FOLDER}/${s_wallet}/${WALLET_PAY_SK_FILENAME}"
     
-    s_payment_addr_file="${WALLET_FOLDER}/${s_wallet}/${WALLET_PAY_ADDR_FILENAME}"
-    s_base_addr_file="${WALLET_FOLDER}/${s_wallet}/${WALLET_BASE_ADDR_FILENAME}"
-    
-    getBalanceAllAddr "${WALLET_FOLDER}/${s_wallet}" "no"
-    
-    if [[ ${payment_lovelace} -gt 0 && ${base_lovelace} -gt 0 ]]; then
-      # Both payment and base address available with funds, let user choose what to use
-      say "Both payment and base address available with funds, choose address"
-      say "$(printf "%s\t${CYAN}%s${NC} ADA" "Payment"  "$(numfmt --grouping ${payment_ada})")" "log"
-      say "$(printf "%s\t${CYAN}%s${NC} ADA" "Base"  "$(numfmt --grouping ${base_ada})")" "log"
-      echo ""
-      case $(select_opt "[p] Payment" "[b] Base" "[c] Cancel") in
-        0) s_addr_file="${s_payment_addr_file}"
-           totalAmountLovelace=${payment_lovelace}
-           totalAmountADA=${payment_ada}
-           ;;
-        1) s_addr_file="${s_base_addr_file}" 
-           totalAmountLovelace=${base_lovelace}
-           totalAmountADA=${base_ada}
-           ;;
-        2) continue ;;
-      esac
-    elif [[ ${payment_lovelace} -gt 0 ]]; then
-      s_addr_file="${s_payment_addr_file}"
-      totalAmountLovelace=${payment_lovelace}
-      totalAmountADA=${payment_ada}
-      say "$(printf "%s\t${CYAN}%s${NC} ADA" "Payment"  "$(numfmt --grouping ${payment_ada})")" "log"
-    elif [[ ${base_lovelace} -gt 0 ]]; then
-      s_addr_file="${s_base_addr_file}"
-      totalAmountLovelace=${base_lovelace}
-      totalAmountADA=${base_ada}
-      say "$(printf "%s\t${CYAN}%s${NC} ADA" "Base"  "$(numfmt --grouping ${base_ada})")" "log"
+    getBalance ${s_addr}
+    if [[ ${base_lovelace} -gt 0 ]]; then
+      say "$(printf "%s\t${CYAN}%s${NC} ADA" "Funds in source wallet:"  "$(numfmt --grouping ${base_ada})")" "log"
     else
-      say "${RED}ERROR${NC}: no funds available in either payment or base address for wallet ${GREEN}${s_wallet}${NC}"
+      say "${RED}ERROR${NC}: no funds available for wallet ${GREEN}${wallet_name}${NC}"
       waitForInput && continue
     fi
-    s_addr="$(cat ${s_addr_file})"
 
     # Amount
     echo ""
@@ -816,8 +664,8 @@ case $OPERATION in
       esac
     else
       echo ""
-      amountADA=${totalAmountADA}
-      amountLovelace=${totalAmountLovelace}
+      amountADA=${base_ada}
+      amountLovelace=${base_lovelace}
       say "ADA to send set to total supply: $(numfmt --grouping ${amountADA})" "log"
       echo ""
       include_fee="yes"
@@ -826,59 +674,27 @@ case $OPERATION in
     # Destination
     say " -- Destination Address / Wallet --"
     echo ""
-    d_addr_file=""
+    d_wallet=""
     say "Is destination a local wallet or an address?\n"
     case $(select_opt "[w] Wallet" "[a] Address" "[c] Cancel") in
       0) d_wallet_dirs=()
          if ! getDirs "${WALLET_FOLDER}"; then continue; fi # dirs() array populated with all wallet folders
          for dir in "${dirs[@]}"; do
-           d_payment_addr_file="${WALLET_FOLDER}/${dir}/${WALLET_PAY_ADDR_FILENAME}"
            d_base_addr_file="${WALLET_FOLDER}/${dir}/${WALLET_BASE_ADDR_FILENAME}"
-           [[ ! -f ${d_payment_addr_file} && ! -f ${d_base_addr_file} ]] && continue
+           [[ ! -f ${d_base_addr_file} ]] && continue
            d_wallet_dirs+=("${dir}")
          done
          say "Select Destination Wallet:\n"
          if ! selectDir "${d_wallet_dirs[@]}"; then continue; fi # ${dir_name} populated by selectDir function
          d_wallet="${dir_name}"
-
-         d_payment_addr_file="${WALLET_FOLDER}/${d_wallet}/${WALLET_PAY_ADDR_FILENAME}"
-         d_base_addr_file="${WALLET_FOLDER}/${d_wallet}/${WALLET_BASE_ADDR_FILENAME}"
-    
-         if [[ -f "${d_payment_addr_file}" && -f "${d_base_addr_file}" ]]; then
-           # Both payment and base address available, let user choose what to use
-           say "Both payment and base address available, choose address\n"
-           case $(select_opt "[p] Payment" "[b] Base" "[c] Cancel") in
-             0) d_addr_file="${d_payment_addr_file}" ;;
-             1) d_addr_file="${d_base_addr_file}" ;;
-             2) continue ;;
-           esac
-         elif [[ -f "${d_payment_addr_file}" ]]; then
-           d_addr_file="${d_payment_addr_file}"
-         elif [[ -f "${d_base_addr_file}" ]]; then
-           d_addr_file="${d_base_addr_file}"
-         else
-           say "${RED}ERROR${NC}: no payment or base address file found for wallet ${GREEN}${d_wallet}${NC}"
-           say "${d_payment_addr_file}"
-           say "${d_base_addr_file}"
-           waitForInput && continue
-         fi
-         d_addr="$(cat ${d_addr_file})"
+         d_addr="$(cat ${WALLET_FOLDER}/${d_wallet}/${WALLET_BASE_ADDR_FILENAME})"
          ;;
       1) echo "" && read -r -p "Address: " d_addr ;;
       2) continue ;;
     esac
-    # Destination could be empty, if so  without getting a valid address
+    # Destination could be empty, if so without getting a valid address
     if [[ -z ${d_addr} ]]; then
       say "${RED}ERROR${NC}: destination address field empty"
-      waitForInput && continue
-    fi
-
-    # Source Sign Key
-    # decrypt signing key if needed and make sure to encrypt again even on failure
-    s_payment_sk_file="${WALLET_FOLDER}/${s_wallet}/${WALLET_PAY_SK_FILENAME}"
-    if [[ ! -f "${s_payment_sk_file}" ]]; then
-      say "${RED}ERROR${NC}: source wallet signing key file not found:"
-      say "${s_payment_sk_file}"
       waitForInput && continue
     fi
 
@@ -892,37 +708,34 @@ case $OPERATION in
       waitForInput && continue
     fi
 
-    getBalance ${s_addr} >/dev/null
+    getBalance ${s_addr}
 
-    while [[ ${TOTALBALANCE} -ne ${newBalance} ]]; do
+    while [[ ${base_lovelace} -ne ${newBalance} ]]; do
       say ""
-      say "${ORANGE}WARN${NC}: Balance mismatch, transaction not included in latest block ($(numfmt --grouping ${TOTALBALANCE}) != $(numfmt --grouping ${newBalance}))"
+      say "${ORANGE}WARN${NC}: Balance mismatch, transaction not included in latest block ($(numfmt --grouping ${base_lovelace}) != $(numfmt --grouping ${newBalance}))"
       if ! waitNewBlockCreated; then
         break
       fi
-      getBalance ${s_addr} >/dev/null
+      getBalance ${s_addr}
     done
     
-    if [[ ${TOTALBALANCE} -ne ${newBalance} ]]; then 
+    if [[ ${base_lovelace} -ne ${newBalance} ]]; then 
       waitForInput && continue
     fi
 
-    s_balance_ada=${totalBalanceADA}
+    s_balance_ada=${base_ada}
 
-    getBalance ${d_addr} >/dev/null
+    getBalance ${d_addr}
 
-    d_balance_ada=${totalBalanceADA}
+    d_balance_ada=${base_ada}
 
     say ""
     say "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     say "Transaction" "log"
-    [[ "${s_addr_file}" = "${s_payment_addr_file}" ]] && s_wallet_type="payment" || s_wallet_type="base"
-    say "  From          : ${GREEN}${s_wallet}${NC} (${s_wallet_type})" "log"
+    say "  From          : ${GREEN}${s_wallet}${NC}" "log"
     say "  Amount        : $(numfmt --grouping ${amountADA}) ADA" "log"
-    if [[ "${d_addr_file}" = "${d_payment_addr_file}" ]]; then
-      say "  To            : ${GREEN}${d_wallet}${NC} (payment)" "log"
-    elif [[ "${d_addr_file}" = "${d_base_addr_file}" ]]; then
-      say "  To            : ${GREEN}${d_wallet}${NC} (base)" "log"
+    if [[ -n "${d_wallet}" ]]; then
+      say "  To            : ${GREEN}${d_wallet}${NC}" "log"
     else
       say "  To            : ${d_addr}" "log"
     fi
@@ -945,7 +758,7 @@ case $OPERATION in
     echo ""
     
     if [[ ! -f ${TMP_FOLDER}/protparams.json ]]; then
-      say "${RED}ERROR${NC}: CNTOOLS started without node access, only offline functions available!"
+      say "${RED}ERROR${NC}: CNTools started without node access, only offline functions available!"
       waitForInput && continue
     fi
     
@@ -960,8 +773,11 @@ case $OPERATION in
       pay_payment_sk_file="${WALLET_FOLDER}/${dir}/${WALLET_PAY_SK_FILENAME}"
       [[ ! -f "${base_addr_file}" || ! -f "${stake_addr_file}" || ! -f "${stake_sk_file}" || ! -f "${stake_vk_file}" || ! -f "${pay_payment_sk_file}" ]] && continue
       if [[ ${wallet_count} -le ${WALLET_SELECTION_FILTER_LIMIT} ]]; then
-        getBalance "$(cat ${base_addr_file})" >/dev/null
-        delegation_pool_id=$(${CCLI} shelley query stake-address-info --testnet-magic ${NWMAGIC} --address "$(cat ${stake_addr_file})" | jq -r '.[].delegation // empty')
+        getAddress ${dir}
+        getBalance ${base_addr}
+        [[ ${base_lovelace} -eq 0 ]] && continue
+        getRewardAddress ${dir}
+        delegation_pool_id=$(${CCLI} shelley query stake-address-info --testnet-magic ${NWMAGIC} --address "${reward_addr}" | jq -r '.[].delegation // empty')
         unset poolName
         if [[ -n ${delegation_pool_id} ]]; then
           while IFS= read -r -d '' pool; do
@@ -972,11 +788,11 @@ case $OPERATION in
           done < <(find "${POOL_FOLDER}" -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
         fi
         if [[ -n ${poolName} ]]; then
-          wallet_dirs+=("${dir} (Base: ${CYAN}${totalBalanceADA}${NC} - ${RED}delegated${NC} to ${BLUE}${poolName}${NC})")
+          wallet_dirs+=("${dir} (${CYAN}${base_ada}${NC} ADA - ${RED}delegated${NC} to ${BLUE}${poolName}${NC})")
         elif [[ -n ${delegation_pool_id} ]]; then
-          wallet_dirs+=("${dir} (Base: ${CYAN}${totalBalanceADA}${NC} - ${RED}delegated${NC} to external address)")
+          wallet_dirs+=("${dir} (${CYAN}${base_ada}${NC} ADA - ${RED}delegated${NC} to external address)")
         else
-          wallet_dirs+=("${dir} (Base: ${CYAN}${totalBalanceADA}${NC})")
+          wallet_dirs+=("${dir} (${CYAN}${base_ada}${NC} ADA)")
         fi
       else
         wallet_dirs+=("${dir}")
@@ -990,14 +806,25 @@ case $OPERATION in
     if ! selectDir "${wallet_dirs[@]}"; then continue; fi # ${dir_name} populated by selectDir function
     wallet_name="$(echo ${dir_name} | cut -d' ' -f1)"
     
-    getBalanceAllAddr "${WALLET_FOLDER}/${wallet_name}" "yes"
+    getAddress ${wallet_name}
+    getBalance ${base_addr}
+    if [[ ${base_lovelace} -gt 0 ]]; then
+      say "$(printf "%s\t${CYAN}%s${NC} ADA" "Funds in wallet:"  "$(numfmt --grouping ${base_ada})")" "log"
+    else
+      say "${RED}ERROR${NC}: no funds available for wallet ${GREEN}${wallet_name}${NC}"
+      waitForInput && continue
+    fi
+    getRewards ${wallet_name}
+    
+    if [[ reward_lovelace -eq -1 ]] && ! registerStakeWallet ${wallet_name}; then
+      waitForInput && continue
+    fi
 
-    say "$(printf "%s\t${CYAN}%s${NC} ADA" "Payment"  "$(numfmt --grouping ${payment_ada})")" "log"
-    say "$(printf "%s\t${CYAN}%s${NC} ADA" "Base"  "$(numfmt --grouping ${base_ada})")" "log"
+    echo ""
+    say "$(printf "%s\t${CYAN}%s${NC} ADA" "Funds"  "$(numfmt --grouping ${base_ada})")" "log"
     say "$(printf "%s\t${CYAN}%s${NC} ADA" "Rewards"  "$(numfmt --grouping ${reward_ada})")" "log"
     echo ""
     
-    base_addr_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_BASE_ADDR_FILENAME}"
     stake_sk_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_STAKE_SK_FILENAME}"
     stake_vk_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_STAKE_VK_FILENAME}"
     pay_payment_sk_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_PAY_SK_FILENAME}"
@@ -1039,8 +866,7 @@ case $OPERATION in
     say "-- creating delegation cert --" "log"
     ${CCLI} shelley stake-address delegation-certificate --stake-verification-key-file "${stake_vk_file}" --cold-verification-key-file "${pool_coldkey_vk_file}" --out-file "${delegation_cert_file}"
 
-    #[stake vkey] [stake skey] [pay skey] [pay addr] [pool vkey] [deleg cert]
-    if ! delegate "${stake_vk_file}" "${stake_sk_file}" "${pay_payment_sk_file}" "$(cat ${base_addr_file})" "${pool_coldkey_vk_file}" "${delegation_cert_file}" ; then
+    if ! delegate "${stake_vk_file}" "${stake_sk_file}" "${pay_payment_sk_file}" "${base_addr}" "${pool_coldkey_vk_file}" "${delegation_cert_file}" ; then
       echo "" && say "${RED}ERROR${NC}: failure during delegation, removing newly created delegation certificate file"
       rm -f "${delegation_cert_file}"
       waitForInput && continue
@@ -1050,25 +876,25 @@ case $OPERATION in
       waitForInput && continue
     fi
 
-    getBalance "$(cat ${base_addr_file})" >/dev/null
+    getBalance ${base_addr}
 
-    while [[ ${TOTALBALANCE} -ne ${newBalance} ]]; do
+    while [[ ${base_lovelace} -ne ${newBalance} ]]; do
       echo ""
-      say "${ORANGE}WARN${NC}: Balance mismatch, transaction not included in latest block ($(numfmt --grouping ${TOTALBALANCE}) != $(numfmt --grouping ${newBalance}))"
+      say "${ORANGE}WARN${NC}: Balance mismatch, transaction not included in latest block ($(numfmt --grouping ${base_lovelace}) != $(numfmt --grouping ${newBalance}))"
       if ! waitNewBlockCreated; then
         break
       fi
-      getBalance "$(cat ${base_addr_file})" >/dev/null
+      getBalance ${base_addr}
     done
     
-    if [[ ${TOTALBALANCE} -ne ${newBalance} ]]; then
+    if [[ ${base_lovelace} -ne ${newBalance} ]]; then
       waitForInput && continue
     fi
 
     say "Delegation successfully registered"
     say "Wallet : ${GREEN}${wallet_name}${NC}"
     say "Pool   : ${GREEN}${pool_name}${NC}" "log"
-    say "Amount : $(numfmt --grouping ${totalBalanceADA}) ADA" "log"
+    say "Amount : $(numfmt --grouping ${base_ada}) ADA" "log"
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     echo ""
 
@@ -1177,7 +1003,7 @@ case $OPERATION in
     echo ""
     
     if [[ ! -f ${TMP_FOLDER}/protparams.json ]]; then
-      say "${RED}ERROR${NC}: CNTOOLS started without node access, only offline functions available!"
+      say "${RED}ERROR${NC}: CNTools started without node access, only offline functions available!"
       waitForInput && continue
     fi
     
@@ -1417,8 +1243,11 @@ case $OPERATION in
       pay_payment_sk_file="${WALLET_FOLDER}/${dir}/${WALLET_PAY_SK_FILENAME}"
       [[ ! -f "${base_addr_file}" || ! -f "${stake_addr_file}" || ! -f "${stake_sk_file}" || ! -f "${stake_vk_file}" || ! -f "${pay_payment_sk_file}" ]] && continue
       if [[ ${wallet_count} -le ${WALLET_SELECTION_FILTER_LIMIT} ]]; then
-        getBalance "$(cat ${base_addr_file})" >/dev/null
-        delegation_pool_id=$(${CCLI} shelley query stake-address-info --testnet-magic ${NWMAGIC} --address "$(cat ${stake_addr_file})" | jq -r '.[].delegation // empty')
+        getAddress ${dir}
+        getBalance ${base_addr}
+        [[ ${base_lovelace} -eq 0 ]] && continue
+        getRewardAddress ${dir}
+        delegation_pool_id=$(${CCLI} shelley query stake-address-info --testnet-magic ${NWMAGIC} --address "${reward_addr}" | jq -r '.[].delegation // empty')
         unset poolName
         if [[ -n ${delegation_pool_id} ]]; then
           while IFS= read -r -d '' pool; do
@@ -1429,11 +1258,11 @@ case $OPERATION in
           done < <(find "${POOL_FOLDER}" -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
         fi
         if [[ -n ${poolName} ]]; then
-          wallet_dirs+=("${dir} (Base: ${CYAN}${totalBalanceADA}${NC} - ${RED}delegated${NC} to ${BLUE}${poolName}${NC})")
+          wallet_dirs+=("${dir} (${CYAN}${base_ada}${NC} ADA - ${RED}delegated${NC} to ${BLUE}${poolName}${NC})")
         elif [[ -n ${delegation_pool_id} ]]; then
-          wallet_dirs+=("${dir} (Base: ${CYAN}${totalBalanceADA}${NC} - ${RED}delegated${NC} to external address)")
+          wallet_dirs+=("${dir} (${CYAN}${base_ada}${NC} ADA - ${RED}delegated${NC} to external address)")
         else
-          wallet_dirs+=("${dir} (Base: ${CYAN}${totalBalanceADA}${NC})")
+          wallet_dirs+=("${dir} (${CYAN}${base_ada}${NC} ADA)")
         fi
       else
         wallet_dirs+=("${dir}")
@@ -1446,6 +1275,18 @@ case $OPERATION in
     say "Select Pledge Wallet:\n"
     if ! selectDir "${wallet_dirs[@]}"; then continue; fi # ${dir_name} populated by selectDir function
     pledge_wallet="$(echo ${dir_name} | cut -d' ' -f1)"
+    getAddress ${pledge_wallet}
+    getBalance ${base_addr}
+    
+    if [[ ${base_lovelace} -gt 0 ]]; then
+      say "$(printf "%s\t${CYAN}%s${NC} ADA" "Funds in pledge wallet:"  "$(numfmt --grouping ${base_ada})")" "log"
+    else
+      say "${RED}ERROR${NC}: no funds available for wallet ${GREEN}${pledge_wallet}${NC}"
+      waitForInput && continue
+    fi
+    if ! isWalletRegistered ${pledge_wallet} && ! registerStakeWallet ${pledge_wallet}; then
+      waitForInput && continue
+    fi
     
     # Construct relay json array
     relay_json=$({
@@ -1485,13 +1326,15 @@ case $OPERATION in
     #Generated Files
     pool_regcert_file="${POOL_FOLDER}/${pool_name}/${POOL_REGCERT_FILENAME}"
     pool_pledgecert_file="${POOL_FOLDER}/${pool_name}/${POOL_PLEDGECERT_FILENAME}"
-
-    say "-- creating registration cert --" "log" 
+    
+    echo ""
+    say " -- creating registration cert --" "log"
+    echo ""
     ${CCLI} shelley stake-pool registration-certificate --cold-verification-key-file "${pool_coldkey_vk_file}" --vrf-verification-key-file "${pool_vrf_vk_file}" --pool-pledge ${pledge_lovelace} --pool-cost ${cost_lovelace} --pool-margin ${margin_fraction} --pool-reward-account-verification-key-file "${stake_vk_file}" --pool-owner-stake-verification-key-file "${stake_vk_file}" --out-file "${pool_regcert_file}" --testnet-magic ${NWMAGIC} --metadata-url "${meta_json_url}" --metadata-hash "$(${CCLI} shelley stake-pool metadata-hash --pool-metadata-file ${pool_meta_file} )" ${relay_output}
     say "-- creating delegation cert --" "log"
     ${CCLI} shelley stake-address delegation-certificate --stake-verification-key-file "${stake_vk_file}" --cold-verification-key-file "${pool_coldkey_vk_file}" --out-file "${pool_pledgecert_file}"
     
-    say "-- Sending transaction to chain --" "log"
+    say " -- Sending transaction to chain --" "log"
     if ! registerPool "$(cat ${base_addr_file})" "${pool_coldkey_sk_file}" "${stake_sk_file}" "${pool_regcert_file}" "${pool_pledgecert_file}" "${pay_payment_sk_file}"; then
       say "${RED}ERROR${NC}: failure during pool registration, removing newly created pledge and registration files"
       rm -f "${pool_regcert_file}" "${pool_pledgecert_file}"
@@ -1502,18 +1345,18 @@ case $OPERATION in
       waitForInput && continue
     fi
 
-    getBalance "$(cat ${base_addr_file})" >/dev/null
+    getBalance ${base_addr}
 
-    while [[ ${TOTALBALANCE} -ne ${newBalance} ]]; do
+    while [[ ${base_lovelace} -ne ${newBalance} ]]; do
       say ""
-      say "${ORANGE}WARN${NC}: Balance mismatch, transaction not included in latest block ($(numfmt --grouping ${TOTALBALANCE}) != $(numfmt --grouping ${newBalance}))"
+      say "${ORANGE}WARN${NC}: Balance mismatch, transaction not included in latest block ($(numfmt --grouping ${base_lovelace}) != $(numfmt --grouping ${newBalance}))"
       if ! waitNewBlockCreated; then
         break
       fi
-      getBalance "$(cat ${base_addr_file})" >/dev/null
+      getBalance ${base_addr}
     done
     
-    if [[ ${TOTALBALANCE} -ne ${newBalance} ]]; then
+    if [[ ${base_lovelace} -ne ${newBalance} ]]; then
       waitForInput && continue
     fi
 
@@ -1522,9 +1365,9 @@ case $OPERATION in
     say "Pledge : $(numfmt --grouping ${pledge_ada}) ADA" "log"
     say "Margin : ${margin}%" "log"
     say "Cost   : $(numfmt --grouping ${cost_ada}) ADA" "log"
-    if [[ ${TOTALBALANCE} -lt ${pledge_lovelace} ]]; then
+    if [[ ${base_lovelace} -lt ${pledge_lovelace} ]]; then
       echo ""
-      say "${ORANGE}WARN${NC}: Balance in pledge wallet base address is less than set pool pledge"
+      say "${ORANGE}WARN${NC}: Balance in pledge wallet is less than set pool pledge"
       say "      make sure to put enough funds in wallet to honor pledge"
     fi
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
@@ -1541,7 +1384,7 @@ case $OPERATION in
     echo ""
     
     if [[ ! -f ${TMP_FOLDER}/protparams.json ]]; then
-      say "${RED}ERROR${NC}: CNTOOLS started without node access, only offline functions available!"
+      say "${RED}ERROR${NC}: CNTools started without node access, only offline functions available!"
       waitForInput && continue
     fi
     
@@ -1597,8 +1440,11 @@ case $OPERATION in
       pay_payment_sk_file="${WALLET_FOLDER}/${dir}/${WALLET_PAY_SK_FILENAME}"
       [[ ! -f "${base_addr_file}" || ! -f "${stake_addr_file}" || ! -f "${stake_sk_file}" || ! -f "${stake_vk_file}" || ! -f "${pay_payment_sk_file}" ]] && continue
       if [[ ${wallet_count} -le ${WALLET_SELECTION_FILTER_LIMIT} ]]; then
-        getBalance "$(cat ${base_addr_file})" >/dev/null
-        delegation_pool_id=$(${CCLI} shelley query stake-address-info --testnet-magic ${NWMAGIC} --address "$(cat ${stake_addr_file})" | jq -r '.[].delegation // empty')
+        getAddress ${dir}
+        getBalance ${base_addr}
+        [[ ${base_lovelace} -eq 0 ]] && continue
+        getRewardAddress ${dir}
+        delegation_pool_id=$(${CCLI} shelley query stake-address-info --testnet-magic ${NWMAGIC} --address "${reward_addr}" | jq -r '.[].delegation // empty')
         unset poolName
         if [[ -n ${delegation_pool_id} ]]; then
           while IFS= read -r -d '' pool; do
@@ -1609,11 +1455,11 @@ case $OPERATION in
           done < <(find "${POOL_FOLDER}" -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
         fi
         if [[ -n ${poolName} ]]; then
-          wallet_dirs+=("${dir} (Base: ${CYAN}${totalBalanceADA}${NC} - ${RED}delegated${NC} to ${BLUE}${poolName}${NC})")
+          wallet_dirs+=("${dir} (${CYAN}${base_ada}${NC} ADA - ${RED}delegated${NC} to ${BLUE}${poolName}${NC})")
         elif [[ -n ${delegation_pool_id} ]]; then
-          wallet_dirs+=("${dir} (Base: ${CYAN}${totalBalanceADA}${NC} - ${RED}delegated${NC} to external address)")
+          wallet_dirs+=("${dir} (${CYAN}${base_ada}${NC} ADA - ${RED}delegated${NC} to external address)")
         else
-          wallet_dirs+=("${dir} (Base: ${CYAN}${totalBalanceADA}${NC})")
+          wallet_dirs+=("${dir} (${CYAN}${base_ada}${NC} ADA)")
         fi
       else
         wallet_dirs+=("${dir}")
@@ -1626,8 +1472,20 @@ case $OPERATION in
     say "Select Pledge Wallet:\n"
     if ! selectDir "${wallet_dirs[@]}"; then continue; fi # ${dir_name} populated by selectDir function
     pledge_wallet="$(echo ${dir_name} | cut -d' ' -f1)"
+    getAddress ${pledge_wallet}
+    getBalance ${base_addr}
     
-    say " -- Pool Parameters --\n"
+    if [[ ${base_lovelace} -gt 0 ]]; then
+      say "$(printf "%s\t${CYAN}%s${NC} ADA" "Funds in pledge wallet:"  "$(numfmt --grouping ${base_ada})")" "log"
+    else
+      say "${RED}ERROR${NC}: no funds available for wallet ${GREEN}${pledge_wallet}${NC}"
+      waitForInput && continue
+    fi
+    if ! isWalletRegistered ${pledge_wallet} && ! registerStakeWallet ${pledge_wallet}; then
+      waitForInput && continue
+    fi
+    
+    say "\n -- Pool Parameters --\n"
     say "press enter to use old value\n"
     
     pledge_ada=$(jq -r .pledgeADA "${pool_config}")
@@ -1822,8 +1680,6 @@ case $OPERATION in
     # Update pool config
     echo "{\"pledgeWallet\":\"$pledge_wallet\",\"pledgeADA\":$pledge_ada,\"margin\":$margin,\"costADA\":$cost_ada,\"json_url\":\"$meta_json_url\",\"relays\": $relay_json}" > "${pool_config}"
 
-    echo ""
-
     base_addr_file="${WALLET_FOLDER}/${pledge_wallet}/${WALLET_BASE_ADDR_FILENAME}"
     pay_payment_sk_file="${WALLET_FOLDER}/${pledge_wallet}/${WALLET_PAY_SK_FILENAME}"
     stake_sk_file="${WALLET_FOLDER}/${pledge_wallet}/${WALLET_STAKE_SK_FILENAME}"
@@ -1853,11 +1709,13 @@ case $OPERATION in
     #Generated Files
     pool_regcert_file="${POOL_FOLDER}/${pool_name}/${POOL_REGCERT_FILENAME}"
     
-    say "-- creating registration cert --" "log"
+    echo ""
+    say " -- creating registration cert --" "log"
+    echo ""
     ${CCLI} shelley stake-pool registration-certificate --cold-verification-key-file "${pool_coldkey_vk_file}" --vrf-verification-key-file "${pool_vrf_vk_file}" --pool-pledge ${pledge_lovelace} --pool-cost ${cost_lovelace} --pool-margin ${margin_fraction} --pool-reward-account-verification-key-file "${stake_vk_file}" --pool-owner-stake-verification-key-file "${stake_vk_file}" --metadata-url "${meta_json_url}" --metadata-hash "$(${CCLI} shelley stake-pool metadata-hash --pool-metadata-file ${pool_meta_file} )" ${relay_output} --testnet-magic ${NWMAGIC} --out-file "${pool_regcert_file}"
     
-    say "-- Sending transaction to chain --" "log"
-    if ! modifyPool "$(cat ${base_addr_file})" "${pool_coldkey_sk_file}" "${stake_sk_file}" "${pool_regcert_file}" "${pay_payment_sk_file}"; then
+    say " -- Sending transaction to chain --" "log"
+    if ! modifyPool "${base_addr}" "${pool_coldkey_sk_file}" "${stake_sk_file}" "${pool_regcert_file}" "${pay_payment_sk_file}"; then
       say "${RED}ERROR${NC}: failure during pool update, removing newly created registration certificate"
       rm -f "${pool_regcert_file}"
       waitForInput && continue
@@ -1867,18 +1725,18 @@ case $OPERATION in
       waitForInput && continue
     fi
 
-    getBalance "$(cat ${base_addr_file})" >/dev/null
+    getBalance ${base_addr}
 
-    while [[ ${TOTALBALANCE} -ne ${newBalance} ]]; do
+    while [[ ${base_lovelace} -ne ${newBalance} ]]; do
       say ""
-      say "${ORANGE}WARN${NC}: Balance mismatch, transaction not included in latest block ($(numfmt --grouping ${TOTALBALANCE}) != $(numfmt --grouping ${newBalance}))"
+      say "${ORANGE}WARN${NC}: Balance mismatch, transaction not included in latest block ($(numfmt --grouping ${base_lovelace}) != $(numfmt --grouping ${newBalance}))"
       if ! waitNewBlockCreated; then
         break
       fi
-      getBalance "$(cat ${base_addr_file})" >/dev/null
+      getBalance ${base_addr}
     done
     
-    if [[ ${TOTALBALANCE} -ne ${newBalance} ]]; then
+    if [[ ${base_lovelace} -ne ${newBalance} ]]; then
       waitForInput && continue
     fi
 
@@ -1887,9 +1745,9 @@ case $OPERATION in
     say "Pledge : $(numfmt --grouping ${pledge_ada}) ADA" "log"
     say "Margin : ${margin}%" "log"
     say "Cost   : $(numfmt --grouping ${cost_ada}) ADA" "log"
-    if [[ ${TOTALBALANCE} -lt ${pledge_lovelace} ]]; then
+    if [[ ${base_lovelace} -lt ${pledge_lovelace} ]]; then
       echo ""
-      say "${ORANGE}WARN${NC}: Balance in pledge wallet base address is less than set pool pledge"
+      say "${ORANGE}WARN${NC}: Balance in pledge wallet is less than set pool pledge"
       say "      make sure to put enough funds in wallet to honor pledge"
     fi
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
@@ -1906,7 +1764,7 @@ case $OPERATION in
     echo ""
     
     if [[ ! -f "${TMP_FOLDER}"/protparams.json ]]; then
-      say "${RED}ERROR${NC}: CNTOOLS started without node access, only offline functions available!"
+      say "${RED}ERROR${NC}: CNTools started without node access, only offline functions available!"
       waitForInput && continue
     fi
     
@@ -1956,12 +1814,12 @@ case $OPERATION in
     if ! getDirs "${WALLET_FOLDER}"; then continue; fi # dirs() array populated with all wallet folders
     wallet_count=${#dirs[@]}
     for dir in "${dirs[@]}"; do
-      payment_addr_file="${WALLET_FOLDER}/${dir}/${WALLET_PAY_ADDR_FILENAME}"
       base_addr_file="${WALLET_FOLDER}/${dir}/${WALLET_BASE_ADDR_FILENAME}"
       if [[ ${wallet_count} -le ${WALLET_SELECTION_FILTER_LIMIT} ]]; then
-        getBalanceAllAddr "${WALLET_FOLDER}/${dir}" "no"
-        [[ ${payment_lovelace} -eq 0 && ${base_lovelace} -eq 0 ]] && continue
-        wallet_dirs+=("${dir} (Payment: ${CYAN}$(numfmt --grouping ${payment_ada})${NC} ADA - Base: ${CYAN}$(numfmt --grouping ${base_ada})${NC} ADA)")
+        getAddress ${dir}
+        getBalance ${base_addr}
+        [[ ${base_lovelace} -eq 0 ]] && continue
+        wallet_dirs+=("${dir} (${CYAN}$(numfmt --grouping ${base_ada})${NC} ADA)")
       else
         wallet_dirs+=("${dir}")
       fi
@@ -1973,34 +1831,16 @@ case $OPERATION in
     say "Select Wallet:\n"
     if ! selectDir "${wallet_dirs[@]}"; then continue; fi # ${dir_name} populated by selectDir function
     wallet_name="$(echo ${dir_name} | cut -d' ' -f1)"
+    getAddress ${wallet_name}
+    getBalance ${base_addr}
     
-    payment_addr_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_PAY_ADDR_FILENAME}"
-    base_addr_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_BASE_ADDR_FILENAME}"
-    
-    getBalanceAllAddr "${WALLET_FOLDER}/${wallet_name}" "no"
-    
-    if [[ ${payment_lovelace} -gt 0 && ${base_lovelace} -gt 0 ]]; then
-      # Both payment and base address available with funds, let user choose what to use
-      say "Both payment and base address available with funds, choose address"
-      say "$(printf "%s\t${CYAN}%s${NC} ADA" "Payment"  "$(numfmt --grouping ${payment_ada})")" "log"
-      say "$(printf "%s\t${CYAN}%s${NC} ADA" "Base"  "$(numfmt --grouping ${base_ada})")" "log"
-      echo ""
-      case $(select_opt "[p] Payment" "[b] Base" "[c] Cancel") in
-        0) addr_file="${payment_addr_file}" ;;
-        1) addr_file="${base_addr_file}" ;;
-        2) continue ;;
-      esac
-    elif [[ ${payment_lovelace} -gt 0 ]]; then
-      addr_file="${payment_addr_file}"
-      say "$(printf "%s\t${CYAN}%s${NC} ADA" "Payment"  "$(numfmt --grouping ${payment_ada})")" "log"
-    elif [[ ${base_lovelace} -gt 0 ]]; then
-      addr_file="${base_addr_file}"
-      say "$(printf "%s\t${CYAN}%s${NC} ADA" "Base"  "$(numfmt --grouping ${base_ada})")" "log"
+    if [[ ${base_lovelace} -gt 0 ]]; then
+      say "$(printf "%s\t${CYAN}%s${NC} ADA" "Funds in wallet:"  "$(numfmt --grouping ${base_ada})")" "log"
     else
-      say "${RED}ERROR${NC}: no funds available in either payment or base address for wallet ${GREEN}${wallet_name}${NC}"
+      say "${RED}ERROR${NC}: no funds available for wallet ${GREEN}${wallet_name}${NC}"
+      say "funds needed to pay for tx fee sending deregistration certificate to chain"
       waitForInput && continue
     fi
-    addr="$(cat ${addr_file})"
     echo ""
     
     pool_coldkey_vk_file="${POOL_FOLDER}/${pool_name}/${POOL_COLDKEY_VK_FILENAME}"
@@ -2009,10 +1849,10 @@ case $OPERATION in
     
     payment_sk_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_PAY_SK_FILENAME}"
     
-    say "-- creating de-registration cert --" "log"
+    say " -- creating de-registration cert --" "log"
     ${CCLI} shelley stake-pool deregistration-certificate --cold-verification-key-file ${pool_coldkey_vk_file} --epoch ${epoch_enter} --out-file ${pool_deregcert_file}
     
-    if ! deRegisterPool "${pool_coldkey_sk_file}" "${pool_deregcert_file}" "${addr}" "${payment_sk_file}"; then
+    if ! deRegisterPool "${pool_coldkey_sk_file}" "${pool_deregcert_file}" "${base_addr}" "${payment_sk_file}"; then
       say "${RED}ERROR${NC}: failure during pool de-registration"
       waitForInput && continue
     fi
@@ -2021,18 +1861,18 @@ case $OPERATION in
       waitForInput && continue
     fi
 
-    getBalance "${addr}" >/dev/null
+    getBalance ${base_addr}
 
-    while [[ ${TOTALBALANCE} -ne ${newBalance} ]]; do
+    while [[ ${base_lovelace} -ne ${newBalance} ]]; do
       say ""
-      say "${ORANGE}WARN${NC}: Balance mismatch, transaction not included in latest block ($(numfmt --grouping ${TOTALBALANCE}) != $(numfmt --grouping ${newBalance}))"
+      say "${ORANGE}WARN${NC}: Balance mismatch, transaction not included in latest block ($(numfmt --grouping ${base_lovelace}) != $(numfmt --grouping ${newBalance}))"
       if ! waitNewBlockCreated; then
         break
       fi
-      getBalance "${addr}" >/dev/null
+      getBalance ${base_addr}
     done
     
-    if [[ ${TOTALBALANCE} -ne ${newBalance} ]]; then
+    if [[ ${base_lovelace} -ne ${newBalance} ]]; then
       waitForInput && continue
     fi
     
@@ -2050,11 +1890,12 @@ case $OPERATION in
     echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     
     if [[ ! -f ${TMP_FOLDER}/protparams.json ]]; then
-      say "${RED}ERROR${NC}: CNTOOLS started without node access, only offline functions available!"
+      say "${RED}ERROR${NC}: CNTools started without node access, only offline functions available!"
       waitForInput && continue
     fi
     
     say "Dumping ledger-state from node, can take a while on larger networks...\n"
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     
     timeout -k 5 30 ${CCLI} shelley query ledger-state --testnet-magic ${NWMAGIC} --out-file "${TMP_FOLDER}"/ledger-state.json
     
@@ -2073,8 +1914,7 @@ case $OPERATION in
       fi
     done < <(find "${POOL_FOLDER}" -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
     echo ""
-    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    echo ""
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     
     waitForInput
     
@@ -2088,7 +1928,7 @@ case $OPERATION in
     echo ""
     
     if [[ ! -f ${TMP_FOLDER}/protparams.json ]]; then
-      say "${RED}ERROR${NC}: CNTOOLS started without node access, only offline functions available!"
+      say "${RED}ERROR${NC}: CNTools started without node access, only offline functions available!"
       waitForInput && continue
     fi
     
@@ -2111,7 +1951,7 @@ case $OPERATION in
     say "Dumping ledger-state from node, can take a while on larger networks...\n"
     timeout -k 5 30 ${CCLI} shelley query ledger-state --testnet-magic ${NWMAGIC} --out-file "${TMP_FOLDER}"/ledger-state.json
     
-    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     echo ""
     pool_id=$(cat "${POOL_FOLDER}/${pool_name}/${POOL_ID_FILENAME}")
     ledger_pool_state=$(jq -r '.esLState._delegationState._pstate._pParams."'"${pool_id}"'" // empty' "${TMP_FOLDER}"/ledger-state.json)
@@ -2181,7 +2021,7 @@ case $OPERATION in
     say "$(printf "%-21s   %s" "" "--shelley-vrf-key ${pool_vrf_sk_file}")" "log"
     say "$(printf "%-21s   %s" "" "--shelley-operational-certificate ${pool_opcert_file}")" "log"
     echo ""
-    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     waitForInput
     
     ;; ###################################################################
@@ -2194,7 +2034,7 @@ case $OPERATION in
     echo ""
     
     if [[ ! -f ${TMP_FOLDER}/protparams.json ]]; then
-      say "${RED}ERROR${NC}: CNTOOLS started without node access, only offline functions available!"
+      say "${RED}ERROR${NC}: CNTools started without node access, only offline functions available!"
       waitForInput && continue
     fi
     

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -41,6 +41,20 @@ if ! need_cmd "curl" || \
    ! need_cmd "numfmt"; then exit 1
 fi
 
+# check to see if there are any updates available
+URL="https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts"
+wget -q -O "${TMP_FOLDER}"/cntools.library "${URL}/cntools.library"
+GIT_MAJOR_VERSION=$(grep -r ^CNTOOLS_MAJOR_VERSION= "${TMP_FOLDER}"/cntools.library |sed -e "s#.*=##")
+GIT_MINOR_VERSION=$(grep -r ^CNTOOLS_MINOR_VERSION= "${TMP_FOLDER}"/cntools.library |sed -e "s#.*=##")
+if [[ "${CNTOOLS_MAJOR_VERSION}" != "${GIT_MAJOR_VERSION}" || "${CNTOOLS_MINOR_VERSION}" != "${GIT_MINOR_VERSION}" ]]; then
+  clear
+  say "\nA new version of CNTools is available"
+  say "\nInstalled Version : ${CNTOOLS_MAJOR_VERSION}.${CNTOOLS_MINOR_VERSION}"
+  say "Available Version : ${GREEN}${GIT_MAJOR_VERSION}.${GIT_MINOR_VERSION}${NC}"
+  say "\nGo to Update section for upgrade"
+  waitForInput "press any key to proceed to home menu"
+fi
+
 ###################################################################
 
 function main {
@@ -2446,10 +2460,9 @@ case $OPERATION in
   echo ""
 
   URL="https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts"
-  wget -q -O /tmp/cntools.library "${URL}/cntools.library"
-  GIT_MAJOR_VERSION=$(grep -r ^CNTOOLS_MAJOR_VERSION= /tmp/cntools.library |sed -e "s#.*=##")
-  GIT_MINOR_VERSION=$(grep -r ^CNTOOLS_MINOR_VERSION= /tmp/cntools.library |sed -e "s#.*=##")
-  rm -f /tmp/cntools.library
+  wget -q -O "${TMP_FOLDER}"/cntools.library "${URL}/cntools.library"
+  GIT_MAJOR_VERSION=$(grep -r ^CNTOOLS_MAJOR_VERSION= "${TMP_FOLDER}"/cntools.library |sed -e "s#.*=##")
+  GIT_MINOR_VERSION=$(grep -r ^CNTOOLS_MINOR_VERSION= "${TMP_FOLDER}"/cntools.library |sed -e "s#.*=##")
   if [ "$CNTOOLS_MAJOR_VERSION" != "$GIT_MAJOR_VERSION" ];then
     say "New major version available: ${GREEN}${GIT_MAJOR_VERSION}.${GIT_MINOR_VERSION}${NC} (Current: ${CNTOOLS_MAJOR_VERSION}.${CNTOOLS_MINOR_VERSION})\n"
     say "${RED}WARNING${NC}: Breaking changes were made to CNTools!\n"

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -912,7 +912,7 @@ case $OPERATION in
     #Generated Files
     delegation_cert_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_DELEGCERT_FILENAME}"
 
-    say "-- creating delegation cert --" "log"
+    say " -- creating delegation cert --" "log"
     ${CCLI} shelley stake-address delegation-certificate --stake-verification-key-file "${stake_vk_file}" --cold-verification-key-file "${pool_coldkey_vk_file}" --out-file "${delegation_cert_file}"
 
     if ! delegate "${stake_vk_file}" "${stake_sk_file}" "${pay_payment_sk_file}" "${base_addr}" "${pool_coldkey_vk_file}" "${delegation_cert_file}" ; then
@@ -1377,10 +1377,12 @@ case $OPERATION in
     pool_pledgecert_file="${POOL_FOLDER}/${pool_name}/${POOL_PLEDGECERT_FILENAME}"
     
     echo ""
+    say " ## Register Stake Pool ##" "log"
+    echo ""
     say " -- creating registration cert --" "log"
     echo ""
     ${CCLI} shelley stake-pool registration-certificate --cold-verification-key-file "${pool_coldkey_vk_file}" --vrf-verification-key-file "${pool_vrf_vk_file}" --pool-pledge ${pledge_lovelace} --pool-cost ${cost_lovelace} --pool-margin ${margin_fraction} --pool-reward-account-verification-key-file "${stake_vk_file}" --pool-owner-stake-verification-key-file "${stake_vk_file}" --out-file "${pool_regcert_file}" --testnet-magic ${NWMAGIC} --metadata-url "${meta_json_url}" --metadata-hash "$(${CCLI} shelley stake-pool metadata-hash --pool-metadata-file ${pool_meta_file} )" ${relay_output}
-    say "-- creating delegation cert --" "log"
+    say " -- creating delegation cert --" "log"
     ${CCLI} shelley stake-address delegation-certificate --stake-verification-key-file "${stake_vk_file}" --cold-verification-key-file "${pool_coldkey_vk_file}" --out-file "${pool_pledgecert_file}"
     
     say " -- Sending transaction to chain --" "log"

--- a/scripts/cnode-helper-scripts/sendADA.sh
+++ b/scripts/cnode-helper-scripts/sendADA.sh
@@ -68,8 +68,8 @@ else
 fi
 
 getBalance ${S_ADDR}
-if [[ ${base_lovelace} -gt 0 ]]; then
-  say "$(printf "\n%s\t${CYAN}%s${NC} ADA" "Funds in source wallet:"  "$(numfmt --grouping ${base_ada})")" "log"
+if [[ ${lovelace} -gt 0 ]]; then
+  say "$(printf "\n%s\t${CYAN}%s${NC} ADA" "Funds in source wallet:"  "$(numfmt --grouping ${ada})")" "log"
 else
   say "${RED}ERROR${NC}: no funds available in source address"
   echo "" && exit 1
@@ -81,13 +81,13 @@ if [[ ${LOVELACE} != "all" ]]; then
     echo "" && exit 1
   fi
   LOVELACE=$(ADAtoLovelace "${LOVELACE}")
-  if [[ ${LOVELACE} -gt ${base_lovelace} ]]; then
+  if [[ ${LOVELACE} -gt ${lovelace} ]]; then
     say "${RED}ERROR${NC}: not enough funds available in source address"
     echo "" && exit 1
   fi
 else
-  LOVELACE=${base_lovelace}
-  say "$(printf "\n%s\t${CYAN}%s${NC} ADA" "ADA to send set to total supply:"  "$(numfmt --grouping ${base_ada})")" "log"
+  LOVELACE=${lovelace}
+  say "$(printf "\n%s\t${CYAN}%s${NC} ADA" "ADA to send set to total supply:"  "$(numfmt --grouping ${ada})")" "log"
   INCL_FEE="yes"
 fi
 
@@ -101,18 +101,18 @@ fi
 
 getBalance ${S_ADDR}
 
-while [[ ${base_lovelace} -ne ${newBalance} ]]; do
+while [[ ${lovelace} -ne ${newBalance} ]]; do
   say ""
-  say "${ORANGE}WARN${NC}: Balance mismatch, transaction not included in latest block ($(numfmt --grouping ${base_lovelace}) != $(numfmt --grouping ${newBalance}))"
+  say "${ORANGE}WARN${NC}: Balance mismatch, transaction not included in latest block ($(numfmt --grouping ${lovelace}) != $(numfmt --grouping ${newBalance}))"
   if ! waitNewBlockCreated; then
     echo "" && exit 1
   fi
   getBalance ${S_ADDR}
 done
 
-say "$(printf "\n%s\t\t${CYAN}%s${NC} ADA" "Funds in source wallet:"  "$(numfmt --grouping ${base_ada})")" "log"
+say "$(printf "\n%s\t\t${CYAN}%s${NC} ADA" "Funds in source wallet:"  "$(numfmt --grouping ${ada})")" "log"
 
 getBalance ${D_ADDR}
-say "$(printf "%s\t${CYAN}%s${NC} ADA" "Funds in destination wallet:"  "$(numfmt --grouping ${base_ada})")" "log"
+say "$(printf "%s\t${CYAN}%s${NC} ADA" "Funds in destination wallet:"  "$(numfmt --grouping ${ada})")" "log"
 
 say "\n## Finished! ##\n"


### PR DESCRIPTION
Support for payment address(aka enterprise) removed and only base address support left. Everything that can be done with a payment address can also be done with the base address, ie doesn't need to be registered on-chain unless its delegated or used as a pledge wallet. This is done to present fewer options to end-user and remove confusion regarding the different address types. Because of this, the commit is set as a breaking change and major version bump to 1.0.

Previous payment wallets(ie not upgraded to stake wallet) won't be listed in CNTools as they are missing the stake keys. Either send all funds to a stake wallet before upgrading or use an external script to move funds afterward, ie for example with sendADA script.

Wallet registration is removed as a manual action and is now done automatically when delegating the wallet or using it as a pledge wallet when creating/modifying a pool. This also goes for genesis address, use an external script to send funds to a CNTools created wallet.

The payment and base address types were rooted deep in the code and as such, removing payment address support resulted in major code changes with possible breaking functionality. Please test thoroughly before merging into master.
CNTools docs also require an update because of this and should be committed to PR branch before merging with master.
Label do-not-merge set because of this and can be removed after docs update and tests have been performed. 

To address issue #277 