### PR TITLE
CNTools - 5.4.0

### DIFF
--- a/docs/Build/node-cli.md
+++ b/docs/Build/node-cli.md
@@ -50,3 +50,59 @@ cd $CNODE_HOME/scripts
 ./cnode.sh
 ```
 
+##### Run as systemd service
+
+The preferred way to run the node is through a service manager like systemd. This section explains how to setup a systemd service file.
+
+**1. Create systemd service file** 
+Replace `$USER` with the correct user for your system. Copy & paste all code below to create the service file.
+``` bash
+sudo bash -c "cat << 'EOF' > /etc/systemd/system/cnode.service
+[Unit]
+Description=C
+After=network.target
+
+[Service]
+Type=simple
+Restart=on-failure
+RestartSec=5
+User=$USER
+LimitNOFILE=1048576
+WorkingDirectory=/opt/cardano/cnode/scripts
+ExecStart=/bin/bash -l -c 'exec \"\$@\"' _ cnode.sh
+KillSignal=SIGINT
+SuccessExitStatus=143
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=cnode
+
+[Install]
+WantedBy=multi-user.target
+EOF"
+```
+
+**2. Reload systemd and enable automatic start of service on startup**  
+```
+sudo systemctl daemon-reload
+sudo systemctl enable cnode.service
+```
+
+**3. Modify configuration to run with view mode SimpleView**  
+```
+pushd $CNODE_HOME/files >/dev/null && \
+tmpConfig=$(mktemp) && \
+jq '.ViewMode = "SimpleView"' config.json > "${tmpConfig}" && mv -f "${tmpConfig}" config.json && \
+popd >/dev/null
+```
+
+**4. Start the node**  
+Run below commands to enable automatic start of service on startup and start it.
+```
+sudo systemctl start cnode.service
+```
+
+**5. Check status and stop/start commands** 
+Replace `status` with `stop`/`start`/`restart` depending on what action to take.
+```
+sudo systemctl status cnode.service
+```

--- a/docs/Build/node-cli.md
+++ b/docs/Build/node-cli.md
@@ -59,7 +59,7 @@ Replace `$USER` with the correct user for your system. Copy & paste all code bel
 ``` bash
 sudo bash -c "cat << 'EOF' > /etc/systemd/system/cnode.service
 [Unit]
-Description=C
+Description=Cardano Node
 After=network.target
 
 [Service]

--- a/docs/Scripts/cntools-blocks.md
+++ b/docs/Scripts/cntools-blocks.md
@@ -17,7 +17,7 @@ In this example normal output from the `cntoolsBlockCollector.sh` script is igno
 **1. Create systemd service file**  
 Replace `$USER` with the correct user for your system. Copy & paste all code below to create the service file.
 ``` bash
-sudo bash -c 'cat <<EOF > /etc/systemd/system/cntools-blockcollector.service
+sudo bash -c "cat << 'EOF' > /etc/systemd/system/cntools-blockcollector.service
 [Unit]
 Description=CNTools - Block Collector
 After=network.target
@@ -28,7 +28,7 @@ Restart=on-failure
 RestartSec=10
 User=$USER
 WorkingDirectory=/opt/cardano/cnode/scripts
-ExecStart=/opt/cardano/cnode/scripts/cntoolsBlockCollector.sh
+ExecStart=/bin/bash -l -c 'exec \"\$@\"' _ /opt/cardano/cnode/scripts/cntoolsBlockCollector.sh
 SuccessExitStatus=143
 StandardOutput=null
 StandardError=syslog
@@ -36,7 +36,7 @@ SyslogIdentifier=cntools-blockcollector
 
 [Install]
 WantedBy=multi-user.target
-EOF'
+EOF"
 ```
 
 **2. Reload systemd**  

--- a/docs/Scripts/cntools-changelog.md
+++ b/docs/Scripts/cntools-changelog.md
@@ -19,6 +19,7 @@ and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ##### Added
 - Sanity check before launching a second instance of cnode.sh
+- Doc update to run cnode.sh as a systemd service
 
 ##### Removed
 - `Pool >> Delegators` removed.

--- a/docs/Scripts/cntools-changelog.md
+++ b/docs/Scripts/cntools-changelog.md
@@ -30,6 +30,7 @@ and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - Block hash is now truncated in log, issue https://github.com/input-output-hk/cardano-node/issues/1738
 - High cpu usage reported in a few cases when running Block Collector
   - Depending on log level, parsing and byte64 enc each entry with jq could potentially put high load on weaker systems. Replaced with grep to only parse entries containing specific traces.
+- Docs for creating systemd block collector service file updated to include user env in run command
 
 
 ## [5.3.6] - 2020-08-22

--- a/docs/Scripts/cntools-changelog.md
+++ b/docs/Scripts/cntools-changelog.md
@@ -5,10 +5,38 @@ All notable changes to this tool will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.4.0] - 2020-08-23
+
+> A non-breaking change have been made to files outside of CNTools. Internal update function is not enough to update all files.  
+> - Execute the below (by default it will set you up against mainnet network), do not overwrite config please:  
+>    `cd "$CNODE_HOME"/scripts`  
+>    `curl -sS -o prereqs.sh https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/prereqs.sh`  
+>    `chmod 755 prereqs.sh`  
+>    `./prereqs.sh -s`  
+> - Start using updated cnode.sh to run a passive node, or edit the cnode.sh to include your pool keys and run as pool owner.
+
+=======
+
+##### Added
+- Sanity check before launching a second instance of cnode.sh
+
+##### Removed
+- `Pool >> Delegators` removed.
+  - If/when a better option than dumping and parsing ledger-state dump arise re-adding it will be considered. 
+  - Utilize the community explorers listed at https://cardano-community.github.io/support-faq/#/explorers 
+
+##### Fixed
+- Block Collector script adapted for cardano-node 1.19.0.
+  - Block hash is now truncated in log, issue https://github.com/input-output-hk/cardano-node/issues/1738
+- High cpu usage reported in a few cases when running Block Collector
+  - Depending on log level, parsing and byte64 enc each entry with jq could potentially put high load on weaker systems. Replaced with grep to only parse entries containing specific traces.
+
+
 ## [5.3.6] - 2020-08-22
 
 ##### Fixed
 - cardano-node 1.19.0 introduced an issue that required us to use KES as current - 1 while rotating.
+
 
 ## [5.3.5] - 2020-08-20
 
@@ -21,6 +49,7 @@ and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - A new pool.id-bech32 file gets created if cold.vkey is available and decrypted
 - Added error check to see if cardano-cli is in $PATH before continuing.
 
+
 ## [5.3.4] - 2020-08-18
 
 ##### Changed
@@ -31,17 +60,8 @@ and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ##### Added
 - Use secure remove (`srm`) when available when deleting files.
 
+
 ## [5.3.2] - 2020-08-05
-
-> If you're coming version 5.2.1 (not required if you're on 5.3.0), We have made quite a few changes to not use ptn0 in our scripts and source github structures (except template files), alongwith other changes listed beneath. Please follow steps below for upgrade:  
-> - Execute the below (by default it will set you up against mainnet network), do not overwrite config please:  
->    `cd "$CNODE_HOME"/scripts`  
->    `curl -sS -o prereqs.sh https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/prereqs.sh`  
->    `chmod 755 prereqs.sh`  
->    `./prereqs.sh -s`  
-> - Start using updated cnode.sh to run a passive node, or edit the cnode.sh to include your pool keys and run as pool owner.
-
-=======
 
 #### Fixed
 - Backup & Restore paths were failing on machines due to alnum class availability on certain interpreters.
@@ -60,6 +80,7 @@ and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Removed +i file locking on .addr files when using `Wallet >> Encrypt` as these are re-generated from keys and need to be writable
 - Balance check added to `Funds >> Withdraw` for base address as this is used to pay the withdraw transaction fee
 - Resolve issue with Multi Owner causing an error with new pool registration (error was due to quotes)
+
 
 ## [5.3.0] - 2020-08-03
 ##### Added

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -9,9 +9,9 @@
 # Any breaking changes (eg: that requires change of cntools.config, env or a change in priv folder would be considered breaking and will be exempt from auto-update)
 CNTOOLS_MAJOR_VERSION=5
 # Changes that can be applied without breaking existing functionality that can be applied from within CNTools
-CNTOOLS_MINOR_VERSION=3
+CNTOOLS_MINOR_VERSION=4
 # Backwards compatible bug fixes. No additional functionality or major changes and can be applied from within CNTools
-CNTOOLS_PATCH_VERSION=6
+CNTOOLS_PATCH_VERSION=0
 CNTOOLS_VERSION="${CNTOOLS_MAJOR_VERSION}.${CNTOOLS_MINOR_VERSION}.${CNTOOLS_PATCH_VERSION}"
 
 ############################################################

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -1155,25 +1155,23 @@ case $OPERATION in
   say " ) Retire     -  de-register stake pool from chain in specified epoch"
   say " ) List       -  a compact list view of available local pools"
   say " ) Show       -  detailed view of specified pool"
-  say " ) Delegators -  list all delegators for pool"
   say " ) Rotate     -  rotate pool KES keys"
   say " ) Decrypt    -  remove write protection and decrypt pool"
   say " ) Encrypt    -  encrypt pool cold keys and make all files immutable"
   say "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
 
   say " Select Pool operation\n"
-  case $(select_opt "[n] New" "[r] Register" "[m] Modify" "[x] Retire" "[l] List" "[s] Show" "[g] Delegators" "[o] Rotate" "[d] Decrypt" "[e] Encrypt" "[h] Home") in
+  case $(select_opt "[n] New" "[r] Register" "[m] Modify" "[x] Retire" "[l] List" "[s] Show" "[o] Rotate" "[d] Decrypt" "[e] Encrypt" "[h] Home") in
     0) SUBCOMMAND="new" ;;
     1) SUBCOMMAND="register" ;;
     2) SUBCOMMAND="modify" ;;
     3) SUBCOMMAND="retire" ;;
     4) SUBCOMMAND="list" ;;
     5) SUBCOMMAND="show" ;;
-    6) SUBCOMMAND="delegators" ;;
-    7) SUBCOMMAND="rotate" ;;
-    8) SUBCOMMAND="decrypt" ;;
-    9) SUBCOMMAND="encrypt" ;;
-    10) continue ;;
+    6) SUBCOMMAND="rotate" ;;
+    7) SUBCOMMAND="decrypt" ;;
+    8) SUBCOMMAND="encrypt" ;;
+    9) continue ;;
   esac
 
   case $SUBCOMMAND in
@@ -2483,57 +2481,6 @@ case $OPERATION in
     say "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     waitForInput
     
-    ;; ###################################################################
-
-    delegators)
-    
-    clear
-    say " >> POOL >> DELEGATORS" "log"
-    say "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    say ""
-
-    if [[ ! -f "${TMP_FOLDER}"/protparams.json ]]; then
-      say "${RED}ERROR${NC}: CNTools started without node access, only offline functions available!"
-      waitForInput && continue
-    fi
-    
-    pool_dirs=()
-    if ! getDirs "${POOL_FOLDER}"; then continue; fi # dirs() array populated with all pool folders
-    for dir in "${dirs[@]}"; do
-      pool_id_file="${POOL_FOLDER}/${dir}/${POOL_ID_FILENAME}"
-      [[ ! -f "${pool_id_file}" ]] && continue
-      pool_dirs+=("${dir}")
-    done
-    if [[ ${#pool_dirs[@]} -eq 0 ]]; then
-      say "${ORANGE}WARN${NC}: No pools available!"
-      say "first create a pool"
-      waitForInput && continue
-    fi
-    say "Select Pool:\n"
-    if ! selectDir "${pool_dirs[@]}"; then continue; fi # ${dir_name} populated by selectDir function
-    pool_name="${dir_name}"
-    getPoolID ${pool_name}
-    
-    say "Looking for delegators, please wait..."
-    if ! getDelegators ${pool_id}; then
-      waitForInput && continue
-    fi
-    
-    clear
-    say " >> POOL >> DELEGATORS" "log"
-    say "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    say ""
-    say "${BLUE}${delegator_nbr}${NC} wallet(s) delegated to ${GREEN}${pool_name}${NC} of which ${ORANGE}${owner_nbr}${NC} are owner(s)\n"
-    say "Total Stake: $(formatLovelace ${total_stake}) ADA [ owners pledge: $(formatLovelace ${total_pledged}) | delegators: $(formatLovelace $((total_stake-total_pledged))) ]\n"
-    
-    if [[ ${total_pledged} -lt ${pledge} ]]; then
-      say "${ORANGE}WARN${NC}: Owners pledge does not cover registered pledge of $(formatLovelace ${pledge}) ADA\n"
-    fi
-    
-    printTable ';' "$(say 'Hex Key;Stake;Rewards' | cat - <(jq -r -c '.[] | "\(.hex_key);\(.stake);\(.rewards)"' <<< "${delegators_json}"))"
-    
-    waitForInput && continue
-
     ;; ###################################################################
 
     rotate)


### PR DESCRIPTION
##### Added
- Sanity check before launching a second instance of cnode.sh [eaa16f6]

##### Removed
- `Pool >> Delegators` removed. [closes #435]
  - If/when a better option than dumping and parsing ledger-state dump arise re-adding it will be considered.
  - Utilize the community explorers listed at https://cardano-community.github.io/support-faq/#/explorers

##### Fixed
- Block Collector script adapted for cardano-node 1.19.0.
  - Block hash is now truncated in the log, issue https://github.com/input-output-hk/cardano-node/issues/1738
- High CPU usage reported in a few cases when running Block Collector
  - Depending on log level, parsing, and byte64 enc each entry with jq could potentially put a high load on weaker systems. Replaced with grep to only parse entries containing specific traces.
- Docs for creating systemd block collector service file updated to include user env in run command