### PR TITLE
cntools: add live stake and delegators

### DIFF
--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -2060,9 +2060,23 @@ case $OPERATION in
           say "$(printf "%-21s : %s" "Reward account" "${reward_account}")" "log"
         fi
       fi
-      # delegator count
-      delegator_count=$(jq -r '[.esLState._delegationState._dstate._delegations[] | select(.[] == "'"${pool_id}"'")] | length' "${TMP_FOLDER}"/ledger-state.json)
-      say "$(printf "%-21s : %s" "Delegators" "${delegator_count}")" "log"
+      # Delegators
+      say "$(printf "%-21s :" "Delegators")" "log"
+      non_myopic_delegators=$(jq -r ".esNonMyopic.snapNM._delegations | .[] | select(.[1] == \"${pool_id}\") | .[0][\"key hash\"]" "${TMP_FOLDER}"/ledger-state.json)
+      snapshot_delegators=$(jq -r ".esSnapshots._pstakeSet._delegations | .[] | select(.[1] == \"${pool_id}\") | .[0][\"key hash\"]" "${TMP_FOLDER}"/ledger-state.json)
+      lstate_delegators=$(jq -r ".esLState._delegationState._dstate._delegations | .[] | select(.[1] == \"${pool_id}\") | .[0][\"key hash\"]" "${TMP_FOLDER}"/ledger-state.json)
+      delegators=$(echo "${non_myopic_delegators}" "${snapshot_delegators}" "${lstate_delegators}" | tr ' ' '\n' | sort -u)
+      total_stake=0
+      output="$(printf " \tStake\tReward\tStake Address")"
+      for key in $delegators; do
+        stake_address="581de0$key"
+        reward=$(${CCLI} shelley query stake-address-info --address $stake_address --testnet-magic 42 | jq ".[\"$stake_address\"][\"rewardAccountBalance\"]")
+        stake=$(jq ".esLState._utxoState._utxo | .[] | select(.address | contains(\"${key}\")) | .amount" "${TMP_FOLDER}"/ledger-state.json | awk '{total = total + $1} END {print total}')
+        total_stake=$((${total_stake} + ${stake}))
+        output="$(printf "${output}\n \t${stake}\t${reward}\t${stake_address}")"
+      done
+      say "$(printf "${output}\n" | rev | column -t -s $'\t' | rev)" "log"
+      say "$(printf "%-21s : %s ADA" "Stake" "$(numfmt --grouping $(lovelacetoADA ${total_stake}))")" "log"
       stake_pct=$(fractionToPCT "$(printf "%.10f" "$(${CCLI} shelley query stake-distribution --testnet-magic ${NWMAGIC} | grep "${pool_id}" | tr -s ' ' | cut -d ' ' -f 2)")")
       if validateDecimalNbr ${stake_pct}; then
         say "$(printf "%-21s : %s %%" "Stake distribution" "${stake_pct}")" "log"


### PR DESCRIPTION
This adds the current delegators and stake in "Pool -> Show". The data is retrieved from all ledger states, including current epoch modifications (so a delegation TX is displayed immediately).

### Notes

#### 1.
Here is an example of the current output:
```
MYPOOL 
ID                    : 7607d58f4ff02f4de24cb45984efab063e64cb1d6d6ce00807d69962
Pledge                : 50,000 ADA
Margin                : 7.5 %
...
Reward wallet         : MyPoolWallet
Delegators            :
          Stake  Reward                                                   Stake Address
     7499241366       0  581de0194854d765fae7f20146065bf5874630e4592a4cd9365f2da4f6d131
   999999256414       0  581de0c5b9bc7c5fb9f25be091aa73f3e3d78a3877f578f880da517e216a7c
Stake                 : 1,007,498.49778 ADA
Stake distribution    : 0.0002954 %
```
Just tell me if you want a different output.

#### 2.
I use the 3 different delegations tables from the ledger, because I noticed that using `esLState` is not enough in some cases. That said, I don't have yet a perfect understanding of their difference, so if you have a documentation or pointer, this could help.

#### 3.
I put in on top of `cntools-wallet` branch for now. I will rebase and change to master once this branch has been merged.


#### 4.
It's slow...