### PR TITLE
add cncli installation and run script

### DIFF
--- a/scripts/cnode-helper-scripts/cncli-install.sh
+++ b/scripts/cnode-helper-scripts/cncli-install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+#shellcheck source=/dev/null
 
 dirs -c
 
@@ -12,8 +13,8 @@ else
   rustup update &>/dev/null #ignore any errors, not crucial that update succeed
 fi
 
-[[ -d ${HOME}/git ]] || mkdir -p ${HOME}/git
-pushd ${HOME}/git >/dev/null || exit 1
+[[ -d "${HOME}"/git ]] || mkdir -p "${HOME}"/git
+pushd "${HOME}"/git >/dev/null || exit 1
 
 if [[ -d ./cncli ]]; then
   echo "previous cncli installation found, updating and building latest..."
@@ -26,13 +27,13 @@ else
 fi
 if ! output=$(cargo install --path . --force 2>&1); then echo -e "${output}" && exit 1; fi
 
-. ${HOME}/.profile # source profile to load ${HOME}/.cargo/bin into PATH
+. "${HOME}"/.profile # source profile to load ${HOME}/.cargo/bin into PATH
 
 pushd -0 >/dev/null && dirs -c
 
-PARENT="$(dirname $0)"
+PARENT="$(dirname "$0")"
 if [[ $(grep "_HOME=" "${PARENT}"/env) =~ ^#?([^[:space:]]+)_HOME ]]; then
-  vname=$(tr '[:upper:]' '[:lower:]' <<< ${BASH_REMATCH[1]})
+  vname=$(tr '[:upper:]' '[:lower:]' <<< "${BASH_REMATCH[1]}")
 else
   echo "failed to get cnode instance name from env file, aborting!"
   exit 1
@@ -71,6 +72,6 @@ else
 fi
 
 sudo systemctl daemon-reload
-sudo systemctl enable ${vname}-cncli.service &>/dev/null
+sudo systemctl enable "${vname}"-cncli.service &>/dev/null
 
 echo -e "\n$(cncli -V) installed!"

--- a/scripts/cnode-helper-scripts/cncli-install.sh
+++ b/scripts/cnode-helper-scripts/cncli-install.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+dirs -c
+
+echo "~ Installing CNCLI with dependencies ~"
+# install rust if not available
+if ! command -v "rustup" &>/dev/null; then
+  echo "installing RUST..."
+  if ! output=$(curl https://sh.rustup.rs -sSf | sh -s -- -y 2>&1); then echo -e "${output}" && exit 1; fi
+else
+  echo "updating rustup if needed..."
+  rustup update &>/dev/null #ignore any errors, not crucial that update succeed
+fi
+
+[[ -d ${HOME}/git ]] || mkdir -p ${HOME}/git
+pushd ${HOME}/git >/dev/null || exit 1
+
+if [[ -d ./cncli ]]; then
+  echo "previous cncli installation found, updating and building latest..."
+  pushd ./cncli >/dev/null || exit 1
+  if ! output=$(git pull 2>&1); then echo -e "${output}" && exit 1; fi
+else
+  echo "downloading and building cncli..."
+  if ! output=$(git clone https://github.com/AndrewWestberg/cncli.git 2>&1); then echo -e "${output}" && exit 1; fi
+  pushd ./cncli >/dev/null || exit 1
+fi
+if ! output=$(cargo install --path . --force 2>&1); then echo -e "${output}" && exit 1; fi
+
+. ${HOME}/.profile # source profile to load ${HOME}/.cargo/bin into PATH
+
+pushd -0 >/dev/null && dirs -c
+
+PARENT="$(dirname $0)"
+if [[ $(grep "_HOME=" "${PARENT}"/env) =~ ^#?([^[:space:]]+)_HOME ]]; then
+  vname=$(tr '[:upper:]' '[:lower:]' <<< ${BASH_REMATCH[1]})
+else
+  echo "failed to get cnode instance name from env file, aborting!"
+  exit 1
+fi
+
+if [[ ! -f "/etc/systemd/system/${vname}-cncli.service" ]]; then
+  echo "deploying systemd ${vname}-cncli.service file"
+  sudo bash -c "cat << 'EOF' > /etc/systemd/system/${vname}-cncli.service
+[Unit]
+Description=Cardano Node - CNCLI
+Requires=${vname}.service
+After=${vname}.service
+
+[Service]
+Type=simple
+Restart=on-failure
+RestartSec=5
+User=$USER
+LimitNOFILE=1048576
+WorkingDirectory=${CNODE_HOME}/scripts
+ExecStart=/bin/bash -l -c \"exec ${CNODE_HOME}/scripts/cncli.sh\"
+ExecStop=/bin/bash -l -c \"exec kill -2 \$(ps -ef | grep [c]ncli.*.${CNODE_HOME}/ | tr -s ' ' | cut -d ' ' -f2)\"
+KillSignal=SIGINT
+SuccessExitStatus=143
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=${vname}-cncli
+TimeoutStopSec=5
+KillMode=mixed
+
+[Install]
+WantedBy=multi-user.target
+EOF"
+else
+  echo "${vname}-cncli.service already deployed, skipping!"
+fi
+
+sudo systemctl daemon-reload
+sudo systemctl enable ${vname}-cncli.service &>/dev/null
+
+echo -e "\n$(cncli -V) installed!"

--- a/scripts/cnode-helper-scripts/cncli.sh
+++ b/scripts/cnode-helper-scripts/cncli.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#shellcheck disable=SC2086
 #shellcheck source=/dev/null
 
 [[ -z "${CNODE_HOME}" ]] && CNODE_HOME="/opt/cardano/cnode"
@@ -19,6 +18,6 @@
 
 [[ -z "${CNCLI_DB}" ]] && CNCLI_DB="${CNODE_HOME}/db/cncli"
 
-[[ ! -f ${CNCLI} ]] && echo "failed to locate cncli executable, please update to latest env file and run install-cncli.sh!" && exit 1
+[[ ! -f "${CNCLI}" ]] && echo "failed to locate cncli executable, please update to latest env file and run install-cncli.sh!" && exit 1
 
-${CNCLI} sync --host 127.0.0.1 --network-magic ${NWMAGIC} --port ${CNODE_PORT} --db "${CNCLI_DB}"
+${CNCLI} sync --host 127.0.0.1 --network-magic "${NWMAGIC}" --port "${CNODE_PORT}" --db "${CNCLI_DB}"

--- a/scripts/cnode-helper-scripts/cncli.sh
+++ b/scripts/cnode-helper-scripts/cncli.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#shellcheck disable=SC2086
+#shellcheck source=/dev/null
+
+[[ -z "${CNODE_HOME}" ]] && CNODE_HOME="/opt/cardano/cnode"
+
+. "${CNODE_HOME}"/scripts/env
+
+######################################
+# User Variables - Change as desired #
+# Common variables set in env file   #
+######################################
+
+#CNCLI_DB="${CNODE_HOME}/db/cncli"        # path to sqlite db for cncli
+
+######################################
+# Do NOT modify code below           #
+######################################
+
+[[ -z "${CNCLI_DB}" ]] && CNCLI_DB="${CNODE_HOME}/db/cncli"
+
+[[ ! -f ${CNCLI} ]] && echo "failed to locate cncli executable, please update to latest env file and run install-cncli.sh!" && exit 1
+
+${CNCLI} sync --host 127.0.0.1 --network-magic ${NWMAGIC} --port ${CNODE_PORT} --db "${CNCLI_DB}"

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -37,8 +37,8 @@ if [[ -z "${CCLI}" ]]; then
     return 1
   fi
 else
-  PARENT="$(dirname ${CCLI})"
-  export PATH="${PARENT}":$PATH
+  CCLI_PARENT="$(dirname ${CCLI})"
+  export PATH="${CCLI_PARENT}":$PATH
 fi
 
 if [[ -z "${CNCLI}" ]]; then

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -7,6 +7,7 @@
 ######################################
 
 #CCLI="${HOME}/.cabal/bin/cardano-cli"                  # Override automatic detection of path to cardano-cli executable
+#CNCLI="${HOME}/.cargo/bin/cncli"                       # Override automatic detection of path to cncli executable (https://github.com/AndrewWestberg/cncli)
 #CNODE_HOME="/opt/cardano/cnode"                        # Override default CNODE_HOME path (defaults to /opt/cardano/cnode)
 CNODE_PORT=6000                                         # Set node port
 #CONFIG="${CNODE_HOME}/files/config.json"               # Override automatic detection of node config path
@@ -38,6 +39,10 @@ if [[ -z "${CCLI}" ]]; then
 else
   PARENT="$(dirname ${CCLI})"
   export PATH="${PARENT}":$PATH
+fi
+
+if [[ -z "${CNCLI}" ]]; then
+  CNCLI=$(command -v cncli) || CNCLI="${HOME}/.cargo/bin/cncli"
 fi
 
 [[ -z "${CNODE_HOME}" ]] && CNODE_HOME=/opt/cardano/cnode
@@ -137,6 +142,7 @@ if [[ "${PROTOCOL_IDENTIFIER}" = "--cardano-mode" ]]; then
   BYRON_EPOCH_LENGTH=$(( 10 * BYRON_K ))
 fi
 
+[[ -z ${TERM} ]] && export TERM=xterm
 FG_BLACK=$(tput setaf 0)
 FG_RED=$(tput setaf 1)
 FG_GREEN=$(tput setaf 2)

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -111,7 +111,7 @@ else
   [[ ! -f "${BYRON_GENESIS_JSON}" ]] && echo "Byron genesis file not found: ${BYRON_GENESIS_JSON}" && return 1
 fi
 
-CNODE_PID=$(pgrep -fn "[-]-port ${CNODE_PORT}")
+CNODE_PID=$(pgrep -fn "[c]ardano-node*.*--port ${CNODE_PORT}")
 
 PROTOCOL=$(jq -r .Protocol "${CONFIG}")
 NETWORKID=$(jq -r .networkId ${GENESIS_JSON})

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -142,18 +142,17 @@ if [[ "${PROTOCOL_IDENTIFIER}" = "--cardano-mode" ]]; then
   BYRON_EPOCH_LENGTH=$(( 10 * BYRON_K ))
 fi
 
-[[ -z ${TERM} ]] && export TERM=xterm
-FG_BLACK=$(tput setaf 0)
-FG_RED=$(tput setaf 1)
-FG_GREEN=$(tput setaf 2)
-FG_YELLOW=$(tput setaf 3)
-FG_BLUE=$(tput setaf 4)
-FG_MAGENTA=$(tput setaf 5)
-FG_CYAN=$(tput setaf 6)
-FG_WHITE=$(tput setaf 7)
-STANDOUT=$(tput smso)
-BOLD=$(tput bold)
-NC=$(tput sgr0)
+FG_BLACK='\e[30m'
+FG_RED='\e[31m'
+FG_GREEN='\e[32m'
+FG_YELLOW='\e[33m'
+FG_BLUE='\e[34m'
+FG_MAGENTA='\e[35m'
+FG_CYAN='\e[36m'
+FG_WHITE='\e[97m'
+STANDOUT='\e[7m'
+BOLD='\e[1m'
+NC='\e[0m'
 
 [[ -z ${BLOCK_LOG_DIR} && -d "${CNODE_HOME}/db/blocks" ]] && BLOCK_LOG_DIR="${CNODE_HOME}/db/blocks"
 

--- a/scripts/cnode-helper-scripts/prereqs.sh
+++ b/scripts/cnode-helper-scripts/prereqs.sh
@@ -273,7 +273,7 @@ curl -s -m ${CURL_TIMEOUT} -o sLiveView.sh ${URL_RAW}/scripts/cnode-helper-scrip
 curl -s -m ${CURL_TIMEOUT} -o gLiveView.sh.tmp ${URL_RAW}/scripts/cnode-helper-scripts/gLiveView.sh
 curl -s -m ${CURL_TIMEOUT} -o deploy-as-systemd.sh ${URL_RAW}/scripts/cnode-helper-scripts/deploy-as-systemd.sh
 curl -s -m ${CURL_TIMEOUT} -o cncli.sh ${URL_RAW}/scripts/cnode-helper-scripts/cncli.sh
-curl -s -m ${CURL_TIMEOUT} -o install-cncli.sh ${URL_RAW}/scripts/cnode-helper-scripts/install-cncli.sh
+curl -s -m ${CURL_TIMEOUT} -o cncli-install.sh ${URL_RAW}/scripts/cnode-helper-scripts/cncli-install.sh
 sed -e "s@SyslogIdentifier=.*@SyslogIdentifier=${CNODE_NAME}@g" -e "s@cnode.service@${CNODE_NAME}.service@g" -i deploy-as-systemd.sh
 sed -e "s@/opt/cardano/cnode@${CNODE_HOME}@g" -e "s@CNODE_HOME@${CNODE_VNAME}_HOME@g" -i ./*.* ./env.tmp
 

--- a/scripts/cnode-helper-scripts/prereqs.sh
+++ b/scripts/cnode-helper-scripts/prereqs.sh
@@ -120,7 +120,7 @@ if [ "$WANT_BUILD_DEPS" = 'Y' ]; then
     $sudo apt-get -y install curl > /dev/null
     $sudo apt-get -y update > /dev/null
     echo "  Installing missing prerequisite packages, if any.."
-    pkg_list="libpq-dev python3 build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev systemd libsystemd-dev libsodium-dev zlib1g-dev make g++ tmux git jq libncursesw5 gnupg aptitude libtool autoconf secure-delete iproute2 bc tcptraceroute dialog libsqlite3-dev"
+    pkg_list="libpq-dev python3 build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev systemd libsystemd-dev libsodium-dev zlib1g-dev make g++ tmux git jq libncursesw5 gnupg aptitude libtool autoconf secure-delete iproute2 bc tcptraceroute dialog sqlite libsqlite3-dev"
     $sudo apt-get -y install ${pkg_list} > /dev/null;rc=$?
     if [ $rc != 0 ]; then
       echo "An error occurred while installing the prerequisite packages, please investigate by using the command below:"
@@ -135,7 +135,7 @@ if [ "$WANT_BUILD_DEPS" = 'Y' ]; then
     $sudo yum -y install curl > /dev/null
     $sudo yum -y update > /dev/null
     echo "  Installing missing prerequisite packages, if any.."
-    pkg_list="python3 coreutils pkgconfig libffi-devel gmp-devel openssl-devel ncurses-libs ncurses-compat-libs systemd systemd-devel libsodium-devel zlib-devel make gcc-c++ tmux git jq gnupg libtool autoconf srm iproute bc tcptraceroute dialog libsqlite3x-devel"
+    pkg_list="python3 coreutils pkgconfig libffi-devel gmp-devel openssl-devel ncurses-libs ncurses-compat-libs systemd systemd-devel libsodium-devel zlib-devel make gcc-c++ tmux git jq gnupg libtool autoconf srm iproute bc tcptraceroute dialog sqlite libsqlite3x-devel"
     [[ ! "${DISTRO}" =~ Fedora ]] && $sudo yum -y install epel-release > /dev/null
     $sudo yum -y install ${pkg_list} > /dev/null;rc=$?
     if [ $rc != 0 ]; then

--- a/scripts/cnode-helper-scripts/prereqs.sh
+++ b/scripts/cnode-helper-scripts/prereqs.sh
@@ -120,7 +120,7 @@ if [ "$WANT_BUILD_DEPS" = 'Y' ]; then
     $sudo apt-get -y install curl > /dev/null
     $sudo apt-get -y update > /dev/null
     echo "  Installing missing prerequisite packages, if any.."
-    pkg_list="libpq-dev python3 build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev systemd libsystemd-dev libsodium-dev zlib1g-dev make g++ tmux git jq libncursesw5 gnupg aptitude libtool autoconf secure-delete iproute2 bc tcptraceroute dialog"
+    pkg_list="libpq-dev python3 build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev systemd libsystemd-dev libsodium-dev zlib1g-dev make g++ tmux git jq libncursesw5 gnupg aptitude libtool autoconf secure-delete iproute2 bc tcptraceroute dialog libsqlite3-dev"
     $sudo apt-get -y install ${pkg_list} > /dev/null;rc=$?
     if [ $rc != 0 ]; then
       echo "An error occurred while installing the prerequisite packages, please investigate by using the command below:"
@@ -135,7 +135,7 @@ if [ "$WANT_BUILD_DEPS" = 'Y' ]; then
     $sudo yum -y install curl > /dev/null
     $sudo yum -y update > /dev/null
     echo "  Installing missing prerequisite packages, if any.."
-    pkg_list="python3 coreutils pkgconfig libffi-devel gmp-devel openssl-devel ncurses-libs ncurses-compat-libs systemd systemd-devel libsodium-devel zlib-devel make gcc-c++ tmux git jq gnupg libtool autoconf srm iproute bc tcptraceroute dialog"
+    pkg_list="python3 coreutils pkgconfig libffi-devel gmp-devel openssl-devel ncurses-libs ncurses-compat-libs systemd systemd-devel libsodium-devel zlib-devel make gcc-c++ tmux git jq gnupg libtool autoconf srm iproute bc tcptraceroute dialog libsqlite3x-devel"
     [[ ! "${DISTRO}" =~ Fedora ]] && $sudo yum -y install epel-release > /dev/null
     $sudo yum -y install ${pkg_list} > /dev/null;rc=$?
     if [ $rc != 0 ]; then
@@ -272,6 +272,8 @@ curl -s -m ${CURL_TIMEOUT} -o system-info.sh ${URL_RAW}/scripts/cnode-helper-scr
 curl -s -m ${CURL_TIMEOUT} -o sLiveView.sh ${URL_RAW}/scripts/cnode-helper-scripts/sLiveView.sh
 curl -s -m ${CURL_TIMEOUT} -o gLiveView.sh.tmp ${URL_RAW}/scripts/cnode-helper-scripts/gLiveView.sh
 curl -s -m ${CURL_TIMEOUT} -o deploy-as-systemd.sh ${URL_RAW}/scripts/cnode-helper-scripts/deploy-as-systemd.sh
+curl -s -m ${CURL_TIMEOUT} -o cncli.sh ${URL_RAW}/scripts/cnode-helper-scripts/cncli.sh
+curl -s -m ${CURL_TIMEOUT} -o install-cncli.sh ${URL_RAW}/scripts/cnode-helper-scripts/install-cncli.sh
 sed -e "s@SyslogIdentifier=.*@SyslogIdentifier=${CNODE_NAME}@g" -e "s@cnode.service@${CNODE_NAME}.service@g" -i deploy-as-systemd.sh
 sed -e "s@/opt/cardano/cnode@${CNODE_HOME}@g" -e "s@CNODE_HOME@${CNODE_VNAME}_HOME@g" -i ./*.* ./env.tmp
 


### PR DESCRIPTION
CNCLI is developed by Andrew and available at https://github.com/AndrewWestberg/cncli
It's a RUST implementation for low-level interaction with cardano-node.
Current functionality include cardano-node ping and chain sync into sqlite db for different block queries.

use cncli-install.sh to install RUST, CNCLI and deploy it as a systemd service. Script can also be used to upgrade CNCLI. Updated prereqs.sh needed to install libsqlite3 and env updated with variable for path to CNCLI executable.