### PR TITLE
Closes #504; Add cardano-address and bech32 to build process

### DIFF
--- a/docs/Build/node-cli.md
+++ b/docs/Build/node-cli.md
@@ -22,11 +22,8 @@ git fetch --tags --all
 git pull
 git checkout 1.19.0
 
-echo -e "package cardano-crypto-praos\n  flags: -external-libsodium-vrf" > cabal.project.local
-# On CentOS 7 (GCC 4.8.5) we should also do
-# echo -e "package cryptonite\n  flags: -use_target_attributes" >> cabal.project.local
-
-$CNODE_HOME/scripts/cabal-build-all.sh
+# The "-o" flag against script below will download cabal.project.local to depend on system libSodium package, and include cardano-address and bech32 binaries to your build
+$CNODE_HOME/scripts/cabal-build-all.sh -o
 ```
 
 The above would copy the binaries built into `~/.cabal/bin` folder.

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -6,7 +6,9 @@ The architecture and description of various components are best described at [Ad
 
 ##### Set up OS packages, folder structure and fetch files from repo
 
-The pre-requisites for Linux systems are automated to be executed as a single script. Note that the guide assumes you do *NOT* change working directory or mix multiple SSH sessions. Follow the instructions below to deploy the same:
+!> You're expected to run the commands below from same session, using same working directories as indicated and using a non-root user with passwordless sudo access. You'd be expected to be familiar with this as part of pre-requisite skillsets expected off a stake pool operator.
+
+The pre-requisites for Linux systems are automated to be executed as a single script. Follow the instructions below to deploy the same:
 
 ``` bash
 mkdir "$HOME/tmp";cd "$HOME/tmp"

--- a/files/cabal.project.local
+++ b/files/cabal.project.local
@@ -1,0 +1,20 @@
+package cardano-crypto-praos
+  flags: -external-libsodium-vrf
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/bech32
+  tag: v1.1.0
+  subdir: bech32
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-addresses
+  tag: 2.0.0
+  subdir: core
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-addresses
+  tag: 2.0.0
+  subdir: command-line

--- a/scripts/cnode-helper-scripts/cabal-build-all.sh
+++ b/scripts/cnode-helper-scripts/cabal-build-all.sh
@@ -3,14 +3,23 @@
 # executes cabal build all
 # parses executables created from compiler output and copies it to ~./cabal/bin folder.
 
-echo "Deleting build config artifact to remove cached version, this prevents invalid Git Rev"
-[[ -d "dist-newstyle/build/x86_64-linux/ghc-8.6.5/cardano-config-0.1.0.0" ]] && rm -rf "dist-newstyle/build/x86_64-linux/ghc-8.6.5/cardano-config-0.1.0.0"
+OVERWRITE_LOCAL="N"
+
+[[ "$1" == "-o" ]] && OVERWRITE_LOCAL="Y"
+
+if [[ "${PWD##*/}" == "cardano-node" ]] && [[ "${OVERWRITE_LOCAL}" == "Y" ]]; then
+  echo "Overwriting cabal.project.local with latest file from guild-repo (previous file, if any, will be saved as cabal.project.local.swp).."
+  [[ -f cabal.project.local ]] && mv cabal.project.local cabal.project.local.swp
+  curl -s -o cabal.project.local -C - https://raw.githubusercontent.com/cardano-community/guild-operators/master/files/cabal.project.local
+  chmod 640 cabal.project.local
+fi
+
 echo "Running cabal update to ensure you're on latest dependencies.."
 cabal update 2>&1 | tee /tmp/cabal-build.log
 echo "Building.."
 cabal build all 2>&1 | tee /tmp/build.log
 
-grep "^Linking" /tmp/build.log | while read -r line ; do
+grep "^Linking" /tmp/build.log | grep -Ev 'test|golden|demo' | while read -r line ; do
     act_bin_path=$(echo "$line" | awk '{print $2}')
     act_bin=$(echo "$act_bin_path" | awk -F "/" '{print $NF}')
     echo "Copying $act_bin to $HOME/.cabal/bin/"


### PR DESCRIPTION
Update cabal-build-all.sh script to include latest cabal.project.local from guild repo (it is to ensure that we can maintain updated tags for cardano-address and bech32 binaries without impacting user steps), and add an overwrite flag to only overwrite cabal.project.local if specified.
The change only occurs if current folder is named `cardano-node` . Thus, it should match git repo being node one when following guild repo instructions.