### PR TITLE
cntools: work-around awk versions that only support 32-bit integers

### DIFF
--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -2203,7 +2203,7 @@ case $OPERATION in
       for key in ${delegators}; do
         printf "\r"
         stake_address="581de0${key}"
-        stake=$(jq ".esLState._utxoState._utxo | .[] | select(.address | contains(\"${key}\")) | .amount" "${TMP_FOLDER}"/ledger-state.json | awk 'BEGIN{total = 0} {total = total + $1} END{print total}')
+        stake=$(jq ".esLState._utxoState._utxo | .[] | select(.address | contains(\"${key}\")) | .amount" "${TMP_FOLDER}"/ledger-state.json | awk 'BEGIN{total = 0} {total = total + $1} END{printf "%.0f", total}')
         reward=$(jq -r ".esLState._delegationState._dstate._rewards | .[] | select(.[0][\"credential\"][\"key hash\"] == \"${key}\") | .[1]" "${TMP_FOLDER}"/ledger-state.json)
         total_stake=$((total_stake + stake + reward))
         say "$(printf "%-21s : %s" "Delegator ${delegator} hex key" "${key}")" "log"


### PR DESCRIPTION
Fixes #297