### PR TITLE
Add CCLI dirname to PATH even if CCLI found

### DIFF
--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -35,7 +35,7 @@ if [[ -z "${CCLI}" ]]; then
   fi
 else
   PARENT="$(dirname ${CCLI})"
-  export PATH="{PARENT}":$PATH
+  export PATH="${PARENT}":$PATH
 fi
 
 [[ -z "${CNODE_HOME}" ]] && CNODE_HOME=/opt/cardano/cnode

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -34,7 +34,8 @@ if [[ -z "${CCLI}" ]]; then
     return 1
   fi
 else
-  export PATH="$(dirname ${CCLI})":$PATH
+  PARENT="$(dirname ${CCLI})"
+  export PATH="{PARENT}":$PATH
 fi
 
 [[ -z "${CNODE_HOME}" ]] && CNODE_HOME=/opt/cardano/cnode

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -33,6 +33,8 @@ if [[ -z "${CCLI}" ]]; then
     echo "You do not have a cardano-cli binary available in \$PATH."
     return 1
   fi
+else
+  export PATH="$(dirname ${CCLI})":$PATH
 fi
 
 [[ -z "${CNODE_HOME}" ]] && CNODE_HOME=/opt/cardano/cnode


### PR DESCRIPTION
To ensure cardano-node binary is available in $PATH when specifying custom CCLI