### PR TITLE
Add variable based identifiers for Network and protocol

### DIFF
--- a/docs/Common.md
+++ b/docs/Common.md
@@ -30,8 +30,8 @@ The prereqs script above will connect you to guild network. If you would like to
 #wget -O $CNODE_HOME/files/topology.json https://hydra.iohk.io/build/3416851/download/1/mainnet_candidate-topology.json
 #wget -O $CNODE_HOME/files/genesis.json https://hydra.iohk.io/build/3416851/download/1/mainnet_candidate-shelley-genesis.json
 # For Shelley Testnet:
-https://hydra.iohk.io/job/Cardano/iohk-nix/cardano-deployment/latest-finished/download/1/shelley_testnet-shelley-genesis.json
-https://hydra.iohk.io/job/Cardano/iohk-nix/cardano-deployment/latest-finished/download/1/shelley_testnet-topology.json
+wget -O $CNODE_HOME/files/genesis.json https://hydra.iohk.io/job/Cardano/iohk-nix/cardano-deployment/latest-finished/download/1/shelley_testnet-shelley-genesis.json
+wget -O $CNODE_HOME/files/topology.json https://hydra.iohk.io/job/Cardano/iohk-nix/cardano-deployment/latest-finished/download/1/shelley_testnet-topology.json
 ```
 
 If you were already running a node on guild network and would like to *replace* by moving to HTN, but continue using scripts - follow instructions below:

--- a/docs/Common.md
+++ b/docs/Common.md
@@ -25,9 +25,13 @@ chmod 755 prereqs.sh
 The prereqs script above will connect you to guild network. If you would like to connect to public HTN instead, kindly execute the below before you proceed after you've executed the above:
 
 ``` bash
-wget -O $CNODE_HOME/files/byron_genesis.json https://hydra.iohk.io/build/3416851/download/1/mainnet_candidate-byron-genesis.json
-wget -O $CNODE_HOME/files/topology.json https://hydra.iohk.io/build/3416851/download/1/mainnet_candidate-topology.json
-wget -O $CNODE_HOME/files/genesis.json https://hydra.iohk.io/build/3416851/download/1/mainnet_candidate-shelley-genesis.json
+# For mainnet-candidate:
+#wget -O $CNODE_HOME/files/byron_genesis.json https://hydra.iohk.io/build/3416851/download/1/mainnet_candidate-byron-genesis.json
+#wget -O $CNODE_HOME/files/topology.json https://hydra.iohk.io/build/3416851/download/1/mainnet_candidate-topology.json
+#wget -O $CNODE_HOME/files/genesis.json https://hydra.iohk.io/build/3416851/download/1/mainnet_candidate-shelley-genesis.json
+# For Shelley Testnet:
+https://hydra.iohk.io/job/Cardano/iohk-nix/cardano-deployment/latest-finished/download/1/shelley_testnet-shelley-genesis.json
+https://hydra.iohk.io/job/Cardano/iohk-nix/cardano-deployment/latest-finished/download/1/shelley_testnet-topology.json
 ```
 
 If you were already running a node on guild network and would like to *replace* by moving to HTN, but continue using scripts - follow instructions below:

--- a/docs/Scripts/cntools-changelog.md
+++ b/docs/Scripts/cntools-changelog.md
@@ -5,6 +5,11 @@ All notable changes to this tool will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0] - 2020-07-13
+- Add PROTOCOL_IDENTIFIER and NETWORK_IDENTIFIER instead of harcoded entries for combinator v/s TPraos & testnet v/s magic differentiators respectively.
+- Keep both ptn0.yaml and ptn0-combinator.yaml to keep validity with mainnet-combinator
+- Revert back default for Public network to Shelley_Testnet as per https://t.me/CardanoStakePoolWorkgroup/282606
+
 ## [3.0.0] - 2020-07-12
 ### Changed
 - Release `2.1.1` included a change to env file and thus require a major version bump.

--- a/files/ptn0/files/genesis.json
+++ b/files/ptn0/files/genesis.json
@@ -3,11 +3,11 @@
     "protocolParams": {
         "poolDeposit": 50000,
         "protocolVersion": {
-            "minor": 0,
+            "minor": 2,
             "major": 0
         },
         "minUTxOValue": 0,
-        "decentralisationParam": 0.7,
+        "decentralisationParam": 0.5,
         "maxTxSize": 16384,
         "minPoolCost": 0,
         "minFeeA": 10,
@@ -24,32 +24,28 @@
         "tau": 0.1,
         "a0": 0.3
     },
-    "protocolMagicId": 4003,
+    "protocolMagicId": 4005,
     "genDelegs": {
-        "54511819e206bd4d72d0fcdf8dc3b6f3e352384ca199cdbddfd63ee7": {
-            "delegate": "0490a125fa335138f5e07d76f1d3c602a9942cde3141ffb741069fd0",
-            "vrf": "3b00c9286ea779f3c3e173bbeb88470c0c804ad1ee574385603b29e58fe38149"
-        },
-        "4b65778ca1a4a35c804ce602f6ed5b8a00e7fa891737e994ca348872": {
-            "delegate": "00f7f582180984de94489b62476babe24c57c40b8b3d6c38535793b3",
-            "vrf": "b48a073676f89b62ed895727608081f9259fccafa07471cd92e8a5e50624138d"
+        "e4a7e1aa98078f14e9e1b6cca1c147f0ba4070caef08fbcbf7439125": {
+            "delegate": "4fa19855175457898361fe350ba0f7023ac2e08254aede3e6ef9d0f9",
+            "vrf": "8ad2051b1735917d4da5e31000bc7e1f590aa9adc8338dc8ae042ca8923ba3a9"
         }
     },
-    "updateQuorum": 2,
+    "updateQuorum": 1,
     "networkId": "Testnet",
     "initialFunds": {
         "60ba9b690f6698e1e40b4a4a56b13b4cebbce6f6b0410244086656a6a2": 10000000000000,
         "604bde84fe6661cd5e8d6dd63fba7149048e460edee41f6ef87e506b73": 37000000000000000
     },
     "maxLovelaceSupply": 45000000000000000,
-    "networkMagic": 4003,
+    "networkMagic": 4005,
     "epochLength": 1800,
     "staking": {
         "pools": {},
         "stake": {}
     },
-    "systemStart": "2020-07-09T02:21Z",
-    "slotsPerKESPeriod": 1500,
+    "systemStart": "2020-07-13T08:01Z",
+    "slotsPerKESPeriod": 1600,
     "slotLength": 1,
     "maxKESEvolutions": 120,
     "securityParam": 108

--- a/files/ptn0/files/ptn0.yaml
+++ b/files/ptn0/files/ptn0.yaml
@@ -92,7 +92,7 @@ Protocol: TPraos
 NetworkName: phtn
 GenesisFile: /opt/cardano/cnode/files/genesis.json
 NumCoreNodes: 1
-RequiresNetworkMagic: RequiresMagic
+RequiresNetworkMagic: RequiresNoMagic
 TurnOnLogging: True
 ViewMode: LiveView
 TurnOnLogMetrics: False

--- a/files/ptn0/scripts/prereqs.sh
+++ b/files/ptn0/scripts/prereqs.sh
@@ -196,8 +196,8 @@ chmod -R 755 "$CNODE_HOME"
 
 cd "$CNODE_HOME/files" || return
 
-#curl -s -o ptn0.yaml https://raw.githubusercontent.com/cardano-community/guild-operators/master/files/ptn0/files/ptn0.yaml
-curl -s -o ptn0.yaml https://raw.githubusercontent.com/cardano-community/guild-operators/master/files/ptn0/files/ptn0-combinator.yaml
+curl -s -o ptn0.yaml https://raw.githubusercontent.com/cardano-community/guild-operators/master/files/ptn0/files/ptn0.yaml
+curl -s -o ptn0-combinator.yaml https://raw.githubusercontent.com/cardano-community/guild-operators/master/files/ptn0/files/ptn0-combinator.yaml
 curl -s https://raw.githubusercontent.com/cardano-community/guild-operators/master/files/ptn0/files/genesis.json | jq '.' > genesis.json
 curl -s https://raw.githubusercontent.com/cardano-community/guild-operators/master/files/ptn0/files/topology.json | jq '.' > topology.json
 

--- a/scripts/cnode-helper-scripts/balance.sh
+++ b/scripts/cnode-helper-scripts/balance.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC2086
 # Only source env if not done already, this script is sourced from other scripts
 [ "$0" = "${BASH_SOURCE[*]}" ] && . "$(dirname "$0")"/env
 

--- a/scripts/cnode-helper-scripts/balance.sh
+++ b/scripts/cnode-helper-scripts/balance.sh
@@ -23,8 +23,7 @@ function cleanup() {
 # start with a clean slate
 cleanup
 
-# The "testnet magic" is specific on the testnet and will not be needed for the mainnet.
-${CCLI} shelley query utxo --cardano-mode --testnet-magic "${NWMAGIC}" --address "${WALLET_ADDR}" > /tmp/fullUtxo.out
+${CCLI} shelley query utxo ${PROTOCOL_IDENTIFIER} ${NETWORK_IDENTIFIER} --address "${WALLET_ADDR}" > /tmp/fullUtxo.out
 tail -n +3 /tmp/fullUtxo.out | sort -k3 -nr > /tmp/balance.txt
 
 TOTALBALANCE=0

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -7,7 +7,7 @@
 # The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 # and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 # Any breaking changes (eg: that requires change of cntools.config, env or a change in priv folder would be considered breaking and will be exempt from auto-update)
-CNTOOLS_MAJOR_VERSION=3
+CNTOOLS_MAJOR_VERSION=4
 # Changes that can be applied without breaking existing functionality that can be applied from within CNTools
 CNTOOLS_MINOR_VERSION=0
 # Backwards compatible bug fixes. No additional functionality or major changes and can be applied from within CNTools
@@ -351,13 +351,13 @@ decryptFile() {
 # Description: Get latest block number
 # Return     : string with tip on STDOUT
 getBlockTip() {
-  $CCLI shelley query tip --cardano-mode --testnet-magic ${NWMAGIC} | jq -r '.blockNo'
+  $CCLI shelley query tip ${PROTOCOL_IDENTIFIER} ${NETWORK_IDENTIFIER} | jq -r '.blockNo'
 }
 # Command    : getSlotTip
 # Description: Get latest slot number
 # Return     : string with tip on STDOUT
 getSlotTip() {
-  $CCLI shelley query tip --cardano-mode --testnet-magic ${NWMAGIC} | jq -r '.slotNo'
+  $CCLI shelley query tip ${PROTOCOL_IDENTIFIER} ${NETWORK_IDENTIFIER} | jq -r '.slotNo'
 }
 # Command    : getSlotTipRef
 # Description: Get calculated slot number tip
@@ -581,7 +581,7 @@ getPayAddress() {
   payment_vk_file="${WALLET_FOLDER}/${1}/${WALLET_PAY_VK_FILENAME}"
   payment_addr_file="${WALLET_FOLDER}/${1}/${WALLET_PAY_ADDR_FILENAME}"
   if [[ -f "${payment_vk_file}" ]]; then
-    if ${CCLI} shelley address build --payment-verification-key-file "${payment_vk_file}" --out-file "${payment_addr_file}" --mainnet 2>/dev/null; then
+    if ${CCLI} shelley address build --payment-verification-key-file "${payment_vk_file}" --out-file "${payment_addr_file}" ${NETWORK_IDENTIFIER} 2>/dev/null; then
       pay_addr=$(cat "${payment_addr_file}")
     else
       pay_addr=""
@@ -601,7 +601,7 @@ getBaseAddress() {
   stake_vk_file="${WALLET_FOLDER}/${1}/${WALLET_STAKE_VK_FILENAME}"
   base_addr_file="${WALLET_FOLDER}/${1}/${WALLET_BASE_ADDR_FILENAME}"
   if [[ -f "${payment_vk_file}" && -f "${stake_vk_file}" ]]; then
-    ${CCLI} shelley address build --payment-verification-key-file "${payment_vk_file}" --stake-verification-key-file "${stake_vk_file}" --out-file "${base_addr_file}" --mainnet
+    ${CCLI} shelley address build --payment-verification-key-file "${payment_vk_file}" --stake-verification-key-file "${stake_vk_file}" --out-file "${base_addr_file}" ${NETWORK_IDENTIFIER}
     base_addr=$(cat "${base_addr_file}")
   else
     base_addr=""
@@ -616,7 +616,7 @@ getRewardAddress() {
   stake_vk_file="${WALLET_FOLDER}/${1}/${WALLET_STAKE_VK_FILENAME}"
   stake_addr_file="${WALLET_FOLDER}/${1}/${WALLET_STAKE_ADDR_FILENAME}"
   if [[ -f "${stake_vk_file}" ]]; then
-    ${CCLI} shelley stake-address build --stake-verification-key-file "${stake_vk_file}" --out-file "${stake_addr_file}" --mainnet
+    ${CCLI} shelley stake-address build --stake-verification-key-file "${stake_vk_file}" --out-file "${stake_addr_file}" ${NETWORK_IDENTIFIER}
     reward_addr=$(cat "${stake_addr_file}")
   else
     reward_addr=""
@@ -640,7 +640,7 @@ getBalance() {
 
   [[ -z $1 ]] && return 1
 
-  ${CCLI} shelley query utxo --cardano-mode --testnet-magic "${NWMAGIC}" --address "${1}" > "${TMP_FOLDER}"/fullUtxo.out
+  ${CCLI} shelley query utxo ${PROTOCOL_IDENTIFIER} ${NETWORK_IDENTIFIER} --address "${1}" > "${TMP_FOLDER}"/fullUtxo.out
   tail -n +3 "${TMP_FOLDER}"/fullUtxo.out | sort -k3 -nr > "${TMP_FOLDER}"/balance.out
 
   while read -r utxo; do
@@ -718,7 +718,7 @@ sendADA() {
     --tx-body-file "${TMP_FOLDER}"/tx0.tmp
     --tx-in-count ${utxoCount}
     --tx-out-count ${outCount}
-    --mainnet
+    ${NETWORK_IDENTIFIER}
     --witness-count 1
     --byron-witness-count 0
     --protocol-params-file "${TMP_FOLDER}"/protparams.json
@@ -773,15 +773,15 @@ sendADA() {
     shelley transaction sign
     --tx-body-file "${TMP_FOLDER}"/tx.raw
     --signing-key-file ${sKey}
-    --testnet-magic ${NWMAGIC}
+    ${NETWORK_IDENTIFIER}
     --out-file "${TMP_FOLDER}"/tx.signed
   )
 
   submitArgs=(
     shelley transaction submit
     --tx-file "${TMP_FOLDER}"/tx.signed
-    --cardano-mode
-    --testnet-magic ${NWMAGIC}
+    ${PROTOCOL_IDENTIFIER}
+    ${NETWORK_IDENTIFIER}
   )
 
   say "" 1
@@ -821,7 +821,7 @@ sendADA() {
 # Return     : 0 if registered, else 1
 isWalletRegistered() {
   if getRewardAddress $1; then
-    stakeAddressInfo=$(${CCLI} shelley query stake-address-info --cardano-mode --testnet-magic ${NWMAGIC} --address ${reward_addr} | jq -r '.[] // empty')
+    stakeAddressInfo=$(${CCLI} shelley query stake-address-info ${PROTOCOL_IDENTIFIER} ${NETWORK_IDENTIFIER} --address ${reward_addr} | jq -r '.[] // empty')
     [[ -n "${stakeAddressInfo}" ]] && return 0
   fi
   return 1
@@ -876,7 +876,7 @@ registerStakeWallet() {
     --tx-body-file "${TMP_FOLDER}"/tx0.tmp
     --tx-in-count ${utx0_count}
     --tx-out-count 1
-    --testnet-magic ${NWMAGIC}
+    ${NETWORK_IDENTIFIER}
     --witness-count 2
     --byron-witness-count 0
     --protocol-params-file "${TMP_FOLDER}"/protparams.json
@@ -910,15 +910,15 @@ registerStakeWallet() {
     --tx-body-file "${TMP_FOLDER}"/tx.raw
     --signing-key-file ${payment_sk_file}
     --signing-key-file ${stake_sk_file}
-    --testnet-magic ${NWMAGIC}
+    ${NETWORK_IDENTIFIER}
     --out-file "${TMP_FOLDER}"/tx.signed
   )
 
   submitArgs=(
     shelley transaction submit
     --tx-file "${TMP_FOLDER}"/tx.signed
-    --cardano-mode
-    --testnet-magic ${NWMAGIC}
+    ${PROTOCOL_IDENTIFIER}
+    ${NETWORK_IDENTIFIER}
   )
 
   say "" 1
@@ -1033,7 +1033,7 @@ registerPool() {
     --tx-body-file "${TMP_FOLDER}"/tx0.tmp
     --tx-in-count ${utx0_count}
     --tx-out-count 1
-    --testnet-magic ${NWMAGIC}
+    ${NETWORK_IDENTIFIER}
     --witness-count 3
     --byron-witness-count 0
     --protocol-params-file "${TMP_FOLDER}"/protparams.json
@@ -1068,15 +1068,15 @@ registerPool() {
     --signing-key-file ${pay_payment_sk_file}
     --signing-key-file ${pool_coldkey_sk_file}
     --signing-key-file ${stake_sk_file}
-    --testnet-magic ${NWMAGIC}
+    ${NETWORK_IDENTIFIER}
     --out-file "${TMP_FOLDER}"/tx.signed
   )
 
   submitArgs=(
     shelley transaction submit
     --tx-file "${TMP_FOLDER}"/tx.signed
-    --cardano-mode
-    --testnet-magic ${NWMAGIC}
+    ${PROTOCOL_IDENTIFIER}
+    ${NETWORK_IDENTIFIER}
   )
 
   say "" 1
@@ -1160,7 +1160,7 @@ modifyPool() {
     --tx-body-file "${TMP_FOLDER}"/tx0.tmp
     --tx-in-count ${utx0_count}
     --tx-out-count 1
-    --testnet-magic ${NWMAGIC}
+    ${NETWORK_IDENTIFIER}
     --witness-count 3
     --byron-witness-count 0
     --protocol-params-file "${TMP_FOLDER}"/protparams.json
@@ -1194,15 +1194,15 @@ modifyPool() {
     --signing-key-file ${pay_payment_sk_file}
     --signing-key-file ${pool_coldkey_sk_file}
     --signing-key-file ${stake_sk_file}
-    --testnet-magic ${NWMAGIC}
+    ${NETWORK_IDENTIFIER}
     --out-file "${TMP_FOLDER}"/tx.signed
   )
 
   submitArgs=(
     shelley transaction submit
     --tx-file "${TMP_FOLDER}"/tx.signed
-    --cardano-mode
-    --testnet-magic ${NWMAGIC}
+    ${PROTOCOL_IDENTIFIER}
+    ${NETWORK_IDENTIFIER}
   )
 
   say "" 1
@@ -1277,7 +1277,7 @@ withdrawRewards() {
     --tx-body-file "${TMP_FOLDER}"/tx0.tmp
     --tx-in-count ${utx0_count}
     --tx-out-count 1
-    --testnet-magic ${NWMAGIC}
+    ${NETWORK_IDENTIFIER}
     --witness-count 2
     --byron-witness-count 0
     --protocol-params-file "${TMP_FOLDER}"/protparams.json
@@ -1310,15 +1310,15 @@ withdrawRewards() {
     --tx-body-file "${TMP_FOLDER}"/tx.raw
     --signing-key-file ${pay_payment_sk_file}
     --signing-key-file ${stake_sk_file}
-    --testnet-magic ${NWMAGIC}
+    ${NETWORK_IDENTIFIER}
     --out-file "${TMP_FOLDER}"/tx.signed
   )
 
   submitArgs=(
     shelley transaction submit
     --tx-file "${TMP_FOLDER}"/tx.signed
-    --cardano-mode
-    --testnet-magic ${NWMAGIC}
+    ${PROTOCOL_IDENTIFIER}
+    ${NETWORK_IDENTIFIER}
   )
 
   say "" 1
@@ -1404,7 +1404,7 @@ delegate() {
     --tx-body-file "${TMP_FOLDER}"/tx0.tmp
     --tx-in-count ${utx0_count}
     --tx-out-count 1
-    --testnet-magic ${NWMAGIC}
+    ${NETWORK_IDENTIFIER}
     --witness-count 2
     --byron-witness-count 0
     --protocol-params-file "${TMP_FOLDER}"/protparams.json
@@ -1437,15 +1437,15 @@ delegate() {
     --tx-body-file "${TMP_FOLDER}"/tx.raw
     --signing-key-file ${pay_payment_sk_file}
     --signing-key-file ${stake_sk_file}
-    --testnet-magic ${NWMAGIC}
+    ${NETWORK_IDENTIFIER}
     --out-file "${TMP_FOLDER}"/tx.signed
   )
 
   submitArgs=(
     shelley transaction submit
     --tx-file "${TMP_FOLDER}"/tx.signed
-    --cardano-mode
-    --testnet-magic ${NWMAGIC}
+    ${PROTOCOL_IDENTIFIER}
+    ${NETWORK_IDENTIFIER}
   )
 
   say "" 1
@@ -1523,7 +1523,7 @@ deRegisterPool() {
     --tx-body-file "${TMP_FOLDER}"/tx0.tmp
     --tx-in-count ${utx0_count}
     --tx-out-count 1
-    --testnet-magic ${NWMAGIC}
+    ${NETWORK_IDENTIFIER}
     --witness-count 2
     --byron-witness-count 0
     --protocol-params-file "${TMP_FOLDER}"/protparams.json
@@ -1556,15 +1556,15 @@ deRegisterPool() {
     --tx-body-file "${TMP_FOLDER}"/tx.raw
     --signing-key-file ${wallet_payment_sk_file}
     --signing-key-file ${pool_coldkey_sk_file}
-    --testnet-magic ${NWMAGIC}
+    ${NETWORK_IDENTIFIER}
     --out-file "${TMP_FOLDER}"/tx.signed
   )
 
   submitArgs=(
     shelley transaction submit
     --tx-file "${TMP_FOLDER}"/tx.signed
-    --cardano-mode
-    --testnet-magic ${NWMAGIC}
+    ${PROTOCOL_IDENTIFIER}
+    ${NETWORK_IDENTIFIER}
   )
 
   say "" 1

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -23,7 +23,7 @@ if [[ ! -d "${TMP_FOLDER}" ]]; then
 fi
 
 # Get protocol parameters and save to ${TMP_FOLDER}/protparams.json
-${CCLI} shelley query protocol-parameters --cardano-mode --testnet-magic ${NWMAGIC} --out-file "${TMP_FOLDER}"/protparams.json || {
+${CCLI} shelley query protocol-parameters ${PROTOCOL_IDENTIFIER} ${NETWORK_IDENTIFIER} --out-file "${TMP_FOLDER}"/protparams.json || {
   say "\n"
   say "${ORANGE}WARN${NC}: failed to query protocol parameters, node running and env parameters correct?"
   say "\n${BLUE}Press c to continue or any other key to quit${NC}"
@@ -911,7 +911,7 @@ case $OPERATION in
         getBalance ${base_addr}
         [[ ${lovelace} -eq 0 ]] && continue
         if getRewardAddress ${dir}; then
-          delegation_pool_id=$(${CCLI} shelley query stake-address-info --cardano-mode --testnet-magic ${NWMAGIC} --address "${reward_addr}" | jq -r '.[].delegation // empty')
+          delegation_pool_id=$(${CCLI} shelley query stake-address-info ${PROTOCOL_IDENTIFIER} ${NETWORK_IDENTIFIER} --address "${reward_addr}" | jq -r '.[].delegation // empty')
           unset poolName
           if [[ -n ${delegation_pool_id} ]]; then
             while IFS= read -r -d '' pool; do
@@ -1129,7 +1129,7 @@ case $OPERATION in
     say "Dumping ledger-state from node, can take a while on larger networks...\n"
     
     pool_dirs=()
-    timeout -k 5 30 ${CCLI} shelley query ledger-state --cardano-mode --testnet-magic ${NWMAGIC} --out-file "${TMP_FOLDER}"/ledger-state.json
+    timeout -k 5 30 ${CCLI} shelley query ledger-state ${PROTOCOL_IDENTIFIER} ${NETWORK_IDENTIFIER} --out-file "${TMP_FOLDER}"/ledger-state.json
     if ! getDirs "${POOL_FOLDER}"; then continue; fi # dirs() array populated with all pool folders
     for dir in "${dirs[@]}"; do
       pool_coldkey_vk_file="${POOL_FOLDER}/${dir}/${POOL_COLDKEY_VK_FILENAME}"
@@ -1365,7 +1365,7 @@ case $OPERATION in
         getBalance ${base_addr}
         [[ ${lovelace} -eq 0 ]] && continue
         if getRewardAddress ${dir}; then
-          delegation_pool_id=$(${CCLI} shelley query stake-address-info --cardano-mode --testnet-magic ${NWMAGIC} --address "${reward_addr}" | jq -r '.[].delegation // empty')
+          delegation_pool_id=$(${CCLI} shelley query stake-address-info ${PROTOCOL_IDENTIFIER} ${NETWORK_IDENTIFIER} --address "${reward_addr}" | jq -r '.[].delegation // empty')
           unset poolName
           if [[ -n ${delegation_pool_id} ]]; then
             while IFS= read -r -d '' pool; do
@@ -1459,8 +1459,8 @@ case $OPERATION in
     ${CCLI} shelley node issue-op-cert --kes-verification-key-file "${pool_hotkey_vk_file}" --cold-signing-key-file "${pool_coldkey_sk_file}" --operational-certificate-issue-counter-file "${pool_opcert_counter_file}" --kes-period "${start_kes_period}" --out-file "${pool_opcert_file}"
     
     say "creating registration certificate" 1 "log"
-    say "$ ${CCLI} shelley stake-pool registration-certificate --cold-verification-key-file ${pool_coldkey_vk_file} --vrf-verification-key-file ${pool_vrf_vk_file} --pool-pledge ${pledge_lovelace} --pool-cost ${cost_lovelace} --pool-margin ${margin_fraction} --pool-reward-account-verification-key-file ${stake_vk_file} --pool-owner-stake-verification-key-file ${stake_vk_file} --out-file ${pool_regcert_file} --testnet-magic ${NWMAGIC} --metadata-url ${meta_json_url} --metadata-hash \$\(${CCLI} shelley stake-pool metadata-hash --pool-metadata-file ${pool_meta_file} \) ${relay_output}" 2
-    ${CCLI} shelley stake-pool registration-certificate --cold-verification-key-file "${pool_coldkey_vk_file}" --vrf-verification-key-file "${pool_vrf_vk_file}" --pool-pledge ${pledge_lovelace} --pool-cost ${cost_lovelace} --pool-margin ${margin_fraction} --pool-reward-account-verification-key-file "${stake_vk_file}" --pool-owner-stake-verification-key-file "${stake_vk_file}" --out-file "${pool_regcert_file}" --testnet-magic ${NWMAGIC} --metadata-url "${meta_json_url}" --metadata-hash "$(${CCLI} shelley stake-pool metadata-hash --pool-metadata-file ${pool_meta_file} )" ${relay_output}
+    say "$ ${CCLI} shelley stake-pool registration-certificate --cold-verification-key-file ${pool_coldkey_vk_file} --vrf-verification-key-file ${pool_vrf_vk_file} --pool-pledge ${pledge_lovelace} --pool-cost ${cost_lovelace} --pool-margin ${margin_fraction} --pool-reward-account-verification-key-file ${stake_vk_file} --pool-owner-stake-verification-key-file ${stake_vk_file} --out-file ${pool_regcert_file} ${NETWORK_IDENTIFIER} --metadata-url ${meta_json_url} --metadata-hash \$\(${CCLI} shelley stake-pool metadata-hash --pool-metadata-file ${pool_meta_file} \) ${relay_output}" 2
+    ${CCLI} shelley stake-pool registration-certificate --cold-verification-key-file "${pool_coldkey_vk_file}" --vrf-verification-key-file "${pool_vrf_vk_file}" --pool-pledge ${pledge_lovelace} --pool-cost ${cost_lovelace} --pool-margin ${margin_fraction} --pool-reward-account-verification-key-file "${stake_vk_file}" --pool-owner-stake-verification-key-file "${stake_vk_file}" --out-file "${pool_regcert_file}" ${NETWORK_IDENTIFIER} --metadata-url "${meta_json_url}" --metadata-hash "$(${CCLI} shelley stake-pool metadata-hash --pool-metadata-file ${pool_meta_file} )" ${relay_output}
     say "creating delegation certificate" 1 "log"
     say "$ ${CCLI} shelley stake-address delegation-certificate --stake-verification-key-file ${stake_vk_file} --cold-verification-key-file ${pool_coldkey_vk_file} --out-file ${pool_pledgecert_file}" 2
     ${CCLI} shelley stake-address delegation-certificate --stake-verification-key-file "${stake_vk_file}" --cold-verification-key-file "${pool_coldkey_vk_file}" --out-file "${pool_pledgecert_file}"
@@ -1526,7 +1526,7 @@ case $OPERATION in
     say "Dumping ledger-state from node, can take a while on larger networks...\n"
     
     pool_dirs=()
-    timeout -k 5 30 ${CCLI} shelley query ledger-state --cardano-mode --testnet-magic ${NWMAGIC} --out-file "${TMP_FOLDER}"/ledger-state.json
+    timeout -k 5 30 ${CCLI} shelley query ledger-state ${PROTOCOL_IDENTIFIER} ${NETWORK_IDENTIFIER} --out-file "${TMP_FOLDER}"/ledger-state.json
     if ! getDirs "${POOL_FOLDER}"; then continue; fi # dirs() array populated with all pool folders
     for dir in "${dirs[@]}"; do
       pool_coldkey_vk_file="${POOL_FOLDER}/${dir}/${POOL_COLDKEY_VK_FILENAME}"
@@ -1574,7 +1574,7 @@ case $OPERATION in
         getBalance ${base_addr}
         [[ ${lovelace} -eq 0 ]] && continue
         if getRewardAddress ${dir}; then
-          delegation_pool_id=$(${CCLI} shelley query stake-address-info --cardano-mode --testnet-magic ${NWMAGIC} --address "${reward_addr}" | jq -r '.[].delegation // empty')
+          delegation_pool_id=$(${CCLI} shelley query stake-address-info ${PROTOCOL_IDENTIFIER} ${NETWORK_IDENTIFIER} --address "${reward_addr}" | jq -r '.[].delegation // empty')
           unset poolName
           if [[ -n ${delegation_pool_id} ]]; then
             while IFS= read -r -d '' pool; do
@@ -1845,8 +1845,8 @@ case $OPERATION in
     say "\n"
     say "# Modify Stake Pool" "log"
     say "creating registration certificate" 1 "log"
-    say "$ ${CCLI} shelley stake-pool registration-certificate --cold-verification-key-file ${pool_coldkey_vk_file} --vrf-verification-key-file ${pool_vrf_vk_file} --pool-pledge ${pledge_lovelace} --pool-cost ${cost_lovelace} --pool-margin ${margin_fraction} --pool-reward-account-verification-key-file ${stake_vk_file} --pool-owner-stake-verification-key-file ${stake_vk_file} --metadata-url ${meta_json_url} --metadata-hash \$\(${CCLI} shelley stake-pool metadata-hash --pool-metadata-file ${pool_meta_file} \) ${relay_output} --testnet-magic ${NWMAGIC} --out-file ${pool_regcert_file}" 2
-    ${CCLI} shelley stake-pool registration-certificate --cold-verification-key-file "${pool_coldkey_vk_file}" --vrf-verification-key-file "${pool_vrf_vk_file}" --pool-pledge ${pledge_lovelace} --pool-cost ${cost_lovelace} --pool-margin ${margin_fraction} --pool-reward-account-verification-key-file "${stake_vk_file}" --pool-owner-stake-verification-key-file "${stake_vk_file}" --metadata-url "${meta_json_url}" --metadata-hash "$(${CCLI} shelley stake-pool metadata-hash --pool-metadata-file ${pool_meta_file} )" ${relay_output} --testnet-magic ${NWMAGIC} --out-file "${pool_regcert_file}"
+    say "$ ${CCLI} shelley stake-pool registration-certificate --cold-verification-key-file ${pool_coldkey_vk_file} --vrf-verification-key-file ${pool_vrf_vk_file} --pool-pledge ${pledge_lovelace} --pool-cost ${cost_lovelace} --pool-margin ${margin_fraction} --pool-reward-account-verification-key-file ${stake_vk_file} --pool-owner-stake-verification-key-file ${stake_vk_file} --metadata-url ${meta_json_url} --metadata-hash \$\(${CCLI} shelley stake-pool metadata-hash --pool-metadata-file ${pool_meta_file} \) ${relay_output} ${NETWORK_IDENTIFIER} --out-file ${pool_regcert_file}" 2
+    ${CCLI} shelley stake-pool registration-certificate --cold-verification-key-file "${pool_coldkey_vk_file}" --vrf-verification-key-file "${pool_vrf_vk_file}" --pool-pledge ${pledge_lovelace} --pool-cost ${cost_lovelace} --pool-margin ${margin_fraction} --pool-reward-account-verification-key-file "${stake_vk_file}" --pool-owner-stake-verification-key-file "${stake_vk_file}" --metadata-url "${meta_json_url}" --metadata-hash "$(${CCLI} shelley stake-pool metadata-hash --pool-metadata-file ${pool_meta_file} )" ${relay_output} ${NETWORK_IDENTIFIER} --out-file "${pool_regcert_file}"
     
     say "sending transaction to chain" 1 "log"
     if ! modifyPool "${base_addr}" "${pool_coldkey_sk_file}" "${stake_sk_file}" "${pool_regcert_file}" "${pay_payment_sk_file}"; then
@@ -1904,7 +1904,7 @@ case $OPERATION in
     say "Dumping ledger-state from node, can take a while on larger networks...\n"
     
     pool_dirs=()
-    timeout -k 5 30 ${CCLI} shelley query ledger-state --cardano-mode --testnet-magic ${NWMAGIC} --out-file "${TMP_FOLDER}"/ledger-state.json
+    timeout -k 5 30 ${CCLI} shelley query ledger-state ${PROTOCOL_IDENTIFIER} ${NETWORK_IDENTIFIER} --out-file "${TMP_FOLDER}"/ledger-state.json
     if ! getDirs "${POOL_FOLDER}"; then continue; fi # dirs() array populated with all pool folders
     for dir in "${dirs[@]}"; do
       pool_coldkey_vk_file="${POOL_FOLDER}/${dir}/${POOL_COLDKEY_VK_FILENAME}"
@@ -2030,7 +2030,7 @@ case $OPERATION in
     say "Dumping ledger-state from node, can take a while on larger networks...\n"
     say "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     
-    timeout -k 5 30 ${CCLI} shelley query ledger-state --cardano-mode --testnet-magic ${NWMAGIC} --out-file "${TMP_FOLDER}"/ledger-state.json
+    timeout -k 5 30 ${CCLI} shelley query ledger-state ${PROTOCOL_IDENTIFIER} ${NETWORK_IDENTIFIER} --out-file "${TMP_FOLDER}"/ledger-state.json
     
     while IFS= read -r -d '' pool; do 
       say ""
@@ -2091,7 +2091,7 @@ case $OPERATION in
     pool_name="${dir_name}"
     
     say "Dumping ledger-state from node, can take a while on larger networks...\n"
-    timeout -k 5 45 ${CCLI} shelley query ledger-state --cardano-mode --testnet-magic ${NWMAGIC} --out-file "${TMP_FOLDER}"/ledger-state.json
+    timeout -k 5 45 ${CCLI} shelley query ledger-state ${PROTOCOL_IDENTIFIER} ${NETWORK_IDENTIFIER} --out-file "${TMP_FOLDER}"/ledger-state.json
     
     say "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     say ""
@@ -2191,7 +2191,7 @@ case $OPERATION in
         say "$(printf "%-21s : ${stake_color}%s${NC} ADA (%s ADA)" " Stake (reward)" "$(formatLovelace ${stake})" "$(formatLovelace ${reward})")" "log"
       done
       say "$(printf "%-21s : ${GREEN}%s${NC} ADA" "Stake" "$(formatLovelace ${total_stake})")" "log"
-      stake_pct=$(fractionToPCT "$(LC_NUMERIC=C printf "%.10f" "$(${CCLI} shelley query stake-distribution --cardano-mode --testnet-magic ${NWMAGIC} | grep "${pool_id}" | tr -s ' ' | cut -d ' ' -f 2)")")
+      stake_pct=$(fractionToPCT "$(LC_NUMERIC=C printf "%.10f" "$(${CCLI} shelley query stake-distribution ${PROTOCOL_IDENTIFIER} ${NETWORK_IDENTIFIER} | grep "${pool_id}" | tr -s ' ' | cut -d ' ' -f 2)")")
       if validateDecimalNbr ${stake_pct}; then
         say "$(printf "%-21s : %s %%" "Stake distribution" "${stake_pct}")" "log"
       fi

--- a/scripts/cnode-helper-scripts/createAddr.sh
+++ b/scripts/cnode-helper-scripts/createAddr.sh
@@ -9,4 +9,4 @@ fi
 
 WNAME=$1
 ${CCLI} shelley address key-gen --verification-key-file $WNAME.vkey --signing-key-file $WNAME.skey
-${CCLI} shelley address build --payment-verification-key-file $WNAME.vkey  --testnet-magic ${NWMAGIC} | tee $WNAME.addr
+${CCLI} shelley address build --payment-verification-key-file $WNAME.vkey  ${NETWORK_IDENTIFIER} | tee $WNAME.addr

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -3,9 +3,19 @@
 CCLI=$(which cardano-cli)
 CNODE_HOME=/opt/cardano/cnode
 CONFIG=$CNODE_HOME/files/ptn0.yaml
+PROTOCOL=$(grep -ri ^Protocol: "$CONFIG" | awk '{print $2}')
+if [[ "${PROTOCOL}" = "Cardano" ]]; then
+  PROTOCOL_IDENTIFIER="--cardano-mode"
+fi
 GENESIS_JSON=$CNODE_HOME/files/genesis.json
+NETWORKID=$(jq -r .networkId $GENESIS_JSON)
 BYRON_GENESIS_JSON=$CNODE_HOME/files/byron_genesis.json
 NODE_SOCKET_PATH=$CNODE_HOME/sockets/node0.socket
 export CARDANO_NODE_SOCKET_PATH=$CNODE_HOME/sockets/node0.socket
 MAGIC=$(jq -r .protocolMagicId < $GENESIS_JSON)
 NWMAGIC=$(jq -r .networkMagic < $GENESIS_JSON)
+if [[ "${NETWORKID}" = "Mainnet" ]]; then
+  NETWORK_IDENTIFIER="--mainnet"
+else
+  NETWORK_IDENTIFIER="--testnet-magic ${NWMAGIC}"
+fi

--- a/scripts/cnode-helper-scripts/sendADA.sh
+++ b/scripts/cnode-helper-scripts/sendADA.sh
@@ -34,7 +34,7 @@ fi
 rm -f "${TMP_FOLDER}"/*
 
 # Get protocol parameters and save to ${TMP_FOLDER}/protparams.json
-${CCLI} shelley query protocol-parameters --cardano-mode --testnet-magic ${NWMAGIC} --out-file ${TMP_FOLDER}/protparams.json || {
+${CCLI} shelley query protocol-parameters ${PROTOCOL_IDENTIFIER} ${NETWORK_IDENTIFIER} --out-file ${TMP_FOLDER}/protparams.json || {
   echo ""
   say "${RED}ERROR${NC}: failed to query protocol parameters, node running and env parameters correct?"
   exit 1

--- a/scripts/cnode-helper-scripts/topologyUpdater.sh
+++ b/scripts/cnode-helper-scripts/topologyUpdater.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+# shellcheck disable=SC2086 
 USERNAME="${USERNAME}" # replace nonroot with your username
 CNODE_PORT=6000  # must match your relay node port as set in the startup command
 CNODE_HOSTNAME="CHANGE ME"  # optional. must resolve to the IP you are requesting from


### PR DESCRIPTION
- Add PROTOCOL_IDENTIFIER and NETWORK_IDENTIFIER instead of harcoded entries for combinator v/s TPraos & testnet v/s magic differentiators respectively.
- Keep both ptn0.yaml and ptn0-combinator.yaml to keep validity with mainnet-combinator
- Revert back default for Public network to Shelley_Testnet as per https://t.me/CardanoStakePoolWorkgroup/282606