### PR TITLE
Prereqs update - closes #474 and #475

### DIFF
--- a/docs/Build/graphql.md
+++ b/docs/Build/graphql.md
@@ -1,4 +1,4 @@
-!> - An average pool operator may not require cardano-wallet at all. Please verify if it is required for your use as mentioned [here](build.md#components)
+!> We have temporarily disabled updating build documentation for Cardano-GraphQL. The specific component does not follow the process/technology/language (requires npm, yarn) used by other components (cabal/stack), and the value provided by `cardano-graphql` over the (haskell-based) hasura instance has been negligible. Also, an average pool operator may not require cardano-graphql at all, please verify if it is required for your use as mentioned [here](build.md#components). The instructions below are `out of date`.
 
 > Ensure the [Pre-Requisites](basics.md#pre-requisites) are in place before you proceed.
 

--- a/docs/Build/node-cli.md
+++ b/docs/Build/node-cli.md
@@ -44,7 +44,22 @@ cardano-node version
 # git rev 4814003f14340d5a1fc02f3ac15437387a7ada9f
 ```
 
-##### Start a passive node
+##### Update port number or pool name for relative paths
+
+Before you go ahead with starting your node, you may want to update values for CNODE_PORT in `$CNODE_HOME/scripts/cnode.sh`. Note that it is imperative for operational relays and pools to ensure that the port mentioned is opened via firewall to the destination your node is supposed to connect from. Update your network/firewall configuration accordingly. Future executions of prereqs.sh will preserve and not overwrite these values.
+
+```bash
+## Static (content that will not be overwritten by prereqs.sh)
+## Begin
+
+POOL_NAME="GUILD"
+CNODE_PORT=6000
+POOL_DIR="$CNODE_HOME/priv/pool/$POOL_NAME"
+```
+
+> POOL_NAME is the name of folder that you will use when registering pools and starting node in core mode. This folder would typically contain your `hot.skey`,`vrf.skey` and `op.cert` files required. If the mentioned files are absent, the node will automatically start in a passive mode.
+
+##### Start the node
 
 To test starting the node in interactive mode, you can use the pre-built script below (note that the config now uses `SimpleView` so you may not see much output):
 

--- a/scripts/cnode-helper-scripts/cnode.sh.templ
+++ b/scripts/cnode-helper-scripts/cnode.sh.templ
@@ -17,12 +17,33 @@ fi
 
 [[ ! -d "$CNODE_HOME/logs/archive" ]] && mkdir -p "$CNODE_HOME/logs/archive"
 
-[[ $(find "$CNODE_HOME"/logs/*.json | wc -l) -gt 0 ]] && mv $CNODE_HOME/logs/*.json $CNODE_HOME/logs/archive/
+[[ $(find "$CNODE_HOME"/logs/*.json 2>/dev/null | wc -l) -gt 0 ]] && mv $CNODE_HOME/logs/*.json $CNODE_HOME/logs/archive/
 
-cardano-node run \
+## Static - Begin (not overwritten by prereqs.sh)
+
+POOL_NAME="TEST"
+CNODE_PORT=6000
+POOL_DIR="$CNODE_HOME/priv/pool/$POOL_NAME"
+
+if [[ -f "$POOL_DIR/op.cert" && -f "$POOL_DIR/vrf.skey" && -f "$POOL_DIR/hot.skey" ]]; then
+  echo cardano-node run \
 	--topology $CNODE_HOME/files/topology.json \
 	--config $CNODE_HOME/files/config.json \
 	--database-path $CNODE_HOME/db \
 	--socket-path $CNODE_HOME/sockets/node0.socket \
 	--host-addr 0.0.0.0 \
-	--port 6000
+        --shelley-kes-key $POOL_DIR/hot.skey \
+        --shelley-vrf-key $POOL_DIR/vrf.skey \
+        --shelley-operational-certificate $POOL_DIR/op.cert \
+	--port $CNODE_PORT
+else
+  echo cardano-node run \
+        --topology $CNODE_HOME/files/topology.json \
+        --config $CNODE_HOME/files/config.json \
+        --database-path $CNODE_HOME/db \
+        --socket-path $CNODE_HOME/sockets/node0.socket \
+        --host-addr 0.0.0.0 \
+        --port $CNODE_PORT
+fi
+
+## Static - End

--- a/scripts/cnode-helper-scripts/cnode.sh.templ
+++ b/scripts/cnode-helper-scripts/cnode.sh.templ
@@ -19,14 +19,15 @@ fi
 
 [[ $(find "$CNODE_HOME"/logs/*.json 2>/dev/null | wc -l) -gt 0 ]] && mv $CNODE_HOME/logs/*.json $CNODE_HOME/logs/archive/
 
-## Static - Begin (not overwritten by prereqs.sh)
+## Static (content that will not be overwritten by prereqs.sh)
+## Begin
 
 POOL_NAME="TEST"
 CNODE_PORT=6000
 POOL_DIR="$CNODE_HOME/priv/pool/$POOL_NAME"
 
 if [[ -f "$POOL_DIR/op.cert" && -f "$POOL_DIR/vrf.skey" && -f "$POOL_DIR/hot.skey" ]]; then
-  echo cardano-node run \
+  cardano-node run \
 	--topology $CNODE_HOME/files/topology.json \
 	--config $CNODE_HOME/files/config.json \
 	--database-path $CNODE_HOME/db \
@@ -37,7 +38,7 @@ if [[ -f "$POOL_DIR/op.cert" && -f "$POOL_DIR/vrf.skey" && -f "$POOL_DIR/hot.ske
         --shelley-operational-certificate $POOL_DIR/op.cert \
 	--port $CNODE_PORT
 else
-  echo cardano-node run \
+  cardano-node run \
         --topology $CNODE_HOME/files/topology.json \
         --config $CNODE_HOME/files/config.json \
         --database-path $CNODE_HOME/db \
@@ -46,4 +47,4 @@ else
         --port $CNODE_PORT
 fi
 
-## Static - End
+## End

--- a/scripts/cnode-helper-scripts/prereqs.sh
+++ b/scripts/cnode-helper-scripts/prereqs.sh
@@ -33,7 +33,7 @@ usage() {
 Usage: $(basename "$0") [-o] [-s] [-i] [-g] [-p]
 Install pre-requisites for building cardano node and using cntools
 
--o    Do *NOT* overwrite existing cnode.sh, genesis.json, topology.json and topology-updater.sh files (Default: will overwrite)
+-o    Do *NOT* overwrite existing genesis.json, topology.json and topology-updater.sh files (Default: will overwrite)
 -s    Skip installing OS level dependencies (Default: will check and install any missing OS level prerequisites)
 -i    Interactive mode (Default: silent mode)
 -g    Connect to guild network instead of public network (Default: connect to public cardano network)
@@ -112,7 +112,7 @@ if [ "$WANT_BUILD_DEPS" = 'Y' ]; then
   OS_ID=$(grep -i ^id_like= /etc/os-release | cut -d= -f 2)
   DISTRO=$(grep -i ^NAME= /etc/os-release | cut -d= -f 2)
 
-  if [[ "${OS_ID}" =~ "ebian" ]]; then
+  if [[ "${OS_ID}" =~ ebian ]]; then
     #Debian/Ubuntu
     echo "Using apt to prepare packages for ${DISTRO} system"
     echo "  Updating system packages..."
@@ -127,7 +127,7 @@ if [ "$WANT_BUILD_DEPS" = 'Y' ]; then
       echo "It would be best if you could submit an issue at https://github.com/cardano-community/guild-operators with the details to tackle in future, as some errors may be due to external/already present dependencies"
       exit;
     fi
-  elif [[ "${OS_ID}" =~ "rhel" ]] || [[ "${DISTRO}" =~ "Fedora" ]]; then
+  elif [[ "${OS_ID}" =~ rhel ]] || [[ "${DISTRO}" =~ Fedora ]]; then
     #CentOS/RHEL/Fedora
     echo "Using yum to prepare packages for ${DISTRO} system"
     echo "  Updating system packages..."
@@ -135,7 +135,7 @@ if [ "$WANT_BUILD_DEPS" = 'Y' ]; then
     $sudo yum -y update > /dev/null
     echo "  Installing missing prerequisite packages, if any.."
     pkg_list="python3 coreutils pkgconfig libffi-devel gmp-devel openssl-devel ncurses-libs ncurses-compat-libs systemd systemd-devel libsodium-devel zlib-devel make gcc-c++ tmux git wget jq gnupg libtool autoconf srm iproute bc tcptraceroute"
-    [[ ! "${DISTRO}" =~ "Fedora" ]] && pkg_list="epel-release $pkg_list"
+    [[ ! "${DISTRO}" =~ Fedora ]] && pkg_list="epel-release $pkg_list"
     $sudo yum -y install ${pkg_list} > /dev/null;rc=$?
     if [ $rc != 0 ]; then
       echo "An error occurred while installing the prerequisite packages, please investigate by using the command below:"
@@ -227,6 +227,7 @@ if [[ "$GUILD" = "Y" ]]; then
 else
   curl -sL -o byron-genesis.json ${OVERWRITE} https://hydra.iohk.io/job/Cardano/iohk-nix/cardano-deployment/latest-finished/download/1/mainnet-byron-genesis.json
   curl -sL -o genesis.json ${OVERWRITE} https://hydra.iohk.io/job/Cardano/iohk-nix/cardano-deployment/latest-finished/download/1/mainnet-shelley-genesis.json
+  cp topology.json "topology.json_bkp$(date +%s)"
   curl -sL -o topology.json ${OVERWRITE} https://hydra.iohk.io/job/Cardano/iohk-nix/cardano-deployment/latest-finished/download/1/mainnet-topology.json
 fi
 
@@ -245,12 +246,13 @@ curl -s -o createAddr.sh https://raw.githubusercontent.com/cardano-community/gui
 curl -s -o sendADA.sh https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/sendADA.sh
 curl -s -o balance.sh https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/balance.sh
 curl -s -o rotatePoolKeys.sh https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/rotatePoolKeys.sh
-curl -s -o cnode.sh ${OVERWRITE} https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/cnode.sh.templ
+curl -s -o cnode.sh.templ https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/cnode.sh.templ
 curl -s -o cntools.sh https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/cntools.sh
 curl -s -o cntools.config https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/cntools.config
 curl -s -o cntools.library https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/cntools.library
 curl -s -o cntoolsBlockCollector.sh https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/cntoolsBlockCollector.sh
 curl -s -o setup_mon.sh https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/setup_mon.sh
+cp topologyUpdater.sh "topologyUpdater.sh_bkp$(date +%s)"
 curl -s -o topologyUpdater.sh ${OVERWRITE} https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/topologyUpdater.sh
 curl -s -o itnRewards.sh https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/itnRewards.sh
 curl -s -o cabal-build-all.sh https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/cabal-build-all.sh
@@ -261,5 +263,19 @@ curl -s -o gLiveView.sh https://raw.githubusercontent.com/cardano-community/guil
 curl -s -o deploy-as-systemd.sh https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/deploy-as-systemd.sh
 sed -e "s@SyslogIdentifier=.*@SyslogIdentifier=${CNODE_NAME}@g" -e "s@cnode.service@${CNODE_NAME}.service@g" -i deploy-as-systemd.sh
 sed -e "s@CNODE_HOME=.*@${CNODE_VNAME}_HOME=${CNODE_HOME}@g" -e "s@CNODE_HOME@${CNODE_VNAME}_HOME@g" -i ./*.*
+
+### Update cnode.sh retaining existing custom configs
+if grep '## Static' cnode.sh >/dev/null 2>&1; then
+  TEMPL_CMD=$(awk '/#!/,/## Static/' cnode.sh.templ)
+  STATIC_CMD=$(awk '/## Begin/,/## End/' cnode.sh)
+  printf '%s\n%s\n' "$TEMPL_CMD" "$STATIC_CMD" > cnode.sh
+elif grep 'cardano-node' cnode.sh >/dev/null 2>&1;then
+  cp cnode.sh "cnode.sh.bkp_$(date +%s)"
+  cp -f cnode.sh.templ cnode.sh
+  echo "One-time upgrade! Please edit ${CNODE_HOME}/scripts/cnode.sh for values against POOL_NAME and CNODE_PORT variables"
+else
+  cp -f cnode.sh.templ cnode.sh
+fi
 chmod 755 ./*.sh
+
 cd - || return

--- a/scripts/cnode-helper-scripts/prereqs.sh
+++ b/scripts/cnode-helper-scripts/prereqs.sh
@@ -112,7 +112,7 @@ if [ "$WANT_BUILD_DEPS" = 'Y' ]; then
   OS_ID=$(grep -i ^id_like= /etc/os-release | cut -d= -f 2)
   DISTRO=$(grep -i ^NAME= /etc/os-release | cut -d= -f 2)
 
-  if [ -z "${OS_ID##*debian*}" ]; then
+  if [[ "${OS_ID}" =~ "ebian" ]]; then
     #Debian/Ubuntu
     echo "Using apt to prepare packages for ${DISTRO} system"
     echo "  Updating system packages..."
@@ -127,7 +127,7 @@ if [ "$WANT_BUILD_DEPS" = 'Y' ]; then
       echo "It would be best if you could submit an issue at https://github.com/cardano-community/guild-operators with the details to tackle in future, as some errors may be due to external/already present dependencies"
       exit;
     fi
-  elif [ -z "${OS_ID##*rhel*}" ] || [[ "${DISTRO}" =~ "Fedora" ]]; then
+  elif [[ "${OS_ID}" =~ "rhel" ]] || [[ "${DISTRO}" =~ "Fedora" ]]; then
     #CentOS/RHEL/Fedora
     echo "Using yum to prepare packages for ${DISTRO} system"
     echo "  Updating system packages..."

--- a/scripts/cnode-helper-scripts/prereqs.sh
+++ b/scripts/cnode-helper-scripts/prereqs.sh
@@ -227,7 +227,7 @@ if [[ "$GUILD" = "Y" ]]; then
 else
   curl -sL -o byron-genesis.json ${OVERWRITE} https://hydra.iohk.io/job/Cardano/iohk-nix/cardano-deployment/latest-finished/download/1/mainnet-byron-genesis.json
   curl -sL -o genesis.json ${OVERWRITE} https://hydra.iohk.io/job/Cardano/iohk-nix/cardano-deployment/latest-finished/download/1/mainnet-shelley-genesis.json
-  cp topology.json "topology.json_bkp$(date +%s)"
+  [[ -f topology.json ]] && cp topology.json "topology.json_bkp$(date +%s)"
   curl -sL -o topology.json ${OVERWRITE} https://hydra.iohk.io/job/Cardano/iohk-nix/cardano-deployment/latest-finished/download/1/mainnet-topology.json
 fi
 
@@ -252,7 +252,7 @@ curl -s -o cntools.config https://raw.githubusercontent.com/cardano-community/gu
 curl -s -o cntools.library https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/cntools.library
 curl -s -o cntoolsBlockCollector.sh https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/cntoolsBlockCollector.sh
 curl -s -o setup_mon.sh https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/setup_mon.sh
-cp topologyUpdater.sh "topologyUpdater.sh_bkp$(date +%s)"
+[[ -f topologyUpdater.sh ]] && cp topologyUpdater.sh "topologyUpdater.sh_bkp$(date +%s)"
 curl -s -o topologyUpdater.sh ${OVERWRITE} https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/topologyUpdater.sh
 curl -s -o itnRewards.sh https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/itnRewards.sh
 curl -s -o cabal-build-all.sh https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/cabal-build-all.sh

--- a/scripts/cnode-helper-scripts/prereqs.sh
+++ b/scripts/cnode-helper-scripts/prereqs.sh
@@ -127,7 +127,7 @@ if [ "$WANT_BUILD_DEPS" = 'Y' ]; then
       echo "It would be best if you could submit an issue at https://github.com/cardano-community/guild-operators with the details to tackle in future, as some errors may be due to external/already present dependencies"
       exit;
     fi
-  elif [ -z "${OS_ID##*rhel*}" ] || [[ "${DISTRO}" == *Fedora* ]]; then
+  elif [ -z "${OS_ID##*rhel*}" ] || [[ "${DISTRO}" =~ "Fedora" ]]; then
     #CentOS/RHEL/Fedora
     echo "Using yum to prepare packages for ${DISTRO} system"
     echo "  Updating system packages..."
@@ -135,7 +135,7 @@ if [ "$WANT_BUILD_DEPS" = 'Y' ]; then
     $sudo yum -y update > /dev/null
     echo "  Installing missing prerequisite packages, if any.."
     pkg_list="python3 coreutils pkgconfig libffi-devel gmp-devel openssl-devel ncurses-libs ncurses-compat-libs systemd systemd-devel libsodium-devel zlib-devel make gcc-c++ tmux git wget jq gnupg libtool autoconf srm iproute bc tcptraceroute"
-    [[ ! "${DISTRO}" == *Fedora* ]] && pkg_list="epel-release $pkg_list"
+    [[ ! "${DISTRO}" =~ "Fedora" ]] && pkg_list="epel-release $pkg_list"
     $sudo yum -y install ${pkg_list} > /dev/null;rc=$?
     if [ $rc != 0 ]; then
       echo "An error occurred while installing the prerequisite packages, please investigate by using the command below:"

--- a/scripts/cnode-helper-scripts/prereqs.sh
+++ b/scripts/cnode-helper-scripts/prereqs.sh
@@ -117,30 +117,25 @@ if [ "$WANT_BUILD_DEPS" = 'Y' ]; then
     echo "Using apt to prepare packages for ${DISTRO} system"
     echo "  Updating system packages..."
     $sudo apt-get -y install curl > /dev/null
-    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | $sudo apt-key add - > /dev/null
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | $sudo tee /etc/apt/sources.list.d/yarn.list > /dev/null
     $sudo apt-get -y update > /dev/null
     echo "  Installing missing prerequisite packages, if any.."
-    pkg_list="libpq-dev python3 build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev systemd libsystemd-dev libsodium-dev zlib1g-dev yarn make g++ tmux git jq wget libncursesw5 gnupg aptitude libtool autoconf secure-delete iproute2 bc tcptraceroute"
+    pkg_list="libpq-dev python3 build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev systemd libsystemd-dev libsodium-dev zlib1g-dev make g++ tmux git jq wget libncursesw5 gnupg aptitude libtool autoconf secure-delete iproute2 bc tcptraceroute"
     $sudo apt-get -y install ${pkg_list} > /dev/null;rc=$?
     if [ $rc != 0 ]; then
       echo "An error occurred while installing the prerequisite packages, please investigate by using the command below:"
       echo "sudo apt-get -y install ${pkg_list}"
       echo "It would be best if you could submit an issue at https://github.com/cardano-community/guild-operators with the details to tackle in future, as some errors may be due to external/already present dependencies"
       exit;
-    else
-      $sudo aptitude install npm -yq > /dev/null
     fi
-  elif [ -z "${OS_ID##*rhel*}" ]; then
+  elif [ -z "${OS_ID##*rhel*}" ] || [[ "${DISTRO}" == *Fedora* ]]; then
     #CentOS/RHEL/Fedora
     echo "Using yum to prepare packages for ${DISTRO} system"
     echo "  Updating system packages..."
     $sudo yum -y install curl > /dev/null
-    curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | $sudo tee /etc/yum.repos.d/yarn.repo > /dev/null
-    $sudo rpm --import https://dl.yarnpkg.com/rpm/pubkey.gpg > /dev/null
     $sudo yum -y update > /dev/null
     echo "  Installing missing prerequisite packages, if any.."
-    pkg_list="python3 coreutils pkgconfig libffi-devel gmp-devel openssl-devel ncurses-libs ncurses-compat-libs systemd systemd-devel libsodium-devel zlib-devel npm yarn make gcc-c++ tmux git wget epel-release jq gnupg libtool autoconf srm iproute bc tcptraceroute"
+    pkg_list="python3 coreutils pkgconfig libffi-devel gmp-devel openssl-devel ncurses-libs ncurses-compat-libs systemd systemd-devel libsodium-devel zlib-devel make gcc-c++ tmux git wget jq gnupg libtool autoconf srm iproute bc tcptraceroute"
+    [[ ! "${DISTRO}" == *Fedora* ]] && pkg_list="epel-release $pkg_list"
     $sudo yum -y install ${pkg_list} > /dev/null;rc=$?
     if [ $rc != 0 ]; then
       echo "An error occurred while installing the prerequisite packages, please investigate by using the command below:"


### PR DESCRIPTION
- Add special case for Fedora in pre-requisites
- Eliminate GraphQL dependencies from common pre-requisites , as it's an "odd-man-out" (does not follow rest of the components , besides feels forced usage of node for a very minimalistic outcome).
- Take backup before overwriting `topology.json`, `topologyUpdater.sh` and handle `cnode.sh` in a way that it can preserve port as well as information to start node as core (path to keys) v/s relay.