### PR TITLE
Update monitoring scripts

### DIFF
--- a/docs/Appendix/monitoring.md
+++ b/docs/Appendix/monitoring.md
@@ -1,61 +1,104 @@
-!> The script may not be detailed enough at this stage, we will update the contents to be a lot more definitive soon
 > Ensure the [Pre-Requisites](basics.md#pre-requisites) are in place before you proceed.
 
-This is a multi-purpose script to operate various activities (like creating keys, transactions, registering stake pool , delegating to a pool or updating binaries) using cardano node.
+This is an easy-to-use script to automate setting up of monitoring tools. Tasks automates the following tasks:
+- Installs Prometheus, Node Exporter and Grafana Servers for your respective Linux architecture.
+- Configure Prometheus to connect to cardano node and node exporter jobs.
+- Provisions the installed prometheus server to be automatically available as data source in Grafana.
+- Provisions two of the common grafana dashboards used to monitor `cardano-node` by [SkyLight](https://oqulent.com/skylight-pool/) and IOHK to be readily consumed from Grafana.
+- Deploy `prometheus`,`node_exporter` and `grafana-server` as systemd service on Linux.
+- Start and enable those services.
 
-#### Download setup_mon.sh
+Note that securing prometheus/grafana servers via TLS encryption and other security best practices are out of scope for this document, and its mainly aimed to help you get started with monitoring without much fuss.
 
-If you have run `prereqs.sh`, this should already be available in your scripts folder. To download monitoring script, you can execute the commands below:
+!> Ensure that you've opened the firewall port for grafana server (default used in this script is 5000)
+
+#### Download setup_mon.sh {docsify-ignore}
+
+If you have run `prereqs.sh`, you can skip this step. To download monitoring script, you can execute the commands below:
 ``` bash
 cd $CNODE_HOME/scripts
 wget https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/setup_mon.sh
 chmod 750 setup_mon.sh
 ```
 
-#### Set up Monitoring
+#### Customise any Environment Variables
 
-Execute setup_mon.sh with full path to destination folder you want to setup monitoring in
+The default selection may not always be usable for everyone. You can customise further environment variable settings by opening in editor (eg: `vi setup_mon.sh` ), and updating variables below to your liking:
 
 ``` bash
-./setup_mon.sh $CNODE_HOME/monitoring
-#
-# Please use hasPrometeus's IP:PORT from node's config file.
-# The files will be installed in the "$CNODE_HOME/monitoring" directory.
-# What port will be used for prometheus web server (Default is 9090)?9003
-# What is the ip of the node (default:127.0.0.1)?
-# What port is used for prometheus metrics of the node running on 127.0.0.1's (Default is 9001)?
-# Is this correct? http://127.0.0.1:9001/metrics
-# Do you want to continue? [Y/n/q] Y
+#!/bin/bash
+# shellcheck disable=SC2209,SC2164
+
+######################################################################
+#### Environment Variables
+######################################################################
+CNODE_IP=127.0.0.1
+CNODE_PORT=12798
+GRAFANA_HOST=0.0.0.0
+GRAFANA_PORT=5000
+PROJ_PATH=/opt/cardano/monitoring
+PROM_HOST=127.0.0.1
+PROM_PORT=9090
+NEXP_PORT=$(( PROM_PORT + 1 ))
+````
+
+#### Set up Monitoring
+
+Execute setup_mon.sh with full path to destination folder you want to setup monitoring in. If you're following guild folder structure, you do not need to specify `-d`. Read the usage comments below before you run the actual script.
+
+Note that to deploy services as systemd, the script expect sudo access is available to the user running the script.
+
+``` bash
+cd $CNODE_HOME/scripts
+# To check Usage parameters:
+# ./setup_mon.sh -h
+#Usage: setup_mon.sh [-d directory] [-h hostname] [-p port]
+#Setup monitoring using Prometheus and Grafana for Cardano Node
+#-d directory      Directory where you'd like to deploy the packages for prometheus , node exporter and grafana
+#-i IP/hostname    IPv4 address or a FQDN/DNS name where your cardano-node (relay) is running (check for hasPrometheus in config.json; eg: 127.0.0.1 if same machine as cardano-node)
+#-p port           Port at which your cardano-node is exporting stats (check for hasPrometheus in config.json; eg: 12798)
+./setup_mon.sh
 # 
 # Downloading prometheus v2.18.1...
 # Downloading grafana v7.0.0...
 # Downloading exporter v0.18.1...
 # Downloading grafana dashboard(s)...
-#   - Haskel_Node_SKY_Relay1_Dash.json
-#   - cardano-application-dashboard-v2.json
+#   - SKYLight Monitoring Dashboard
+#   - IOHK Monitoring Dashboard
 # 
+# NOTE: Could not create directory as rdlrt, attempting sudo ..
+# NOTE: No worries, sudo worked !! Moving on ..
 # Configuring components
-# 
+# Registering Prometheus as datasource in Grafana..
+# Creating service files as root..
 # 
 # =====================================================
 # Installation is completed
 # =====================================================
 # 
-# - Prometheus (default): http://localhost:9003/metrics
-#     Node metrics:       http://127.0.0.1:9001
-#     Node exp metrics:   http://127.0.0.1:9002
-# - Grafana (default):    http://localhost:3000
+# - Prometheus (default): http://127.0.0.1:9090/metrics
+#     Node metrics:       http://127.0.0.1:12798
+#     Node exp metrics:   http://127.0.0.1:9091
+# - Grafana (default):    http://0.0.0.0:5000
 # 
 # 
 # You need to do the following to configure grafana:
-# 0. Start the required services in a new terminal by "$CNODE_HOME/monitoring/start_all.sh"
-#   - check the prometheus and its exporters by opening URLs above after start.
-# 1. Login to grafana as admin/admin (http://localhost:3000)
-# 2. Add "prometheus" (all lowercase) datasource (http://localhost:9003)
+# 0. The services should already be started, verify if you can login to grafana, and prometheus. If using 127.0.0.1 as IP, you can check via curl
+# 1. Login to grafana as admin/admin (http://0.0.0.0:5000)
+# 2. Add "prometheus" (all lowercase) datasource (http://127.0.0.1:9090)
 # 3. Create a new dashboard by importing dashboards (left plus sign).
 #   - Sometimes, the individual panel's "prometheus" datasource needs to be refreshed.
 # 
 # Enjoy...
 # 
 # Cleaning up...
+
 ```
+
+#### View Dashboards
+
+You should now be able to Login to grafana dashboard, using the public IP of your server, at port 5000.
+The initial credentials to login would be *admin/admin*, and you will be asked to update your password upon first login.
+Once logged on, you should be able to go to `Manage > Dashboards` and select the dashboard you'd like to view. Note that if you've just started the server, you might see graphs as empty, as initial interval for dashboards is 12 hours. You can change it to 5 minutes by looking at top right section of the page.
+
+Thanks to [Pal Dorogit](https://github.com/ilap) for the original setup instructions used for modifying.

--- a/scripts/cnode-helper-scripts/setup_mon.sh
+++ b/scripts/cnode-helper-scripts/setup_mon.sh
@@ -1,17 +1,32 @@
 #!/bin/bash
-#---------------------------------------------------------------------
-# File:    setup_shelley_monitoring.sh
-# Created: 2019/10/17
-# Creator: ilap
-#=====================================================================
-# UPDATES:
-# - 21/05/2020: Updated to the `cardano-node` i.e. Haskell Shelley
-#
-# DESCRIPTION:
-#
-# This script downloads and configures the required files
-# for monitoring a Shelley node by using grafana/prometheus.
-#
+# shellcheck disable=SC2209,SC2164
+
+######################################################################
+#### Environment Variables
+######################################################################
+CNODE_IP=127.0.0.1
+CNODE_PORT=12798
+GRAFANA_HOST=0.0.0.0
+GRAFANA_PORT=5000
+PROJ_PATH=/opt/cardano/monitoring
+PROM_HOST=127.0.0.1
+PROM_PORT=9090
+NEXP_PORT=$(( PROM_PORT + 1 ))
+
+######################################################################
+#### Static Variables
+######################################################################
+ARCHS=("darwin-amd64" "linux-amd64"  "linux-armv6")
+TMP_DIR=$(mktemp -d "/tmp/cnode_monitoring.XXXXXXXX")
+PROM_VER=2.18.1
+GRAF_VER=7.0.0
+NEXP_VER=0.18.1
+NEXP="node_exporter"
+SKY_DB_URL="https://raw.githubusercontent.com/Oqulent/SkyLight-Pool/master/Haskel_Node_SKY_Relay1_Dash.json"
+IOHK_DB="cardano-application-dashboard-v2.json"
+IOHK_DB_URL="https://raw.githubusercontent.com/input-output-hk/cardano-ops/master/modules/grafana/cardano/$IOHK_DB"
+export CNODE_IP CNODE_PORT PROJ_PATH TMP_DIR
+DEBUG="N"
 
 ######################################################################
 #### Functions
@@ -62,88 +77,73 @@ dl() {
     esac
 }
 
+usage() {
+  cat <<EOF >&2
+Usage: $(basename "$0") [-d directory] [-h hostname] [-p port]
+Setup monitoring using Prometheus and Grafana for Cardano Node
+-d directory      Directory where you'd like to deploy the packages for prometheus , node exporter and grafana
+-i IP/hostname    IPv4 address or a FQDN/DNS name where your cardano-node (relay) is running (check for hasPrometheus in config.json; eg: 127.0.0.1 if same machine as cardano-node)
+-p port           Port at which your cardano-node is exporting stats (check for hasPrometheus in config.json; eg: 12798)
+EOF
+  exit 1
+}
+
 ######################################################################
 #### MAIN
 ######################################################################
 
-# shellcheck disable=SC2209
-DBG=echo
-unset DBG # For debug only
-
-PROM_VER=2.18.1
-GRAF_VER=7.0.0
-NEXP_VER=0.18.1
+if [[ "${DEBUG}" == "Y" ]]; then
+  DBG=echo
+else
+  unset DBG
+fi
 
 CURL=$(command -v curl)
 WGET=$(command -v wget)
 
 DL=${CURL:=$WGET}
 
-if [ -z "$1" ] ; then
-    message "usage: $(basename "$0") <full path to folder which would contain monitoring artifacts>\nExample: ./$(basename "$0") /opt/cardano/cnode/monitoring"
-fi
-
 if  [ -z "$DL" ]; then
     message 'You need to have "wget" or "curl" to be installed\nand accessable by PATH environment to continue...\nExiting.'
 fi
 
-PROJ_DIR=$(dirname "$1")
-PROJ_NAME=$(basename "$1")
-PROJ_PATH="$PROJ_DIR/$PROJ_NAME"
+# if using CNODE_HOME
+if [[ -f "$CNODE_HOME/sripts/env" ]]; then
+  CNODE_IP=$(jq -r .hasPrometheus[0] "$CONFIG" 2>/dev/null)
+  CNODE_PORT=$(jq -r .hasPrometheus[1] "$CONFIG" 2>/dev/null)
+  PROJ_PATH="$(cd "$CNODE_HOME/../monitoring 2>/dev/null";pwd)"
+fi
+
+while getopts :d:i:p: opt; do
+  case ${opt} in
+    i)
+      CNODE_IP="$OPTARG"
+      ;;
+    p)
+      CNODE_PORT="$OPTARG"
+      ;;
+    d)
+      PROJ_PATH="$OPTARG"
+      ;;
+    \?)
+      usage
+      exit
+      ;;
+  esac
+done
+shift "$((OPTIND -1))"
 
 if [ -e "$PROJ_PATH" ]; then
     message "The \"$PROJ_PATH\" directory exist pls move or delete it.\nExiting."
 fi
 
-TMP_DIR=$(mktemp -d "/tmp/$PROJ_NAME.XXXXXXXX")
-
-# Default parameters
-IP=127.0.0.1
-PORT=9001
-export IP PORT TMP_DIR
-
-while :
-do
-    echo "Please use hasPrometeus's IP:PORT from node's config file."
-    echo "The files will be installed in the \"$PROJ_PATH\" directory."
-    read -rp "What port will be used for prometheus web server (Default is 9090)?" prom_port
-    read -rp "What is the ip of the node (default:${IP})? " ip
-    read -rp "What port is used for prometheus metrics of the node running on ${IP:="${ip}"}'s (Default is ${PORT})?" port
-    echo "Is this correct? http://${ip:-"${IP}"}:${port:-"${PORT}"}/metrics"
-    read -rp "Do you want to continue? [Y/n/q] " answer
-
-    case ${answer:="Y"} in
-        [yY]*)
-            IP=${ip:-"${IP}"}
-            PORT=${port:-"${PORT}"}
-            PROM_PORT=${prom_port:-"9090"}
-            break;;
-        [nN]* )
-            continue;;
-        [qQ]* )
-            exit;;
-        * )
-            echo "Please enter [yY](es), [nN](o) or [qQ](quit).";;
-    esac
-done
-
-ARCHS=("darwin-amd64" "linux-amd64"  "linux-armv6")
 IDX=$(get_idx)
 
-PROM_URL="https://github.com/prometheus/prometheus/releases/download/v$PROM_VER/prometheus-$PROM_VER.${ARCHS[IDX]}.tar.gz"
-
-GRAF_URL="https://dl.grafana.com/oss/release/grafana-$GRAF_VER.${ARCHS[IDX]}.tar.gz"
-
-NEXP="node_exporter"
-NEXP_URL="https://github.com/prometheus/$NEXP/releases/download/v$NEXP_VER/$NEXP-$NEXP_VER.${ARCHS[IDX]}.tar.gz"
-
-UMED_DB="Haskel_Node_SKY_Relay1_Dash.json"
-UMED_DB_URL="https://raw.githubusercontent.com/Oqulent/SkyLight-Pool/master/$UMED_DB"
-
-IOHK_DB="cardano-application-dashboard-v2.json"
-IOHK_DB_URL="https://raw.githubusercontent.com/input-output-hk/cardano-ops/master/modules/grafana/cardano/$IOHK_DB"
-
 trap clean_up  SIGHUP SIGINT SIGQUIT SIGTRAP SIGABRT SIGTERM
+
+PROM_URL="https://github.com/prometheus/prometheus/releases/download/v$PROM_VER/prometheus-$PROM_VER.${ARCHS[IDX]}.tar.gz"
+GRAF_URL="https://dl.grafana.com/oss/release/grafana-$GRAF_VER.${ARCHS[IDX]}.tar.gz"
+NEXP_URL="https://github.com/prometheus/$NEXP/releases/download/v$NEXP_VER/$NEXP-$NEXP_VER.${ARCHS[IDX]}.tar.gz"
 
 echo ""
 echo -e "Downloading prometheus v$PROM_VER..." >&2
@@ -157,10 +157,10 @@ $DBG dl "$NEXP_URL"
 
 echo -e "Downloading grafana dashboard(s)..." >&2
 
-echo -e "  - $UMED_DB" >&2
-$DBG dl "$UMED_DB_URL"
+echo -e "  - SKYLight Monitoring Dashboard" >&2
+$DBG dl "$SKY_DB_URL"
 
-echo -e "  - $IOHK_DB" >&2
+echo -e "  - IOHK Monitoring Dashboard" >&2
 $DBG dl "$IOHK_DB_URL"
 
 echo ""
@@ -169,8 +169,18 @@ PROM_DIR="$PROJ_PATH/prometheus"
 GRAF_DIR="$PROJ_PATH/grafana"
 NEXP_DIR="$PROJ_PATH/exporters"
 DASH_DIR="$PROJ_PATH/dashboards"
+SYSD_DIR="$PROJ_PATH/systemd"
 
-mkdir -p "$PROM_DIR" "$GRAF_DIR" "$NEXP_DIR" "$DASH_DIR"
+mkdir -p "$PROJ_PATH" 2>/dev/null
+rc=$?
+if [[ "$rc" != 0 ]]; then
+  echo "NOTE: Could not create directory as $(whoami), attempting sudo .."
+  sudo mkdir -p "$PROJ_PATH" || message "WARN:Could not create folder $PROJ_PATH , please ensure that you have access to create it"
+  sudo chown "$(whoami)":"$(id -g)" "$PROJ_PATH"
+  chmod 750 "$PROJ_PATH"
+  echo "NOTE: No worries, sudo worked !! Moving on .."
+fi
+mkdir -p "$PROM_DIR" "$GRAF_DIR" "$NEXP_DIR" "$DASH_DIR" "$SYSD_DIR"
 
 tar zxC "$PROM_DIR" -f "$TMP_DIR"/*prome*gz --strip-components 1
 tar zxC "$GRAF_DIR" -f "$TMP_DIR"/*graf*gz --strip-components 1
@@ -182,58 +192,151 @@ mv "$TMP_DIR/node_exporter" "$NEXP_DIR/"
 chmod +x "$NEXP_DIR"/*
 
 # Fix grafana's datasource.
-sed -e "s#Prometheus#prometheus#g" "$TMP_DIR/$UMED_DB" -i
-cp -pr "$TMP_DIR/$UMED_DB" "$DASH_DIR/"
+sed -e "s#Prometheus#prometheus#g" "$TMP_DIR"/*.json -i
+cp -pr "$TMP_DIR"/*.json "$DASH_DIR/"
 
-cp -pr "$TMP_DIR/$IOHK_DB" "$DASH_DIR/"
-
-NEXP_PORT=$(( PORT + 1 ))
 HOSTNAME=$(hostname)
 
+sed -e "s/http_addr.*/http_addr = $GRAFANA_HOST/g" -e "s/http_port = 3000/http_port = $GRAFANA_PORT/g" "$GRAF_DIR"/conf/defaults.ini -i
 sed -e "s#\(^scrape_configs:.*\)#\1\n\
-  - job_name: '${HOSTNAME}_node'\n\
+  - job_name: '${HOSTNAME}_cardano_node'\n\
     static_configs:\n\
-    - targets: ['$IP:$PORT']\n\
-  - job_name: '${HOSTNAME}_node_exp'\n\
+    - targets: ['$CNODE_IP:$CNODE_PORT']\n\
+  - job_name: '${HOSTNAME}_node_exporter'\n\
     static_configs:\n\
-    - targets: ['$IP:$NEXP_PORT']#g" -e "s#9090#$PROM_PORT#g" "$PROM_DIR"/prometheus.yml -i
+    - targets: ['$CNODE_IP:$NEXP_PORT']#g" -e "s#localhost:9090#$PROM_HOST:$PROM_PORT#g" "$PROM_DIR"/prometheus.yml -i
 
-cat > "$PROJ_PATH/start_all.sh" <<EOF
-#!/bin/bash
+echo "Registering Prometheus as datasource in Grafana.."
 
-        #1. exporter
-        "$PROJ_PATH/exporters/node_exporter" --web.listen-address="$IP:$NEXP_PORT" &
-        sleep 3
+cat > "$GRAF_DIR"/conf/provisioning/datasources/prometheus.yaml <<EOF
+# # config file version
+apiVersion: 1
 
-        #2. Prometheus
-        "$PROM_DIR/prometheus" --config.file="$PROM_DIR/prometheus.yml" --web.listen-address=:$PROM_PORT &
-        sleep 3
+deleteDatasources:
+  - name: prometheus
+    orgId: 1
 
-        #3. Grafana
-        #vi "$GRAF_DIR/conf/defaults.ini"
-        cd "$GRAF_DIR"
-        ./bin/grafana-server web
+datasources:
+#   # <string, required> name of the datasource. Required
+  - name: prometheus
+    type: prometheus
+    access: proxy
+    orgId: 1
+    url: http://$PROM_HOST:$PROM_PORT
+    password:
+    user:
+    database:
+    basicAuth:
+    basicAuthUser:
+    basicAuthPassword:
+    withCredentials:
+    isDefault: 1
+    jsonData:
+      graphiteVersion: "1.1"
+      tlsAuth: false
+      tlsAuthWithCACert: false
+    #  httpHeaderName1: "Authorization"
+    #secureJsonData:
+    #  tlsCACert: "..."
+    #  tlsClientCert: "..."
+    #  tlsClientKey: "..."
+    #  # <openshift\kubernetes token example>
+    #  httpHeaderValue1: "Bearer xf5yhfkpsnmgo"
+    version: 1
+    # <bool> allow users to edit datasources from the UI.
+    editable: true
 EOF
 
-chmod a+rx "$PROJ_PATH/start_all.sh"
+cat > "$GRAF_DIR"/conf/provisioning/dashboards/cardano.yaml <<EOF
+# # config file version
+apiVersion: 1
+
+providers:
+ - name: 'Cardano Node'
+   orgId: 1
+   folder: ''
+   folderUid: ''
+   type: file
+   options:
+     path: $DASH_DIR
+EOF
+
+
+cat > "$SYSD_DIR"/prometheus.service <<EOF
+[Unit]
+Description=Prometheus Server
+Documentation=https://prometheus.io/docs/introduction/overview/
+After=network-online.target
+
+[Service]
+User=$(whoami)
+Restart=on-failure
+ExecStart=$PROM_DIR/prometheus \
+  --config.file=$PROM_DIR/prometheus.yml \
+  --storage.tsdb.path=$PROM_DIR/data --web.listen-address=$PROM_HOST:$PROM_PORT
+WorkingDirectory=$PROM_DIR
+LimitNOFILE=10000
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat > "$SYSD_DIR"/node_exporter.service <<EOF
+[Unit]
+Description=Node Exporter
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=$(whoami)
+Restart=on-failure
+ExecStart=$NEXP_DIR/node_exporter --web.listen-address="$CNODE_IP:$NEXP_PORT"
+WorkingDirectory=$NEXP_DIR
+LimitNOFILE=3500
+
+[Install]
+WantedBy=default.target
+EOF
+
+cat > "$SYSD_DIR"/grafana-server.service <<EOF
+[Unit]                                                                                          
+Description=Grafana instance                                                                    
+Documentation=http://docs.grafana.org                                                           
+Wants=network-online.target                                                                     
+After=network-online.target
+
+[Service]
+User=$(whoami)
+Restart=on-failure
+ExecStart=$GRAF_DIR/bin/grafana-server web
+WorkingDirectory=$GRAF_DIR
+LimitNOFILE=10000
+
+[Install]
+WantedBy=default.target
+EOF
+
+echo "Creating service files as root.."
+sudo cp "$SYSD_DIR"/*.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl start node_exporter prometheus grafana-server
+sudo systemctl enable node_exporter prometheus grafana-server
 
 echo -e "
-
 =====================================================
 Installation is completed
 =====================================================
 
-- Prometheus (default): http://localhost:$PROM_PORT/metrics
-    Node metrics:       http://$IP:$PORT
-    Node exp metrics:   http://$IP:$NEXP_PORT
-- Grafana (default):    http://localhost:3000
+- Prometheus (default): http://$PROM_HOST:$PROM_PORT/metrics
+    Node metrics:       http://$CNODE_IP:$CNODE_PORT
+    Node exp metrics:   http://$CNODE_IP:$NEXP_PORT
+- Grafana (default):    http://$GRAFANA_HOST:$GRAFANA_PORT
 
 
 You need to do the following to configure grafana:
-0. Start the required services in a new terminal by \"$PROJ_PATH/start_all.sh\"
-  - check the prometheus and its exporters by opening URLs above after start.
-1. Login to grafana as admin/admin (http://localhost:3000)
-2. Add \"prometheus\" (all lowercase) datasource (http://localhost:$PROM_PORT)
+0. The services should already be started, verify if you can login to grafana, and prometheus. If using 127.0.0.1 as IP, you can check via curl
+1. Login to grafana as admin/admin (http://$GRAFANA_HOST:$GRAFANA_PORT)
+2. Add \"prometheus\" (all lowercase) datasource (http://$PROM_HOST:$PROM_PORT)
 3. Create a new dashboard by importing dashboards (left plus sign).
   - Sometimes, the individual panel's \"prometheus\" datasource needs to be refreshed.
 


### PR DESCRIPTION
Align with current cntools structure, in adddition to below:
- Installs Prometheus, Node Exporter and Grafana Servers for your respective Linux architecture.
- Configure Prometheus to connect to cardano node and node exporter jobs.
- Provisions the installed prometheus server to be automatically available as data source in Grafana.
- Provisions two of the common grafana dashboards used to monitor `cardano-node` by [SkyLight](https://oqulent.com/skylight-pool/) and IOHK to be readily consumed from Grafana.
- Deploy `prometheus`,`node_exporter` and `grafana-server` as systemd service on Linux.
- Start and enable those services.