### PR TITLE
Revert change to cnode.sh

### DIFF
--- a/scripts/cnode-helper-scripts/cnode.sh.templ
+++ b/scripts/cnode-helper-scripts/cnode.sh.templ
@@ -1,6 +1,8 @@
 #!/bin/bash
 # shellcheck disable=SC2086
 
+[[ -z "$CNODE_HOME" ]] && CNODE_HOME="/opt/cardano/cnode"
+
 . "${CNODE_HOME}"/scripts/env
 
 [[ -z "$CNODE_HOME" ]] && CNODE_HOME="/opt/cardano/cnode"

--- a/scripts/cnode-helper-scripts/cnode.sh.templ
+++ b/scripts/cnode-helper-scripts/cnode.sh.templ
@@ -5,8 +5,6 @@
 
 . "${CNODE_HOME}"/scripts/env
 
-[[ -z "$CNODE_HOME" ]] && CNODE_HOME="/opt/cardano/cnode"
-
 if [[ -S "$CNODE_HOME/sockets/node0.socket" ]]; then
   if [ `ps -ef | grep -c [c]ardano-node.*.$CNODE_HOME/sockets/node0.socket` -gt 0 ]; then
      echo "ERROR: A Cardano node is already running, please terminate this node before starting a new one with this script."


### PR DESCRIPTION
We possibly missed why the order was changed in the first place.

If deploying as systemd, the env vars wont be resolved, and so the env file wouldnt be called either.

If customised is needed, it would CNODE_HOME variable's value changed when installing via `prereqs` or by hand.