### PR TITLE
cntools: remove NODE_SOCKET_PATH (replaced by CARDANO_NODE_SOCKET_PATH)

### DIFF
--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -10,7 +10,6 @@ fi
 GENESIS_JSON=$CNODE_HOME/files/genesis.json
 NETWORKID=$(jq -r .networkId $GENESIS_JSON)
 BYRON_GENESIS_JSON=$CNODE_HOME/files/byron_genesis.json
-NODE_SOCKET_PATH=$CNODE_HOME/sockets/node0.socket
 export CARDANO_NODE_SOCKET_PATH=$CNODE_HOME/sockets/node0.socket
 MAGIC=$(jq -r .protocolMagicId < $GENESIS_JSON)
 NWMAGIC=$(jq -r .networkMagic < $GENESIS_JSON)


### PR DESCRIPTION
NODE_SOCKET_PATH does not seem used anymore in any of the following projects:
- CNTools
- cardano-node/cardano-cli and its dependencies
- cardano-db-sync and its dependencies