### PR TITLE
Resume logrotate functionality

### DIFF
--- a/files/ptn0-combinator.json
+++ b/files/ptn0-combinator.json
@@ -48,7 +48,7 @@
   "defaultScribes": [
     [
       "FileSK",
-      "/opt/cardano/cnode/logs/node-0.json"
+      "/opt/cardano/cnode/logs/node0.json"
     ]
   ],
   "hasEKG": 12788,
@@ -166,7 +166,7 @@
   "setupScribes": [
     {
       "scKind": "FileSK",
-      "scName": "/opt/cardano/cnode/logs/node-0.json",
+      "scName": "/opt/cardano/cnode/logs/node0.json",
       "scFormat": "ScJson",
       "scRotation": null
     }

--- a/files/ptn0-mainnet.json
+++ b/files/ptn0-mainnet.json
@@ -46,7 +46,7 @@
   "defaultScribes": [
     [
       "FileSK",
-      "/opt/cardano/cnode/logs/node-0.json"
+      "/opt/cardano/cnode/logs/node0.json"
     ]
   ],
   "hasEKG": 12788,
@@ -164,7 +164,7 @@
   "setupScribes": [
     {
       "scKind": "FileSK",
-      "scName": "/opt/cardano/cnode/logs/node-0.json",
+      "scName": "/opt/cardano/cnode/logs/node0.json",
       "scFormat": "ScJson",
       "scRotation": null
     }

--- a/files/ptn0-praos.json
+++ b/files/ptn0-praos.json
@@ -43,7 +43,7 @@
   "defaultScribes": [
     [
       "FileSK",
-      "/opt/cardano/cnode/logs/node-0.json"
+      "/opt/cardano/cnode/logs/node0.json"
     ]
   ],
   "hasEKG": 12788,
@@ -161,7 +161,7 @@
   "setupScribes": [
     {
       "scKind": "FileSK",
-      "scName": "/opt/cardano/cnode/logs/node-0.json",
+      "scName": "/opt/cardano/cnode/logs/node0.json",
       "scFormat": "ScJson",
       "scRotation": null
     }


### PR DESCRIPTION
Closes #446 

Turns out node logging breaks for deleting old files because it uses hyphen as seperator to split filename with timestamp. Thus, remove the additional hyphen from config file templates, to allow log rotate functionality to work correctly.