### PR TITLE
[CNTools] More robust cnode.sh socket check

### DIFF
--- a/scripts/cnode-helper-scripts/cnode.sh.templ
+++ b/scripts/cnode-helper-scripts/cnode.sh.templ
@@ -4,8 +4,13 @@
 [[ -z "$CNODE_HOME" ]] && CNODE_HOME="/opt/cardano/cnode"
 
 if [[ -S "$CNODE_HOME/sockets/node0.socket" ]]; then
-    echo "ERROR: A Cardano node is already running, please terminate this node before starting a new one with this script."
-    exit 1
+    if [ `ps -ef | grep -c [c]ardano-node` -gt 0 ]; then
+       echo "ERROR: A Cardano node is already running, please terminate this node before starting a new one with this script."
+       exit 1
+    else
+      echo "WARN: A prior running Cardano node was not cleanly shutdown, socket file still exists. Cleaning up."
+      unlink $CNODE_HOME/sockets/node0.socket
+    fi       
 fi
 
 [[ ! -d "$CNODE_HOME/logs/archive" ]] && mkdir -p "$CNODE_HOME/logs/archive"

--- a/scripts/cnode-helper-scripts/cnode.sh.templ
+++ b/scripts/cnode-helper-scripts/cnode.sh.templ
@@ -4,7 +4,7 @@
 [[ -z "$CNODE_HOME" ]] && CNODE_HOME="/opt/cardano/cnode"
 
 if [[ -S "$CNODE_HOME/sockets/node0.socket" ]]; then
-    if [ `lsof -Ua | grep -c $CNODE_HOME/sockets/node0.socket` -gt 0 ]; then
+    if [ `ps -ef | grep -c cardano-node.*.node0.socket` -gt 0 ]; then
        echo "ERROR: A Cardano node is already running, please terminate this node before starting a new one with this script."
        exit 1
     else

--- a/scripts/cnode-helper-scripts/cnode.sh.templ
+++ b/scripts/cnode-helper-scripts/cnode.sh.templ
@@ -4,7 +4,7 @@
 [[ -z "$CNODE_HOME" ]] && CNODE_HOME="/opt/cardano/cnode"
 
 if [[ -S "$CNODE_HOME/sockets/node0.socket" ]]; then
-    if [ `ps -ef | grep -c cardano-node.*.node0.socket` -gt 0 ]; then
+  if [ `ps -ef | grep -c cardano-node.*.$CNODE_HOME/sockets/node0.socket` -gt 0 ]; then
        echo "ERROR: A Cardano node is already running, please terminate this node before starting a new one with this script."
        exit 1
     else

--- a/scripts/cnode-helper-scripts/cnode.sh.templ
+++ b/scripts/cnode-helper-scripts/cnode.sh.templ
@@ -4,7 +4,7 @@
 [[ -z "$CNODE_HOME" ]] && CNODE_HOME="/opt/cardano/cnode"
 
 if [[ -S "$CNODE_HOME/sockets/node0.socket" ]]; then
-    if [ `ps -ef | grep -c [c]ardano-node` -gt 0 ]; then
+    if [ `lsof -Ua | grep -c $CNODE_HOME/sockets/node0.socket` -gt 0 ]; then
        echo "ERROR: A Cardano node is already running, please terminate this node before starting a new one with this script."
        exit 1
     else

--- a/scripts/cnode-helper-scripts/cnode.sh.templ
+++ b/scripts/cnode-helper-scripts/cnode.sh.templ
@@ -5,12 +5,12 @@
 
 if [[ -S "$CNODE_HOME/sockets/node0.socket" ]]; then
   if [ `ps -ef | grep -c cardano-node.*.$CNODE_HOME/sockets/node0.socket` -gt 0 ]; then
-       echo "ERROR: A Cardano node is already running, please terminate this node before starting a new one with this script."
-       exit 1
-    else
-      echo "WARN: A prior running Cardano node was not cleanly shutdown, socket file still exists. Cleaning up."
-      unlink $CNODE_HOME/sockets/node0.socket
-    fi       
+     echo "ERROR: A Cardano node is already running, please terminate this node before starting a new one with this script."
+     exit 1
+  else
+    echo "WARN: A prior running Cardano node was not cleanly shutdown, socket file still exists. Cleaning up."
+    unlink $CNODE_HOME/sockets/node0.socket
+  fi
 fi
 
 [[ ! -d "$CNODE_HOME/logs/archive" ]] && mkdir -p "$CNODE_HOME/logs/archive"


### PR DESCRIPTION
When a Cardano node was not cleanly shut down, so the socket file still exists, cnode.sh will now delete the socket file before starting the node provided there is no cardano-node process running.