### PR TITLE
json -> sqlite backend + misc changes

### DIFF
--- a/docs/Scripts/cncli.md
+++ b/docs/Scripts/cncli.md
@@ -57,14 +57,14 @@ Recommended workflow to get started with CNCLI blocklog.
 2. Set required user variables according to [Configuration](#configuration) section.
 3. (**optional**) If a previous blocklog db exist created by cntoolsBlockCollector, run this command to migrate json storage to new SQLite DB:
    * `$CNODE_HOME/scripts/cncli.sh migrate <path>` where <path> is the location for the directory containing all blocks_<epoch>.json files.
-4. Run init command to fill the db with all blocks made by your pool known to the blockchain
-   * `$CNODE_HOME/scripts/cncli.sh init`
-5. Start deployed services with:
+4. Start deployed services with:
    * `sudo systemctl start cnode-cncli-sync.service`
    * `sudo systemctl start cnode-logmonitor.service`
    * `sudo systemctl start cnode-cncli-ptsendtip.service` (**optional but recommended**)
    * alternatively restart the main service that will trigger a start of all services with:
    * `sudo systemctl restart cnode.service`
+5. Run init command to fill the db with all blocks made by your pool known to the blockchain
+   * `$CNODE_HOME/scripts/cncli.sh init`
 6. Enjoy full blocklog automation and visit [View Blocklog](#view-blocklog) section for instructions on how to show blocks from the blocklog DB.
 
 ```

--- a/docs/Scripts/cncli.md
+++ b/docs/Scripts/cncli.md
@@ -6,38 +6,150 @@
 **SYNC**      - Connects to a node(local or remote) and synchronizes blocks to a local sqlite database. 
 **VALIDATE**  - Validates that a block hash or partial block hash is on-chain.
 **LEADERLOG** - Calculates a stakepool's expected slot list. On MainNet and the official TestNet, leader schedule is available 1.5 days before the end of the epoch (`firstSlotOfNextEpoch - (3 * k / f)`).
+**SENDTIP**   - Send node tip to PoolTool for network analysis and to show that your node is alive and well with a green badge.
 
 ##### Installation
-`cncli.sh` script is not meant to be run manually, but instead used to deploy systemd services that run in the background to do the block scraping and validation automatically.  
-The script rely on [Log Monitor](Scripts/logmonitor.md) to get the block hash of an adopted block. Required to be able to do the block validation.
+`cncli.sh` script's main functions, sync, leaderlog, validate and ptsendtip are not meant to be run manually, but instead deploy as systemd services that run in the background to do the block scraping and validation automatically. Additional commands exist for manual execution to migrate old cntoolsBlockCollector JSON blocklog, re-validation of blocks and initially fill the blocklog DB with all blocks created by the pool known to the blockchain. See usage output below for a complete list of available commands.
 
-Run `cncli.sh install` to download and install RUST and CNCLI. If a previous installation is found, RUST and CNCLI will be updated to the latest version.
-In addition three systemd services are created. See above for the different purposes they serve. The validate and leaderlog commands require a synchronized database.
+The script work in tandem with [Log Monitor](Scripts/logmonitor.md) to provide faster adopted status but mainly to catch slots node is leader for but are unable to create a block for. These are marked as invalid. Blocklog will however work fine without logmonitor service and CNCLI is able to handle everything except catching invalid blocks.
 
+1. Run the latest version of prereqs.sh with `prereqs.sh -c -l` to download and install RUST and CNCLI together with IOG fork of libsodium required by CNCLI. If a previous installation is found, RUST and CNCLI will be updated to the latest version.
+2. Run `deploy-as-systemd.sh` to deploy the systemd services that handle all the work in the background. Six systemd services in total are deployed whereof four are related to CNCLI. See above for the different purposes they serve.
+3. If you want to disable some of the deployed services, run `sudo systemctl disable <service>`
+
+* cnode.service (main cardano-node launcher)
 * cnode-cncli-sync.service
 * cnode-cncli-leaderlog.service 
 * cnode-cncli-validate.service
-
-As usual, controlled by `sudo systemctl <status|start|stop|restart> <service name>`  
-Make sure to set appropriate values according to [Configuration](#configuration) section before starting services.
-
-Log output is handled by syslog and end up in the systems standard syslog file, normally `/var/log/syslog`. `journalctl -u <service>` can be used to check log. Other logging configurations are not covered here. 
-
-##### View Collected Blocks
-Best viewed in CNTools but as it's saved as regular JSON any text/JSON viewer could be used. Block data is saved to `BLOCKLOG_DIR` variable set in env file, by default `${CNODE_HOME}/guild-db/blocklog/`. One file is created for each epoch. 
-
-See [Log Monitor](Scripts/logmonitor.md) for example output.
+* cnode-cncli-ptsendtip.service
+* cnode-logmonitor.service (see [Log Monitor](Scripts/logmonitor.md))
 
 ##### Configuration
-You can override the values in the script at the User Variables section shown below. **POOL_ID** & **POOL_VRF_SKEY** need to be set in the script before starting the validation service. For the rest of the commented values, if the automatic detection do not provide the right information, uncomment and make adjustments. We would appreciate if you could also notify us by raising an issue against github repo.
+You can override the values in the script at the User Variables section shown below. **POOL_ID**, **POOL_VRF_SKEY** and **POOL_VRF_VKEY**, **PT_API_KEY** and **POOL_TICKER** need to be set in the script before starting the services. For the rest of the commented values, if the default do not provide the right value, uncomment and make adjustments.
 
 ```
-POOL_ID=""                                # Required for leaderlog calculation, lower-case hex pool id
+POOL_ID=""                                # Required for leaderlog calculation & pooltool sendtip, lower-case hex pool id
 POOL_VRF_SKEY=""                          # Required for leaderlog calculation, path to pool's vrf.skey file
-#CNCLI_DB="${CNODE_HOME}/guild-db/cncli"  # path to folder to hold sqlite db for cncli
-#LIBSODIUM_FORK=/usr/local/lib            # path to IOG fork of libsodium
-#SLEEP_RATE=20                            # time to wait until next check, used in leaderlog and validate (in seconds)
-#CONFIRM_SLOT_CNT=300                     # require at least these many slots to have passed before validating
-#CONFIRM_BLOCK_CNT=10                     # require at least these many blocks on top of minted before validating
-#TIMEOUT_LEDGER_STATE=300                 # timeout in seconds for ledger-state query
+POOL_VRF_VKEY=""                          # Required for block validation, path to pool's vrf.vkey file
+PT_API_KEY=""                             # POOLTOOL sendtip: set API key, e.g "a47811d3-0008-4ecd-9f3e-9c22bdb7c82d"
+POOL_TICKER=""                            # POOLTOOL sendtip: set the pools ticker, e.g "TCKR"
+#PT_HOST="127.0.0.1"                      # POOLTOOL sendtip: connect to a remote node, preferably block producer (default localhost)
+#PT_PORT="${CNODE_PORT}"                  # POOLTOOL sendtip: port of node to connect to (default CNODE_PORT from env file)
+#CNCLI_DIR="${CNODE_HOME}/guild-db/cncli" # path to folder for cncli sqlite db
+#LIBSODIUM_FORK=/usr/local/lib            # path to folder for IOG fork of libsodium
+#SLEEP_RATE=60                            # CNCLI leaderlog/validate: time to wait until next check (in seconds)
+#CONFIRM_SLOT_CNT=300                     # CNCLI validate: require at least these many slots to have passed before validating
+#CONFIRM_BLOCK_CNT=10                     # CNCLI validate: require at least these many blocks on top of minted before validating
+#TIMEOUT_LEDGER_STATE=300                 # CNCLI leaderlog: timeout in seconds for ledger-state query
+```
+
+##### Run
+Services are controlled by `sudo systemctl <status|start|stop|restart> <service name>`  
+All services are configured as child services to cnode.service and as such, when an action is taken against this service it's replicated to all child services. E.g running `sudo systemctl start cnode.service` will also start all child services. 
+
+> Make sure to set appropriate values according to [Configuration](#configuration) section before starting services.
+
+Log output is handled by syslog and end up in the systems standard syslog file, normally `/var/log/syslog`. `journalctl -f -u <service>` can be used to check service output(follow mode). Other logging configurations are not covered here. 
+
+Recommended workflow to get started with CNCLI blocklog.
+
+1. Install and deploy services according to [Installation](#installation) section.
+2. Set required user variables according to [Configuration](#configuration) section.
+3. (**optional**) If a previous blocklog db exist created by cntoolsBlockCollector, run this command to migrate json storage to new SQLite DB:
+   * `$CNODE_HOME/scripts/cncli.sh migrate <path>` where <path> is the location for the directory containing all blocks_<epoch>.json files.
+4. Run init command to fill the db with all blocks made by your pool known to the blockchain
+   * `$CNODE_HOME/scripts/cncli.sh init`
+5. Start deployed services with:
+   * `sudo systemctl start cnode-cncli-sync.service`
+   * `sudo systemctl start cnode-logmonitor.service`
+   * `sudo systemctl start cnode-cncli-ptsendtip.service` (**optional but recommended**)
+   * alternatively restart the main service that will trigger a start of all services with:
+   * `sudo systemctl restart cnode.service`
+6. Enjoy full blocklog automation and visit [View Blocklog](#view-blocklog) section for instructions on how to show blocks from the blocklog DB.
+
+```
+Usage: cncli.sh [sync] [leaderlog] [validate [all] [epoch]] [ptsendtip] [migrate <path>]
+Keep a local blocklog run CNCLI to  
+sync, leaderlog, validate best launched through systemd deployed by 'deploy-as-systemd.sh'
+
+sync        Start CNCLI chainsync process that connects to cardano-node to sync blocks stored in SQLite DB (deployed as service)
+leaderlog   One-time leader schedule calculation for current epoch, 
+            then continously monitors and calculates schedule for coming epochs, 1.5 days before epoch boundary on MainNet (deployed as service)
+validate    Continously monitor and confirm that the blocks made actually was accepted and adopted by chain (deployed as service)
+  all       One-time re-validation of all blocks in blocklog db
+  epoch     One-time re-validation of blocks in blocklog db for the specified epoch 
+ptsendtip   Send node tip to PoolTool for network analysis and to show that your node is alive and well with a green badge (deployed as service)
+init        One-time initialization adding all minted and confirmed blocks to blocklog
+migrate     One-time migration from old blocklog(cntoolsBlockCollector) to new format (post cncli)
+  path      Path to the old cntoolsBlockCollector blocklog folder holding json files with blocks created
+```
+
+##### View Blocklog
+Best and easiest viewed in CNTools and gLiveView but the blocklog database is a SQLite DB so if you are comfortable with SQL, sqlite3 command can be used to query the DB. 
+
+Open CNTools and select `[b] Blocks` to open the block viewer.  
+Either select `Epoch` and enter the epoch you want to see a detailed view for or choose `Summary` to display blocks for last x epochs.
+
+**Block status**
+* leader    - scheduled to make block at this slot
+* adopted   - block created successfully
+* confirmed - block created validated to be on-chain with the certainty set in `cncli.sh` for `CONFIRM_BLOCK_CNT`
+* missed    - scheduled at slot but no record of it in cncli DB and no other pool has made a block for this slot
+* ghosted   - block created but marked as orphaned and no other pool has made a valid block for this slot, height battle or block propagation issue
+* stolen    - another pool has a valid block registered on-chain for the same slot
+* invalid   - pool failed to create block, base64 encoded error message can be decoded with `echo <base64 hash> | base64 -d | jq -r`
+
+If the node was elected to create blocks in the selected epoch it could look something like this:
+
+**Summary**
+```
+ >> BLOCKS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Current epoch: 95
+
++--------+---------+----------+------------+---------+----------+---------+----------+
+| Epoch  | Leader  | Adopted  | Confirmed  | Missed  | Ghosted  | Stolen  | Invalid  |
++--------+---------+----------+------------+---------+----------+---------+----------+
+| 96     | 34      | 0        | 0          | 0       | 0        | 0       | 0        |
+| 95     | 32      | 32       | 32         | 0       | 0        | 0       | 0        |
+| 94     | 20      | 20       | 20         | 0       | 0        | 0       | 0        |
+| 93     | 32      | 32       | 32         | 0       | 0        | 0       | 0        |
+| 92     | 36      | 36       | 36         | 0       | 0        | 0       | 0        |
++--------+---------+----------+------------+---------+----------+---------+----------+
+
+[h] Home | [b] Block View | [i] Info | [*] Refresh
+```
+**Epoch**
+```
+ >> BLOCKS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Current epoch: 95
+
++---------+----------+------------+---------+----------+---------+----------+
+| Leader  | Adopted  | Confirmed  | Missed  | Ghosted  | Stolen  | Invalid  |
++---------+----------+------------+---------+----------+---------+----------+
+| 15      | 13       | 13         | 0       | 0        | 0       | 0        |
++---------+----------+------------+---------+----------+---------+----------+
+
++-----+------------+----------+---------------------+--------------------------+-------+-------------------------------------------------------------------+
+| #   | Status     | Block    | Slot / SlotInEpoch  | Scheduled At             | Size  | Hash                                                              |
++-----+------------+----------+---------------------+--------------------------+-------+-------------------------------------------------------------------+
+| 1   | confirmed  | 2025531  | 10694026 / 23626    | 2020-11-11 03:54:02 CET  | 3     | 1051a2853812eda14f73e313f1a34889f04bdf76be2bfe5c581b1380e2d10ca2  |
+| 2   | confirmed  | 2025607  | 10695745 / 25345    | 2020-11-11 04:22:41 CET  | 3     | bb60030c1888d5ed8c86a0486cf9c7d19dc298e13b8be13ef0bda75cea856379  |
+| 3   | confirmed  | 2025781  | 10700470 / 30070    | 2020-11-11 05:41:26 CET  | 3     | 3f74582609c39c8b6d965f76cf4e9a898b1d3a7b764504388e707198ae9cd530  |
+| 4   | confirmed  | 2025833  | 10701931 / 31531    | 2020-11-11 06:05:47 CET  | 3     | fe77bb854526d13df6e061c34a54fe5522f6ed6cba4391d6651a5a899b478149  |
+| 5   | confirmed  | 2026020  | 10707379 / 36979    | 2020-11-11 07:36:35 CET  | 3     | 54433d1640b90a08ed5fa8c7d925498552b44fda9c0b7908a99ba44cf343ce59  |
+| 6   | confirmed  | 2026146  | 10710255 / 39855    | 2020-11-11 08:24:31 CET  | 3     | f062350f7795e407d32acbe910fbb856d55ee53db55ac6eb88a92314f5fdfc4f  |
+| 7   | confirmed  | 2031225  | 10836135 / 165735   | 2020-11-12 19:22:31 CET  | 3     | 587a8d235a880d4e709173bad21eda2cecfecf5be04bdab2acfea4d9f457286c  |
+| 8   | confirmed  | 2031389  | 10840079 / 169679   | 2020-11-12 20:28:15 CET  | 3     | dd1c95ba4596457412dccec84767ad4e8861b218803c8fbaf66bb2b1f5de327c  |
+| 9   | confirmed  | 2033012  | 10881542 / 211142   | 2020-11-13 07:59:18 CET  | 3     | 26a17109c28a2afc11ad86c375d26a55fa3f7badf601f8dbf85bd851ab7f1121  |
+| 10  | confirmed  | 2033511  | 10894371 / 223971   | 2020-11-13 11:33:07 CET  | 3     | dd77c1da50d8453a170cf9d9a779d6307d897e524bf11a6bfc196adbc079f1e9  |
+| 11  | confirmed  | 2036190  | 10960153 / 289753   | 2020-11-14 05:49:29 CET  | 3     | 5c3049b7c6fed33830e7e4e9ccf75a13a8360717d2fd8ae726e0b81d0d30675d  |
+| 12  | confirmed  | 2037280  | 10987522 / 317122   | 2020-11-14 13:25:38 CET  | 3     | 0a87c2e3a978125728ea707441ad53689eb2b44f6b4c11a83a0b8b368261579b  |
+| 13  | confirmed  | 2040016  | 11057713 / 387313   | 2020-11-15 08:55:29 CET  | 3     | 710d72eaf5fa84ed90a3d3ab4544fcdcd58be163029ead66e46e91bef45dfc78  |
+| 14  | leader     | -        | 11061678 / 391278   | 2020-11-15 10:01:34 CET  | -     | -                                                                 |
+| 15  | leader     | -        | 11078122 / 407722   | 2020-11-15 19:35:38 CET  | -     | -                                                                 |
++-----+------------+----------+---------------------+--------------------------+-------+-------------------------------------------------------------------+
+
+[h] Home | [1] View 1 | [2] View 2 | [3] View 3 | [i] Info | [*] Refresh
 ```

--- a/docs/Scripts/cntools-changelog.md
+++ b/docs/Scripts/cntools-changelog.md
@@ -11,9 +11,9 @@ and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Ability to post metadata on-chain, e.g. (but not limited to) Adams https://vote.crypto2099.io/
 
 ##### Changed
-- Blocks view updated to adapt to changed made to block collector(logMonitor) and the added CNCLI integration
-  - [Log Monitor](https://cardano-community.github.io/guild-operators/#/Scripts/logmonitor)
+- Blocks view updated to adapt to the added CNCLI integration and changes made to block collector(logMonitor)
   - [CNCLI](https://cardano-community.github.io/guild-operators/#/Scripts/cncli)
+  - [Log Monitor](https://cardano-community.github.io/guild-operators/#/Scripts/logmonitor)
 - chattr file locking now optional to use, a new setting in cntools.config added for it.
 
 ##### Fixed

--- a/docs/Scripts/cntools.md
+++ b/docs/Scripts/cntools.md
@@ -17,9 +17,9 @@ The tool consist of three files.
 
 In addition to the above files, there is also a dependency on the common `env` file. CNTools connects to your node through the configuration in the `env` file located in the same directory as the script. Customize `env` and `cntools.config` files for your needs. CNTools can operate in an Offline mode without node access by providing the `-o` runtime argument. This launches CNTools with a limited set of features with Hybrid or Online v/s Offline workflow in mind.
 
-`logMonitor.sh` is a companion script that are optional to run on the core node(block producer) to be able to monitor blocks created.  
-`cncli.sh` is another companion script meant to be run together with logMonitor.sh script to give a complete picture by running leader schedule and block validation.  
-See [Log Monitor](Scripts/logmonitor.md) and [CNCLI](Scripts/cncli.md) sections for more details.  
+`cncli.sh` is a companion script that are optional to run on the core node(block producer) to be able to monitor blocks created and by running leader schedule calculation and block validation.  
+`logMonitor.sh` is another companion script meant to be run together with cncli.sh script to give a complete picture.  
+See [CNCLI](Scripts/cncli.md) and [Log Monitor](Scripts/logmonitor.md) sections for more details.  
 
 > The tool in its default state uses the folder structure [here](basics.md#folder-structure). Everyone is free to customise, but while doing so beware that you may introduce changes that were not tested.
 
@@ -41,23 +41,25 @@ You should get a screen that looks something like this:
  Main Menu
 
  ) Wallet    -  create, show, remove and protect wallets
- ) Funds     -  send, withdraw, delegate and post metadata
+ ) Funds     -  send, withdraw and delegate
  ) Pool      -  pool creation and management
  ) Sign Tx   -  Sign a built transaction file (hybrid/offline mode)
  ) Submit Tx -  Submit a signed transaction file (hybrid/offline mode)
+ ) Metadata  -  Post metadata on-chain (e.g voting)
  ) Blocks    -  show core node leader slots
  ) Update    -  update cntools script and library config files
  ) Backup    -  backup & restore of wallet/pool/config
  ) Refresh   -  reload home screen content
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                                                  Epoch 87 - 114h:10m:30s until next
- What would you like to do?                                         Node Sync: 28 :)
+                                                   Epoch 95 - 04h:34m:47s until next
+ What would you like to do?                                         Node Sync: 22 :)
 
   [w] Wallet
   [f] Funds
   [p] Pool
   [s] Sign Tx
   [t] Submit Tx
+  [m] Metadata
   [b] Blocks
   [u] Update
   [z] Backup & Restore
@@ -68,35 +70,10 @@ You should get a screen that looks something like this:
 ##### Start CNTools in Offline Mode
 `$ ./cntools.sh -o`
 
-You should get a screen that looks something like this:
+The main menu header should let you know that node is started in offline mode:
 ```
  >> CNTools vX.X.X - OFFLINE <<                      A Guild Operators collaboration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- Main Menu
-
- ) Wallet    -  create, show, remove and protect wallets
- ) Funds     -  send, withdraw, delegate and post metadata
- ) Pool      -  pool creation and management
- ) Sign Tx   -  Sign a built transaction file (hybrid/offline mode)
- ) Submit Tx -  Submit a signed transaction file (hybrid/offline mode)
- ) Blocks    -  show core node leader slots
- ) Update    -  update cntools script and library config files
- ) Backup    -  backup & restore of wallet/pool/config
- ) Refresh   -  reload home screen content
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                                                  Epoch 87 - 114h:02m:21s until next
- What would you like to do?
-
-  [w] Wallet
-  [f] Funds
-  [p] Pool
-  [s] Sign Tx
-  [t] Submit Tx
-  [b] Blocks
-  [u] Update
-  [z] Backup & Restore
-  [r] Refresh
-  [q] Quit
 ```
 
 ##### Navigation

--- a/docs/Scripts/gliveview.md
+++ b/docs/Scripts/gliveview.md
@@ -68,6 +68,7 @@ CNODE_PORT=6000                                         # Set node port
 #EKG_TIMEOUT=3                                          # Maximum time in seconds that you allow EKG request to take before aborting (node metrics)
 #CURL_TIMEOUT=10                                        # Maximum time in seconds that you allow curl file download to take before aborting (GitHub update process)
 #BLOCKLOG_DIR="${CNODE_HOME}/guild-db/blocklog"         # Override default directory used to store block data for core node
+#BLOCKLOG_TZ="UTC"                                      # TimeZone to use when displaying blocklog - https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 ```
 
 **gLiveView.sh**

--- a/docs/Scripts/logmonitor.md
+++ b/docs/Scripts/logmonitor.md
@@ -5,78 +5,13 @@
 ##### Block traces
 For the core node (block producer) the `logMonitor.sh` script can be run to monitor the json log file created by cardano-node for traces related to leader slots and block creation.   
 
-For optimal coverage, it's best run together with [CNCLI](Scripts/cncli.md) scripts as they provide different functionality. Together they create a complete picture of blocks assigned, created, validated or invalid due to some issue. 
-
-* [Installation](#installation)
-* [View Collected Blocks](#view-collected-blocks)
+For optimal coverage, it's best run together with [CNCLI](Scripts/cncli.md) scripts as they provide different functionality. Together they create a complete picture of blocks assigned, created, validated or invalid due to node issue. 
 
 ##### Installation
 The script is best run as a background process. This can be accomplished in many ways but the preferred method is to run it as a systemd service. A terminal multiplexer like tmux or screen could also be used but not covered here.
 
-Use the `deploy-as-systemd.sh` script to create a systemd unit file.
-Output is logged using syslog and end up in the systems standard syslog file, normally `/var/log/syslog`. `journalctl -u <service>` can be used to check log. Other logging configurations are not covered here. 
+Use the `deploy-as-systemd.sh` script to create a systemd unit file (deployed together with [CNCLI](Scripts/cncli.md)).
+Log output is handled by syslog and end up in the systems standard syslog file, normally `/var/log/syslog`. `journalctl -f -u cnode-logmonitor.service` can be used to check service output(follow mode). Other logging configurations are not covered here. 
 
-##### View Collected Blocks
-Best viewed in CNTools but as it's saved as regular JSON any text/JSON viewer could be used. Block data is saved to `BLOCKLOG_DIR` variable set in env file, by default `${CNODE_HOME}/guild-db/blocklog/`. One file is created for each epoch. 
-
-Open CNTools and select `[b] Blocks` to open the block viewer.  
-Either select `Epoch` and enter the epoch you want to see a detailed view for or choose `Summary` to display blocks for last x epochs.
-
-**Block status**
-* leader - pool scheduled to make block at this slot
-* adopted - node created block successfully
-* confirmed - block created validated to be on-chain with the certainty set in `cncli.sh` for `CONFIRM_BLOCK_CNT`
-* missed - pool scheduled to make block at a slot that there is no record of it producing
-* ghosted - pool created block but unable to find block hash on-chain, stolen in height/slot battle or block propagation issue
-* invalid - pool failed to create block, base64 encoded error message can be decoded with `echo <base64 hash> | base64 -d | jq -r`
-
-If the node was elected to create blocks in the selected epoch it could look something like this:
-
-**Summary**
-```
- >> BLOCKS
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Current epoch: 94
-
-+--------+---------+----------+------------+---------+----------+----------+
-| Epoch  | Leader  | Adopted  | Confirmed  | Missed  | Ghosted  | Invalid  |
-+--------+---------+----------+------------+---------+----------+----------+
-| 94     | 20      | 10       | 10         | 0       | 0        | 0        |
-| 93     | 4       | 4        | 4          | 0       | 0        | 0        |
-+--------+---------+----------+------------+---------+----------+----------+
-```
-**Epoch**
-```
- >> BLOCKS
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Current epoch: 94
-
-Leader : 20  |  Adopted / Confirmed : 12 / 12  |  Missed / Ghosted / Invalid : 0 / 0 / 0
-
-+------------+----------+---------------------+----------------------+-------+-------------------------------------------------------------------+
-| Status     | Block    | Slot / SlotInEpoch  | At (UTC)             | Size  | Hash                                                              |
-+------------+----------+---------------------+----------------------+-------+-------------------------------------------------------------------+
-| confirmed  | 2007264  | 10246798 / 8398     | 2020-11-05 22:40:14  | 1388  | a4f2bbbc460213c97845b8bd3ebe6774cf8aa100202e595ce9c4c8cd7dcf94bd  |
-| confirmed  | 2007322  | 10248270 / 9870     | 2020-11-05 23:04:46  | 1016  | 754af8761edc8b48d8bf277b9104dd921b3873cf1772d9e6213e5aa1d6348bff  |
-| confirmed  | 2008752  | 10282751 / 44351    | 2020-11-06 08:39:27  | 1016  | 8537280589e8d5da713ec70554d7e40af908496b3dc0d0cc555f19a527e428c0  |
-| confirmed  | 2009568  | 10302283 / 63883    | 2020-11-06 14:04:59  | 1016  | faccc61e2f947a2e3e8c00b270a755ded5872242b37b17ec2baf20d3865bf10b  |
-| confirmed  | 2011042  | 10338139 / 99739    | 2020-11-07 00:02:35  | 1016  | ee7d6734b7505037a5cb3e983a9f6fdde05dd4837cd68b91e021192319e7d707  |
-| confirmed  | 2011577  | 10350929 / 112529   | 2020-11-07 03:35:45  | 1016  | 007b8493b961b542e3f92e0bd5a465a3cf88ebfbe4a308dbe3e058d37fa7e93f  |
-| confirmed  | 2011639  | 10352354 / 113954   | 2020-11-07 03:59:30  | 1016  | 55a97e105c22e98f72077d7a2850bf6742b8fae7032e9ef994015249f58740fd  |
-| confirmed  | 2011968  | 10359685 / 121285   | 2020-11-07 06:01:41  | 1016  | 7924b2e7139686ed9c3fd34273583f386c2010a0fd4aa41328e02204c8491dda  |
-| confirmed  | 2012592  | 10373759 / 135359   | 2020-11-07 09:56:15  | 1016  | 3d6204b337e2c749a7627839a87da9be7d42b2bf6bd24cd81174c7fb15a27fce  |
-| confirmed  | 2012648  | 10375057 / 136657   | 2020-11-07 10:17:53  | 1016  | 788c58fc9b92e54289ed09cc2b004d03b5a5cb071224d26e88b587fe114b0d9d  |
-| confirmed  | 2014605  | 10422950 / 184550   | 2020-11-07 23:36:06  | 1016  | a0eea2aa89d0485a25b477ef54d26a751909fa3ca514ab6f16be31bfce3bcd2f  |
-| confirmed  | 2015566  | 10446589 / 208189   | 2020-11-08 06:10:05  | 1016  | 1c24969ea574a1bd41546be8a688cb1d9d75b7f89b11b2ebb834054315f54197  |
-| leader     | -        | 10481159 / 242759   | 2020-11-08 15:46:15  | -     | -                                                                 |
-| leader     | -        | 10487667 / 249267   | 2020-11-08 17:34:43  | -     | -                                                                 |
-| leader     | -        | 10507185 / 268785   | 2020-11-08 23:00:01  | -     | -                                                                 |
-| leader     | -        | 10512090 / 273690   | 2020-11-09 00:21:46  | -     | -                                                                 |
-| leader     | -        | 10567882 / 329482   | 2020-11-09 15:51:38  | -     | -                                                                 |
-| leader     | -        | 10582037 / 343637   | 2020-11-09 19:47:33  | -     | -                                                                 |
-| leader     | -        | 10630166 / 391766   | 2020-11-10 09:09:42  | -     | -                                                                 |
-| leader     | -        | 10662327 / 423927   | 2020-11-10 18:05:43  | -     | -                                                                 |
-+------------+----------+---------------------+----------------------+-------+-------------------------------------------------------------------+
-
-[h] Home | [1] View 1 | [2] View 2 | [3] View 3 (full) | [*] Refresh current view
-```
+##### View Blocklog
+Best viewed in CNTools or gLiveView. See [CNCLI](Scripts/cncli.md) for example output.

--- a/docs/Scripts/topologyupdater.md
+++ b/docs/Scripts/topologyupdater.md
@@ -57,6 +57,7 @@ CNODE_PORT=6000                                         # Set node port
 #EKG_TIMEOUT=3                                          # Maximum time in seconds that you allow EKG request to take before aborting (node metrics)
 #CURL_TIMEOUT=10                                        # Maximum time in seconds that you allow curl file download to take before aborting (GitHub update process)
 #BLOCKLOG_DIR="${CNODE_HOME}/guild-db/blocklog"         # Override default directory used to store block data for core node
+#BLOCKLOG_TZ="UTC"                                      # TimeZone to use when displaying blocklog - https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 ```
 
 Upon first run,

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -62,6 +62,7 @@ CNODE_PORT=6000                                         # Set node port
 #EKG_TIMEOUT=3                                          # Maximum time in seconds that you allow EKG request to take before aborting (node metrics)
 #CURL_TIMEOUT=10                                        # Maximum time in seconds that you allow curl file download to take before aborting (GitHub update process)
 #BLOCKLOG_DIR="${CNODE_HOME}/guild-db/blocklog"         # Override default directory used to store block data for core node
+#BLOCKLOG_TZ="UTC"                                      # TimeZone to use when displaying blocklog - https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 
 ######################################
 # Do NOT modify code below           #

--- a/scripts/cnode-helper-scripts/cncli.sh
+++ b/scripts/cnode-helper-scripts/cncli.sh
@@ -13,13 +13,14 @@
 
 POOL_ID=""                                # Required for leaderlog calculation & pooltool sendtip, lower-case hex pool id
 POOL_VRF_SKEY=""                          # Required for leaderlog calculation, path to pool's vrf.skey file
+POOL_VRF_VKEY=""                          # Required for block validation, path to pool's vrf.vkey file
 PT_API_KEY=""                             # POOLTOOL sendtip: set API key, e.g "a47811d3-0008-4ecd-9f3e-9c22bdb7c82d"
 POOL_TICKER=""                            # POOLTOOL sendtip: set the pools ticker, e.g "TCKR"
 #PT_HOST="127.0.0.1"                      # POOLTOOL sendtip: connect to a remote node, preferably block producer (default localhost)
 #PT_PORT="${CNODE_PORT}"                  # POOLTOOL sendtip: port of node to connect to (default CNODE_PORT from env file)
-#CNCLI_DB="${CNODE_HOME}/guild-db/cncli"  # path to folder for cncli sqlite db 
+#CNCLI_DIR="${CNODE_HOME}/guild-db/cncli" # path to folder for cncli sqlite db
 #LIBSODIUM_FORK=/usr/local/lib            # path to folder for IOG fork of libsodium
-#SLEEP_RATE=20                            # CNCLI leaderlog/validate: time to wait until next check (in seconds)
+#SLEEP_RATE=60                            # CNCLI leaderlog/validate: time to wait until next check (in seconds)
 #CONFIRM_SLOT_CNT=300                     # CNCLI validate: require at least these many slots to have passed before validating
 #CONFIRM_BLOCK_CNT=10                     # CNCLI validate: require at least these many blocks on top of minted before validating
 #TIMEOUT_LEDGER_STATE=300                 # CNCLI leaderlog: timeout in seconds for ledger-state query
@@ -31,15 +32,19 @@ POOL_TICKER=""                            # POOLTOOL sendtip: set the pools tick
 usage() {
   cat <<EOF >&2
 
-Usage: $(basename "$0") [sync] [leaderlog] [validate [--all]] [ptsendtip] [migrate]
+Usage: $(basename "$0") [sync] [leaderlog] [validate [all] [epoch]] [ptsendtip] [migrate <path>]
 Script to run CNCLI, best launched through systemd deployed by 'deploy-as-systemd.sh'
 
-sync        Start CNCLI chainsync process that connects to cardano-node to sync blocks stored in SQLite DB
-leaderlog   Loops through all slots in current epoch to calculate leader schedule
-validate    Confirms that the block made actually was accepted and adopted by chain
-  --all     Go through entire blocklog and revalidate status for adopted|confirmed|ghosted blocks
-ptsendtip   Send node tip to PoolTool for network analysis and to show that your node is alive and well with a green badge
-migrate     command to migrate old blocklog(cntoolsBlockCollector) to new format (post cncli)
+sync        Start CNCLI chainsync process that connects to cardano-node to sync blocks stored in SQLite DB (deployed as service)
+leaderlog   One-time leader schedule calculation for current epoch, 
+            then continously monitors and calculates schedule for coming epochs, 1.5 days before epoch boundary on MainNet (deployed as service)
+validate    Continously monitor and confirm that the blocks made actually was accepted and adopted by chain (deployed as service)
+  all       One-time re-validation of all blocks in blocklog db
+  epoch     One-time re-validation of blocks in blocklog db for the specified epoch 
+ptsendtip   Send node tip to PoolTool for network analysis and to show that your node is alive and well with a green badge (deployed as service)
+init        One-time initialization adding all minted and confirmed blocks to blocklog
+migrate     One-time migration from old blocklog(cntoolsBlockCollector) to new format (post cncli)
+  path      Path to the old cntoolsBlockCollector blocklog folder holding json files with blocks created
 
 EOF
   exit 1
@@ -76,6 +81,40 @@ getSlotInEpoch() {
   jq -r '.cardano.node.ChainDB.metrics.slotInEpoch.int.val //0' <<< "${node_metrics}"
 }
 
+getEpochFromSlot() {
+  slotnum=$1
+  echo $(( shelley_transition_epoch + ((slotnum - (shelley_transition_epoch * BYRON_EPOCH_LENGTH)) / EPOCH_LENGTH) ))
+}
+
+getSlotInEpochFromSlot() {
+  slotnum=$1
+  epoch=$2
+  echo $(( slotnum - ((shelley_transition_epoch * BYRON_EPOCH_LENGTH) + ((epoch - shelley_transition_epoch) * EPOCH_LENGTH )) ))
+}
+
+getDateFromSlot() {
+  slotnum=$1
+  byron_slots=$(( shelley_transition_epoch * BYRON_EPOCH_LENGTH ))
+  printf -v date_from_slot '%(%FT%T%z)T' $(( (byron_slots * BYRON_SLOT_LENGTH) + ((slotnum-byron_slots) * SLOT_LENGTH) + SHELLEY_GENESIS_START_SEC ))
+  echo "${date_from_slot%??}:${date_from_slot: -2}"
+}
+
+cncliDBinSync() { # node_metrics=$(getNodeMetrics) && slot_tip=$(getSlotTip) expected to have been already run
+  cncli_tip=$(sqlite3 "${CNCLI_DB}" "SELECT slot_number FROM chain ORDER BY slot_number DESC LIMIT 1;")
+  cncli_sync_prog=$(echo "( ${cncli_tip} / ${slot_tip} ) * 100" | bc -l)
+  (( $(echo "${cncli_sync_prog} > 99.999" |bc -l) ))
+}
+
+getPoolVrfVkeyCborHex() {
+  pool_vrf_vkey_cbox_hex=''
+  if [[ -f ${POOL_VRF_VKEY} ]] && pool_vrf_vkey_cbox_hex=$(jq -er .cborHex "${POOL_VRF_VKEY}"); then
+    pool_vrf_vkey_cbox_hex=${pool_vrf_vkey_cbox_hex:4} # strip 5820 from beginning
+  else
+    echo "ERROR: unable to locate the pools VRF vkey file or extract cbox hex string from: ${POOL_VRF_VKEY}"
+    return 1
+  fi
+}
+
 dumpLedgerState() {
   ledger_state_file="/tmp/ledger-state_$(getEpoch).json"
   [[ -f ${ledger_state_file} ]] && return 0 # no need to continue, we have a current ledger-state already
@@ -107,6 +146,7 @@ getShelleyTransitionEpoch() {
     shelley_transition_epoch=208
   elif [[ ${calc_slot} -ne ${slotnum} || ${shelley_epochs} -eq 0 ]]; then
     shelley_transition_epoch=-1
+    return 1
   else
     shelley_transition_epoch=${byron_epochs}
   fi
@@ -136,13 +176,11 @@ getSlotTipRef() {
 #################################
 
 cncliInit() {
-  [[ -z "${CNCLI_DB}" ]] && CNCLI_DB="${CNODE_HOME}/guild-db/cncli"
-  if ! mkdir -p "${CNCLI_DB}"; then echo "ERROR: failed to create CNCLI DB folder: ${CNCLI_DB}" && exit 1; fi
-  CNCLI_DB="${CNCLI_DB}/cncli.db"
-  if ! mkdir -p "${BLOCKLOG_DIR}"; then echo "ERROR: failed to create directory to store blocklog: ${BLOCKLOG_DIR}" && exit 1; fi
+  [[ -z "${CNCLI_DIR}" ]] && CNCLI_DIR="${CNODE_HOME}/guild-db/cncli"
+  CNCLI_DB="${CNCLI_DIR}/cncli.db"
   [[ -z "${LIBSODIUM_FORK}" ]] && LIBSODIUM_FORK=/usr/local/lib
   export LD_LIBRARY_PATH="${LIBSODIUM_FORK}:${LD_LIBRARY_PATH}"
-  [[ -z "${SLEEP_RATE}" ]] && SLEEP_RATE=20
+  [[ -z "${SLEEP_RATE}" ]] && SLEEP_RATE=60
   [[ -z "${CONFIRM_SLOT_CNT}" ]] && CONFIRM_SLOT_CNT=300
   [[ -z "${CONFIRM_BLOCK_CNT}" ]] && CONFIRM_BLOCK_CNT=10
   [[ -z "${TIMEOUT_LEDGER_STATE}" ]] && TIMEOUT_LEDGER_STATE=300
@@ -171,6 +209,7 @@ cncliInit() {
 #################################
 
 cncliSync() {
+  if ! mkdir -p "${CNCLI_DIR}"; then echo "ERROR: failed to create CNCLI DB folder: ${CNCLI_DIR}" && exit 1; fi
   ${CNCLI} sync --host 127.0.0.1 --network-magic "${NWMAGIC}" --port "${CNODE_PORT}" --db "${CNCLI_DB}"
 }
 
@@ -178,71 +217,99 @@ cncliSync() {
 
 cncliLeaderlog() {
   echo "~ CNCLI Leaderlog started ~"
+  createBlocklogDB || exit 1 # create db if needed
   [[ -z ${POOL_ID} || -z ${POOL_VRF_SKEY} ]] && echo "'POOL_ID' and/or 'POOL_VRF_SKEY' not set in $(basename "$0"), exiting!" && exit 1
+  
+  shelley_transition_epoch=-1
   while true; do
-    getShelleyTransitionEpoch
     if [[ ${shelley_transition_epoch} -lt 0 ]]; then
-      echo "Failed to calculate shelley transition epoch, checking again in ${SLEEP_RATE}s"
+      if ! getShelleyTransitionEpoch; then 
+        echo "Failed to calculate shelley transition epoch, checking again in ${SLEEP_RATE}s"
+      else
+        echo "Shelley transition epoch found: ${shelley_transition_epoch}"
+      fi
     else
-      echo "Shelley transition epoch found: ${shelley_transition_epoch}"
       node_metrics=$(getNodeMetrics)
       slot_tip=$(getSlotTip)
-      tip_diff=$(( $(getSlotTipRef) - $(getSlotTip) ))
-      [[ ${tip_diff} -lt 300 ]] && break # Node considered in sync if less than 300 slots from theoretical tip
-      echo "Node still in sync, ${tip_diff} slots from theoretical tip, checking again in ${SLEEP_RATE}s"
+      tip_diff=$(( $(getSlotTipRef) - slot_tip ))
+      if [[ ${tip_diff} -gt 300 ]]; then # Node considered in sync if less than 300 slots from theoretical tip
+        echo "Node still syncing, ${tip_diff} slots from theoretical tip, checking again in ${SLEEP_RATE}s"
+      elif ! cncliDBinSync; then
+        echo "CNCLI still syncing [$(printf "%2.4f %%" ${cncli_sync_prog})], checking again in ${SLEEP_RATE}s"
+      else
+        break
+      fi
     fi
     sleep ${SLEEP_RATE}
   done
-  echo "Node in sync, running leaderlogs for current epoch and merging with existing data if available"
-  first_run="true"
-  slot_in_epoch=$(getSlotInEpoch)
-  # firstSlotOfNextEpoch - stabilityWindow(3 * k / f)
-  slot_for_next_nonce=$(echo "(${slot_tip} - ${slot_in_epoch} + ${EPOCH_LENGTH}) - (3 * ${BYRON_K} / ${ACTIVE_SLOTS_COEFF})" | bc)
+  
+  echo "Node in sync, sleeping for ${SLEEP_RATE}s before running leaderlogs for current epoch"
+  sleep ${SLEEP_RATE}
+  node_metrics=$(getNodeMetrics)
+  slot_tip=$(getSlotTip)
+  curr_epoch=$(getEpoch)
+  echo "Running leaderlogs for epoch ${curr_epoch} and adding leader slots not already in DB"
+  if ! dumpLedgerState; then exit 1; fi
+  cncli_leaderlog=$(${CNCLI} leaderlog --db "${CNCLI_DB}" --byron-genesis "${BYRON_GENESIS_JSON}" --shelley-genesis "${GENESIS_JSON}" --ledger-set current --ledger-state "${ledger_state_file}" --pool-id "${POOL_ID}" --pool-vrf-skey "${POOL_VRF_SKEY}" --tz UTC)
+  if [[ $(jq -r .status <<< "${cncli_leaderlog}") != ok ]]; then
+    error_msg=
+    if [[ "${error_msg}" = "Query returned no rows" ]]; then
+      echo "No leader slots found for epoch ${curr_epoch} :("
+    else
+      echo "ERROR: failure in leaderlog while running:"
+      echo "${CNCLI} leaderlog --db ${CNCLI_DB} --byron-genesis ${BYRON_GENESIS_JSON} --shelley-genesis ${GENESIS_JSON} --ledger-set current --ledger-state ${ledger_state_file} --pool-id ${POOL_ID} --pool-vrf-skey ${POOL_VRF_SKEY} --tz UTC"
+      echo "Error message: $(jq -r '.errorMessage //empty' <<< "${cncli_leaderlog}")"
+      exit 1
+    fi
+  fi
+  while read -r assigned_slot; do
+    block_slot=$(jq -r '.slot' <<< "${assigned_slot}")
+    block_at=$(jq -r '.at' <<< "${assigned_slot}")
+    block_slot_in_epoch=$(jq -r '.slotInEpoch' <<< "${assigned_slot}")
+    sqlite3 "${BLOCKLOG_DB}" "INSERT OR IGNORE INTO blocklog (slot,at,slot_in_epoch,epoch,status) values (${block_slot},'${block_at}',${block_slot_in_epoch},${curr_epoch},'leader');"
+    echo "LEADER: slot[${block_slot}] slotInEpoch[${block_slot_in_epoch}] at[${block_at}]"
+  done < <(jq -c '.assignedSlots[]' <<< "${cncli_leaderlog}" 2>/dev/null)
+  
+  has_run_leader=false
   while true; do
     sleep ${SLEEP_RATE}
     node_metrics=$(getNodeMetrics)
+    slot_tip=$(getSlotTip)
+    if ! cncliDBinSync; then # verify that cncli DB is still in sync
+      echo "CNCLI DB out of sync :( [$(printf "%2.4f %%" ${cncli_sync_prog})] ... checking again in ${SLEEP_RATE}s"
+      continue
+    fi
+    if [[ ${has_run_leader} = true ]]; then
+      [[ $(getSlotInEpoch) -ge ${slot_in_epoch} ]] && continue # leaderlog already run and still same epoch
+      has_run_leader=false # new epoch, reset flag
+    fi
+    slot_in_epoch=$(getSlotInEpoch)
+    slot_for_next_nonce=$(echo "(${slot_tip} - ${slot_in_epoch} + ${EPOCH_LENGTH}) - (3 * ${BYRON_K} / ${ACTIVE_SLOTS_COEFF})" | bc) # firstSlotOfNextEpoch - stabilityWindow(3 * k / f)
     curr_epoch=$(getEpoch)
     next_epoch=$((curr_epoch+1))
-    slot_tip=$(getSlotTip)
-    slot_in_epoch=$(getSlotInEpoch)
-    if [[ ${first_run} = "true" ]]; then # First startup, run leaderlogs for current epoch and merge with current data if it exist
-      blocks_file="${BLOCKLOG_DIR}/blocks_${curr_epoch}.json"
-      if ! dumpLedgerState; then sleep 300; continue; fi
-      cncli_leaderlog=$(${CNCLI} leaderlog --db "${CNCLI_DB}" --byron-genesis "${BYRON_GENESIS_JSON}" --shelley-genesis "${GENESIS_JSON}" --ledger-set current --ledger-state "${ledger_state_file}" --pool-id "${POOL_ID}" --pool-vrf-skey "${POOL_VRF_SKEY}" --tz UTC)
-      [[ ! -f "${blocks_file}" ]] && echo "[]" > "${blocks_file}"
-      if [[ $(jq -r .status <<< "${cncli_leaderlog}") != ok ]]; then
-        echo "ERROR: failure in leaderlog while running:"
-        echo "${CNCLI} leaderlog --db ${CNCLI_DB} --byron-genesis ${BYRON_GENESIS_JSON} --shelley-genesis ${GENESIS_JSON} --ledger-set current --ledger-state ${ledger_state_file} --pool-id ${POOL_ID} --pool-vrf-skey ${POOL_VRF_SKEY}"
-        echo "Error message: $(jq -r '.errorMessage //empty' <<< "${cncli_leaderlog}")"
-        continue
-      fi
-      blocks_data="$(cat "${blocks_file}")"
-      while read -r assigned_slot; do
-        slot=$(jq -r '.slot' <<< "${assigned_slot}")
-        slot_search=$(jq --argjson _slot ${slot} '.[] | select(.slot == $_slot)' "${blocks_file}")
-        if [[ -z ${slot_search} ]]; then
-          at=$(jq -r '.at' <<< "${assigned_slot}")
-          slotInEpoch=$(jq -r '.slotInEpoch' <<< "${assigned_slot}")
-          blocks_data="$(jq --arg _at "${at}" --argjson _slot ${slot} --argjson _slotInEpoch ${slotInEpoch} '. += [{"at": $_at,"slot": $_slot,"slotInEpoch": $_slotInEpoch,"status": "leader"}]' <<< "${blocks_data}")"
-          echo "LEADER: slot[${slot}] slotInEpoch[${slotInEpoch}] at[${at}]"
-        fi
-      done < <(jq -c '.assignedSlots[]' <<< "${cncli_leaderlog}" 2>/dev/null)
-      jq -r . <<< "${blocks_data}" > "${blocks_file}"
-      first_run="false"
-    fi
-    blocks_file="${BLOCKLOG_DIR}/blocks_${next_epoch}.json"
-    
-    if [[ ! -f "${blocks_file}" && ${slot_tip} -gt ${slot_for_next_nonce} ]]; then # Run leaderlogs for next epoch
-      if ! dumpLedgerState; then sleep 300; continue; fi
+    if [[ ${slot_tip} -gt ${slot_for_next_nonce} ]]; then # Run leaderlogs for next epoch
+      echo "Running leaderlogs for next epoch[${next_epoch}]"
+      if ! dumpLedgerState; then sleep 600; continue; fi # Sleep for 10 min before trying to dump ledger-state in case of error
       cncli_leaderlog=$(${CNCLI} leaderlog --db "${CNCLI_DB}" --byron-genesis "${BYRON_GENESIS_JSON}" --shelley-genesis "${GENESIS_JSON}" --ledger-set next --ledger-state "${ledger_state_file}" --pool-id "${POOL_ID}" --pool-vrf-skey "${POOL_VRF_SKEY}" --tz UTC)
       if [[ $(jq -r .status <<< "${cncli_leaderlog}") != ok ]]; then
-        echo "ERROR: failure in leaderlog while running:"
-        echo "${CNCLI} leaderlog --db ${CNCLI_DB} --byron-genesis ${BYRON_GENESIS_JSON} --shelley-genesis ${GENESIS_JSON} --ledger-set next --ledger-state ${ledger_state_file} --pool-id ${POOL_ID} --pool-vrf-skey ${POOL_VRF_SKEY}"
-        echo "Error message: $(jq -r '.errorMessage //empty' <<< "${cncli_leaderlog}")"
-        continue
+        if [[ "${error_msg}" = "Query returned no rows" ]]; then
+          echo "No leader slots found for epoch ${curr_epoch} :("
+        else
+          echo "ERROR: failure in leaderlog while running:"
+          echo "${CNCLI} leaderlog --db ${CNCLI_DB} --byron-genesis ${BYRON_GENESIS_JSON} --shelley-genesis ${GENESIS_JSON} --ledger-set next --ledger-state ${ledger_state_file} --pool-id ${POOL_ID} --pool-vrf-skey ${POOL_VRF_SKEY} --tz UTC"
+          echo "Error message: $(jq -r '.errorMessage //empty' <<< "${cncli_leaderlog}")"
+        fi
+      else
+        while read -r assigned_slot; do
+          block_slot=$(jq -r '.slot' <<< "${assigned_slot}")
+          block_at=$(jq -r '.at' <<< "${assigned_slot}")
+          block_slot_in_epoch=$(jq -r '.slotInEpoch' <<< "${assigned_slot}")
+          sqlite3 "${BLOCKLOG_DB}" "INSERT OR IGNORE INTO blocklog (slot,at,slot_in_epoch,epoch,status) values (${block_slot},'${block_at}',${block_slot_in_epoch},${next_epoch},'leader');"
+          echo "LEADER: slot[${block_slot}] slotInEpoch[${block_slot_in_epoch}] at[${block_at}]"
+        done < <(jq -c '.assignedSlots[]' <<< "${cncli_leaderlog}" 2>/dev/null)
+        echo "Leaderlogs calculation for next epoch[${next_epoch}] completed and saved to blocklog DB"
       fi
-      jq -r '.assignedSlots | .[] += {"status": "leader"}' <<< "${cncli_leaderlog}" > "${blocks_file}"
-      echo "Leaderlogs for next epoch[${next_epoch}] calculated and saved to ${blocks_file}"
+      has_run_leader=true
     fi
   done
 }
@@ -251,113 +318,153 @@ cncliLeaderlog() {
 
 cncliValidate() {
   echo "~ CNCLI Block Validation started ~"
-  if [[ ${subarg} = "--all" ]]; then
+  if ! getPoolVrfVkeyCborHex; then exit 1; fi # We need this to properly validate block
+  createBlocklogDB || exit 1 # create db if needed
+  if ! getShelleyTransitionEpoch; then echo "ERROR: failed to calculate shelley transition epoch" && exit 1; fi
+  if [[ -n ${subarg} ]]; then
     node_metrics=$(getNodeMetrics)
-    block_tip=$(getBlockTip)
     slot_tip=$(getSlotTip)
-    while IFS= read -r -d '' blocks_file; do
-      echo "> Validating: $(basename "${blocks_file}")"
-      blocks_data="$(cat "${blocks_file}")"
-      while read -r block; do
-        block_status=$(jq -r '.status //empty' <<< "${block}")
-        [[ ${block_status} = confirmed || ${block_status} = ghosted ]] && block_status="adopted" # reset status to adopted to revalidate all adopted|confirmed|ghosted blocks
-        validateBlock
-      done < <(jq -c '.[]' "${blocks_file}" 2>/dev/null)
-      jq -r . <<< "${blocks_data}" > "${blocks_file}"
-    done < <(find "${BLOCKLOG_DIR}" -mindepth 1 -maxdepth 1 -type f -name "blocks_*" -print0 | sort -z)
+    if ! cncliDBinSync; then # verify that cncli DB is still in sync
+      echo "CNCLI DB out of sync :( [$(printf "%2.4f %%" ${cncli_sync_prog})] ... check cncli sync service!"
+      exit 1
+    fi
+    tip_diff=$(( $(getSlotTipRef) - slot_tip ))
+    [[ ${tip_diff} -gt 300 ]] && echo "ERROR: node still syncing, ${tip_diff} slots from theoretical tip" && exit 1
+    block_tip=$(getBlockTip)
+    epoch=0
+    epoch_selection=""
+    if [[ ${subarg} =~ ^[0-9]+$ ]]; then
+      epoch_selection="WHERE epoch = ${subarg}"
+    elif [[ ${subarg} != "all" ]]; then
+      echo "ERROR: unknown argument passed to validate command, valid options incl the string 'all' or the epoch number to validate"
+      exit 1
+    fi
+    while read -r block_epoch block_slot block_status block_hash; do
+      [[ ${epoch} -ne ${block_epoch} ]] && echo -e "> Validating epoch ${FG_GREEN}${block_epoch}${NC}" && epoch=${block_epoch}
+      [[ ${block_status} != invalid ]] && block_status="leader" # reset status to leader to re-validate all non invalid blocks
+      validateBlock
+    done < <(sqlite3 -column "${BLOCKLOG_DB}" "SELECT epoch, slot, status, hash FROM blocklog ${epoch_selection} ORDER BY slot;")
   elif [[ -n ${subarg} ]]; then
     echo "ERROR: unknown argument passed to validate subcommand" && usage
   else
     while true; do
       sleep ${SLEEP_RATE}
       node_metrics=$(getNodeMetrics)
-      block_tip=$(getBlockTip)
       slot_tip=$(getSlotTip)
+      if ! cncliDBinSync; then # verify that cncli DB is still in sync
+        echo "CNCLI DB out of sync :( [$(printf "%2.4f %%" ${cncli_sync_prog})] ... checking again in ${SLEEP_RATE}s"
+        continue
+      fi
+      block_tip=$(getBlockTip)
       curr_epoch=$(getEpoch)
       prev_epoch=$((curr_epoch-1))
-      # Start with previous epoch to catch epoch boundary cases
-      blocks_file="${BLOCKLOG_DIR}/blocks_${prev_epoch}.json"
-      if [[ -f "${blocks_file}" ]]; then
-        blocks_data="$(cat "${blocks_file}")"
-        while read -r block; do
-          block_status=$(jq -r '.status //empty' <<< "${block}")
-          validateBlock
-        done < <(jq -c '.[]' "${blocks_file}" 2>/dev/null)
-        jq -r . <<< "${blocks_data}" > "${blocks_file}"
-      fi
-      # continue with current epoch
-      blocks_file="${BLOCKLOG_DIR}/blocks_${curr_epoch}.json"
-      if [[ -f "${blocks_file}" ]]; then
-        blocks_data="$(cat "${blocks_file}")"
-        while read -r block; do
-          block_status=$(jq -r '.status //empty' <<< "${block}")
-          validateBlock
-        done < <(jq -c '.[]' "${blocks_file}" 2>/dev/null)
-        jq -r . <<< "${blocks_data}" > "${blocks_file}"
-      fi
+      # Check both previous epoch and current to catch epoch boundary cases
+      while read -r block_epoch block_slot block_status block_hash; do
+        validateBlock
+      done < <(sqlite3 -column "${BLOCKLOG_DB}" "SELECT epoch, slot, status, hash FROM blocklog WHERE epoch BETWEEN ${prev_epoch} and ${curr_epoch} ORDER BY slot;")
     done
   fi
 }
 
 validateBlock() {
   [[ ${block_status} = invalid ]] && return
-  if [[ ${block_status} = leader ]]; then
-    block_slot=$(jq -r '.slot' <<< "${block}")
-    [[ $((block_slot + CONFIRM_SLOT_CNT)) -ge ${slot_tip} ]] && return
-    # assume lost for now, TODO: use cncli/sqlite to check if slot was made by another pool
-    blocks_data="$(jq --argjson _slot ${block_slot} '[.[] | select(.slot == $_slot) += {"status": "missed"}]' <<< "${blocks_data}")"
-    echo "MISSED: Leader for slot '${block_slot}' but not adopted. Verify that logMonitor companion script is running and working!"
-  elif [[ ${block_status} = adopted ]]; then
-    block_slot=$(jq -r '.slot' <<< "${block}")
-    [[ $((slot_tip - block_slot)) -lt ${CONFIRM_SLOT_CNT} ]] && return # To make sure enough slots has passed before validating
-    block_hash=$(jq -r '.hash //empty' <<< "${block}")
-    if [[ -n ${block_hash} ]]; then # Can't validate without a hash
-      cncli_block_data=$(${CNCLI} validate --hash "${block_hash}" --db "${CNCLI_DB}")
-      if [[ $(jq -r .status <<< "${cncli_block_data}") = ok ]]; then
-        cncli_slot_nbr=$(jq -r .slot_number <<< "${cncli_block_data}")
-        if [[ ${cncli_slot_nbr} -ne ${block_slot} ]]; then
-          echo "ERROR: CNCLI slot nbr[${cncli_slot_nbr}] doesn't match adopted block slot nbr[${block_slot}] for hash '${block_hash}'"
-        else
-          cncli_block_nbr=$(jq -r .block_number <<< "${cncli_block_data}")
-          [[ $((block_tip-cncli_block_nbr)) -lt ${CONFIRM_BLOCK_CNT} ]] && return # To make sure enough blocks has been built on top before validating
-          # Block confimed
-          cncli_block_hash=$(jq -r .hash <<< "${cncli_block_data}")
-          blocks_data="$(jq --argjson _slot ${block_slot} --argjson _block ${cncli_block_nbr} --arg _hash "${cncli_block_hash}" '[.[] | select(.slot == $_slot) += {"block": $_block,"hash": $_hash,"status": "confirmed"}]' <<< "${blocks_data}")"
-          echo "CONFIRMED: Block[${cncli_block_nbr}] / Slot[${block_slot}] at $(date '+%F %T Z' --date="$(jq -r '.at' <<< "${block}")"), hash: ${cncli_block_hash}"
-        fi
+  if [[ ${block_status} = leader || ${block_status} = adopted ]]; then
+    [[ ${block_slot} -gt ${slot_tip} ]] && return # block in the future, wait
+    slot_ok_cnt=$(sqlite3 "${CNCLI_DB}" "SELECT COUNT(*) FROM chain WHERE slot_number=${block_slot} AND orphaned=0;")
+    IFS='|' && read -ra block_data <<< "$(sqlite3 "${CNCLI_DB}" "SELECT block_number, hash, block_size, orphaned FROM chain WHERE slot_number = ${block_slot} AND node_vrf_vkey;")" && IFS=' '
+    if [[ ${block_status} = leader && $((block_slot + CONFIRM_SLOT_CNT)) -le ${slot_tip} ]]; then # just check if block was adopted
+      if [[ ${#block_data[@]} -eq 1 ]]; then
+        echo "ADOPTED: Leader for slot '${block_slot}' and adopted by chain, waiting for confirmation"
+        sqlite3 "${BLOCKLOG_DB}" "UPDATE blocklog SET status = 'adopted', slot_in_epoch = $(getSlotInEpochFromSlot ${block_slot} ${block_epoch}), block = ${block_data[0]}, at = '$(getDateFromSlot ${block_slot})', hash = '${block_data[1]}', size = ${block_data[2]} WHERE slot = ${block_slot};"
+      fi
+    fi
+    [[ $((block_tip-${block_data[0]})) -lt ${CONFIRM_BLOCK_CNT} ]] && return # To make sure enough blocks has been built on top before validating
+    if [[ ${#block_data[@]} -eq 0 ]]; then
+      if [[ ${slot_ok_cnt} -eq 0 ]]; then
+        echo "MISSED: Leader for slot '${block_slot}' but not adopted and no other pool has made a block for this slot"
+        sqlite3 "${BLOCKLOG_DB}" "UPDATE blocklog SET status = 'missed' WHERE slot = ${block_slot};"
       else
-        blocks_data="$(jq --argjson _slot ${block_slot} '[.[] | select(.slot == $_slot) += {"status": "ghosted"}]' <<< "${blocks_data}")"
-        echo "GHOSTED: Leader for slot '${block_slot}' but block hash '${block_hash}' not found, stolen in slot/height battle or block propagation issue!"
+        echo "STOLEN: Leader for slot '${block_slot}' but \"stolen\" by another pool due to bad luck (lower VRF output) :("
+        sqlite3 "${BLOCKLOG_DB}" "UPDATE blocklog SET status = 'stolen' WHERE slot = ${block_slot};"
       fi
     else
-      echo "ERROR: Block adopted for slot '${block_slot}' but no hash logged?"
+      if [[ ${block_data[3]} -eq 0 ]]; then
+        echo "CONFIRMED: Leader for slot '${block_slot}' and match found in CNCLI DB for this slot with pool's VRF public key"
+        sqlite3 "${BLOCKLOG_DB}" "UPDATE blocklog SET status = 'confirmed', slot_in_epoch = $(getSlotInEpochFromSlot ${block_slot} ${block_epoch}), block = ${block_data[0]}, at = '$(getDateFromSlot ${block_slot})', hash = '${block_data[1]}', size = ${block_data[2]} WHERE slot = ${block_slot};"
+      else
+        if [[ ${slot_ok_cnt} -eq 0 ]]; then
+          echo "GHOSTED: Leader for slot '${block_slot}' and block adopted but later orphaned. No other pool with a confirmed block for this slot, height battle or block propagation issue!"
+          sqlite3 "${BLOCKLOG_DB}" "UPDATE blocklog SET status = 'ghosted' WHERE slot = ${block_slot};"
+        else
+          echo "STOLEN: Leader for slot '${block_slot}' but \"stolen\" by another pool due to bad luck (lower VRF output) :("
+          sqlite3 "${BLOCKLOG_DB}" "UPDATE blocklog SET status = 'stolen' WHERE slot = ${block_slot};"
+        fi
+      fi
     fi
   fi
 }
 
 #################################
 
+cncliInitBlocklogDB() {
+  [[ "${PROTOCOL}" != "Cardano" ]] && echo "ERROR: protocol not Cardano mode, not a valid network" && exit 1
+  if ! getPoolVrfVkeyCborHex; then exit 1; fi
+  if ! getShelleyTransitionEpoch; then echo "ERROR: failed to calculate shelley transition epoch" && exit 1; fi
+  node_metrics=$(getNodeMetrics)
+  slot_tip=$(getSlotTip)
+  if ! cncliDBinSync; then # verify that cncli DB is still in sync
+    echo "CNCLI DB out of sync :( [$(printf "%2.4f %%" ${cncli_sync_prog})] ... check cncli sync service!"
+    exit 1
+  fi
+  tip_diff=$(( $(getSlotTipRef) - slot_tip ))
+  [[ ${tip_diff} -gt 300 ]] && echo "ERROR: node still syncing, ${tip_diff} slots from theoretical tip" && exit 1
+  createBlocklogDB || exit 1 # create db if needed
+  echo "Looking for blocks made by pool..."
+  block_cnt=0
+  while read -r block_number slot_number hash block_size orphaned; do
+    # Calculate epoch, at and slot_in_epoch
+    epoch=$(getEpochFromSlot ${slot_number})
+    at=$(getDateFromSlot ${slot_number})
+    slot_in_epoch=$(getSlotInEpochFromSlot ${slot_number} ${epoch})
+    sqlite3 "${BLOCKLOG_DB}" "INSERT OR REPLACE INTO blocklog (slot,at,epoch,block,slot_in_epoch,hash,size,status) values (${slot_number},'${at}',${epoch},${block_number},${slot_in_epoch},'${hash}',${block_size},'adopted');"
+    ((block_cnt++))
+  done < <(sqlite3 -column "${CNCLI_DB}" "SELECT block_number, slot_number, hash, block_size, orphaned FROM chain WHERE node_vrf_vkey = '${pool_vrf_vkey_cbox_hex}' ORDER BY slot_number;")
+  if [[ ${block_cnt} -eq 0 ]]; then
+    echo "No blocks found :("
+  else
+    echo "Successfully added/updated ${block_cnt} blocks in blocklog DB!"
+    echo "Validating all blocks..."
+    subarg="all"
+    cncliValidate
+  fi
+}
+
+#################################
+
 cncliMigrateBlocklog() {
+  [[ ! -d ${subarg} ]] && echo -e "\nERROR: unable to locate directory holding cntoolsBlockCollector blocklog json files:\n${subarg}" && usage
+  if ! getShelleyTransitionEpoch; then echo "ERROR: failed to calculate shelley transition epoch" && exit 1; fi
+  createBlocklogDB || exit 1 # create db if needed
   while IFS= read -r -d '' blocks_file; do
     echo "> Migrating: $(basename "${blocks_file}")"
+    [[ ${blocks_file} =~ blocks_([0-9]+) ]] && epoch=${BASH_REMATCH[1]} || epoch=0
     blocks_data="$(cat "${blocks_file}")"
     while read -r block; do
-      block_status=$(jq -r '.status //empty' <<< "${block}")
-      if [[ -z ${block_status} ]]; then # migration from old blocklog pre cncli
-        block_slot=$(jq -r '.slot' <<< "${block}")
-        block_hash=$(jq -r '.hash //empty' <<< "${block}")
-        block_size=$(jq -r '.size //0' <<< "${block}")
-        if [[ -n ${block_hash} ]]; then
-          [[ ${block_hash} =~ ^Invalid ]] && block_status="invalid" || block_status="adopted"
-        else
-          block_status="leader"
-        fi
-        blocks_data="$(jq --argjson _slot ${block_slot} --argjson _size ${block_size} --arg _status "${block_status}" '[.[] | select(.slot == ($_slot | tostring)) += {"slot": $_slot,"size": $_size,"status": $_status}]' <<< "${blocks_data}")"
-        echo "Block at slot ${block_slot} updated with status '${block_status}'"
+      block_slot=$(jq -r '.slot' <<< "${block}")
+      block_at=$(jq -r '.at' <<< "${block}" | sed 's/\.[0-9]\{2\}Z/+00:00/')
+      block_hash=$(jq -r '.hash //empty' <<< "${block}")
+      block_size=$(jq -r '.size //0' <<< "${block}")
+      slot_in_epoch=$(getSlotInEpochFromSlot ${block_slot} ${epoch})
+      if [[ -n ${block_hash} ]]; then
+        [[ ${block_hash} =~ ^Invalid ]] && block_status="invalid" || block_status="adopted"
+        sqlite3 "${BLOCKLOG_DB}" "INSERT OR REPLACE INTO blocklog (slot,slot_in_epoch,at,epoch,size,hash,status) values (${block_slot},${slot_in_epoch},'${block_at}',${epoch},${block_size},'${block_hash}','${block_status}');"
+      else
+        block_status="leader"
+        sqlite3 "${BLOCKLOG_DB}" "INSERT OR REPLACE INTO blocklog (slot,slot_in_epoch,at,epoch,status) values (${block_slot},${slot_in_epoch},'${block_at}',${epoch},'leader');"
       fi
+      echo "Block at slot ${block_slot} added/updated, status '${block_status}'"
     done < <(jq -c '.[]' <<< "${blocks_data}" 2>/dev/null)
-    jq -r . <<< "${blocks_data}" > "${blocks_file}"
-  done < <(find "${BLOCKLOG_DIR}" -mindepth 1 -maxdepth 1 -type f -name "blocks_*" -print0 | sort -z)
+  done < <(find "${subarg}" -mindepth 1 -maxdepth 1 -type f -name "blocks_*.json" -print0 | sort -z)
 }
 
 #################################
@@ -397,6 +504,8 @@ case ${subcommand} in
     cncliInit && cncliValidate ;;
   ptsendtip )
     cncliInit && cncliPTsendtip ;;
+  init )
+    cncliInit && cncliInitBlocklogDB ;;
   migrate )
     cncliInit && cncliMigrateBlocklog ;;
   * ) usage ;;

--- a/scripts/cnode-helper-scripts/cncli.sh
+++ b/scripts/cnode-helper-scripts/cncli.sh
@@ -371,7 +371,7 @@ validateBlock() {
   if [[ ${block_status} = leader || ${block_status} = adopted ]]; then
     [[ ${block_slot} -gt ${slot_tip} ]] && return # block in the future, wait
     slot_ok_cnt=$(sqlite3 "${CNCLI_DB}" "SELECT COUNT(*) FROM chain WHERE slot_number=${block_slot} AND orphaned=0;")
-    IFS='|' && read -ra block_data <<< "$(sqlite3 "${CNCLI_DB}" "SELECT block_number, hash, block_size, orphaned FROM chain WHERE slot_number = ${block_slot} AND node_vrf_vkey;")" && IFS=' '
+    IFS='|' && read -ra block_data <<< "$(sqlite3 "${CNCLI_DB}" "SELECT block_number, hash, block_size, orphaned FROM chain WHERE slot_number = ${block_slot} AND node_vrf_vkey = '${pool_vrf_vkey_cbox_hex}';")" && IFS=' '
     if [[ ${block_status} = leader && $((block_slot + CONFIRM_SLOT_CNT)) -le ${slot_tip} ]]; then # just check if block was adopted
       if [[ ${#block_data[@]} -eq 1 ]]; then
         echo "ADOPTED: Leader for slot '${block_slot}' and adopted by chain, waiting for confirmation"

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -2304,22 +2304,22 @@ function printTable() {
         numberOfColumns="$(awk -F "${delimiter}" '{print NF}' <<< "${line}")"
         # Add Line Delimiter
         if [[ "${i}" -eq '1' ]]; then
-          table="${table}$(printf '%s#+' "$(repeatString '#+' "${numberOfColumns}")")"
+          table="${table}$(printf '%s@+' "$(repeatString '@+' "${numberOfColumns}")")"
         fi
         # Add Header Or Body
         table="${table}\n"
         local j=1
         for ((j = 1; j <= "${numberOfColumns}"; j = j + 1)); do
-          table="${table}$(printf '#| %s' "$(cut -d "${delimiter}" -f "${j}" <<< "${line}")")"
+          table="${table}$(printf '@| %s' "$(cut -d "${delimiter}" -f "${j}" <<< "${line}")")"
         done
-        table="${table}#|\n"
+        table="${table}@|\n"
         # Add Line Delimiter
         if [[ "${i}" -eq '1' ]] || [[ "${numberOfLines}" -gt '1' && "${i}" -eq "${numberOfLines}" ]]; then
-          table="${table}$(printf '%s#+' "$(repeatString '#+' "${numberOfColumns}")")"
+          table="${table}$(printf '%s@+' "$(repeatString '@+' "${numberOfColumns}")")"
         fi
       done
       if [[ "$(isEmptyString "${table}")" = 'false' ]]; then
-        echo -e "${table}" | column -s '#' -t | awk '/^\+/{gsub(" ", "-", $0)}1'
+        echo -e "${table}" | column -s '@' -t | awk '/^\+/{gsub(" ", "-", $0)}1'
       fi
     fi
   fi

--- a/scripts/cnode-helper-scripts/deploy-as-systemd.sh
+++ b/scripts/cnode-helper-scripts/deploy-as-systemd.sh
@@ -40,10 +40,11 @@ echo
 echo -e "\e[32m~~ Blocklog ~~\e[0m"
 echo "A collection of services that together creates a blocklog of current and upcoming blocks"
 echo "Dependant on ${vname}.service and when started|stopped|restarted all these companion services will apply the same action"
-echo "logmonitor      : parses JSON log of cardano-node for traces of interest"
 echo "cncli-sync      : Start CNCLI chainsync process that connects to cardano-node to sync blocks stored in SQLite DB"
 echo "cncli-leaderlog : Loops through all slots in current epoch to calculate leader schedule"
 echo "cncli-validate  : Confirms that the block made actually was accepted and adopted by chain"
+echo -e "logmonitor      : parses JSON log of cardano-node for traces of interest (deployed but \e[31mdisabled\e[0m by default)"
+echo "                : gives instant adopted status and invalid status but not required for blocklog to function"
 echo
 if command -v "${CNCLI}" >/dev/null; then
   echo "deploy as systemd services? [y|n]"
@@ -214,7 +215,7 @@ fi
 sudo systemctl daemon-reload
 echo
 [[ -f /etc/systemd/system/${vname}.service ]] && sudo systemctl enable ${vname}.service
-[[ -f /etc/systemd/system/${vname}-logmonitor.service ]] && sudo systemctl enable ${vname}-logmonitor.service
+#[[ -f /etc/systemd/system/${vname}-logmonitor.service ]] && sudo systemctl enable ${vname}-logmonitor.service
 [[ -f /etc/systemd/system/${vname}-cncli-sync.service ]] && sudo systemctl enable ${vname}-cncli-sync.service
 [[ -f /etc/systemd/system/${vname}-cncli-leaderlog.service ]] && sudo systemctl enable ${vname}-cncli-leaderlog.service
 [[ -f /etc/systemd/system/${vname}-cncli-validate.service ]] && sudo systemctl enable ${vname}-cncli-validate.service

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -17,7 +17,7 @@ CNODE_PORT=6000                                         # Set node port
 #EKG_TIMEOUT=3                                          # Maximum time in seconds that you allow EKG request to take before aborting (node metrics)
 #CURL_TIMEOUT=10                                        # Maximum time in seconds that you allow curl file download to take before aborting (GitHub update process)
 #BLOCKLOG_DIR="${CNODE_HOME}/guild-db/blocklog"         # Override default directory used to store block data for core node
-#BLOCKLOG_TZ="UTC"                                      # TimeZone to use in blocklog viewer - https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+#BLOCKLOG_TZ="UTC"                                      # TimeZone to use when displaying blocklog - https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 
 ######################################
 # Do NOT modify code below           #
@@ -113,7 +113,21 @@ else
 fi
 
 [[ -z ${BLOCKLOG_DIR} ]] && BLOCKLOG_DIR="${CNODE_HOME}/guild-db/blocklog"
+BLOCKLOG_DB="${BLOCKLOG_DIR}/blocklog.db"
 [[ -z ${BLOCKLOG_TZ} ]] && BLOCKLOG_TZ="UTC"
+createBlocklogDB() {
+  if ! mkdir -p "${BLOCKLOG_DIR}"; then echo "ERROR: failed to create directory to store blocklog: ${BLOCKLOG_DIR}" && return 1; fi
+  if ! command -v sqlite3 >/dev/null; then echo "ERROR: sqlite3 not found, please install before activating blocklog function" && return 1; fi
+  if [[ ! -f ${BLOCKLOG_DB} ]]; then
+    sqlite3 ${BLOCKLOG_DB} <<EOF
+CREATE TABLE blocklog (id INTEGER PRIMARY KEY AUTOINCREMENT, slot INTEGER NOT NULL UNIQUE, at TEXT NOT NULL UNIQUE, epoch INTEGER NOT NULL, block INTEGER NOT NULL DEFAULT 0, slot_in_epoch INTEGER NOT NULL DEFAULT 0, hash TEXT NOT NULL DEFAULT '', size INTEGER NOT NULL DEFAULT 0, status TEXT NOT NULL);
+CREATE UNIQUE INDEX idx_blocklog_slot ON blocklog (slot);
+CREATE INDEX idx_blocklog_epoch ON blocklog (epoch);
+CREATE INDEX idx_blocklog_status ON blocklog (status);
+EOF
+    echo "SQLite blocklog DB created: ${BLOCKLOG_DB}"
+  fi
+}
 
 CNODE_PID=$(pgrep -fn "[c]ardano-node*.*--port ${CNODE_PORT}")
 

--- a/scripts/cnode-helper-scripts/logMonitor.sh
+++ b/scripts/cnode-helper-scripts/logMonitor.sh
@@ -48,7 +48,7 @@ while read -r logentry; do
       slot="$(jq -r '.data.slot' <<< ${logentry})"
       [[ "$(jq -r '.data.blockHash' <<< ${logentry})" =~ ([[:alnum:]]+) ]] && hash="${BASH_REMATCH[1]}" || hash=""
       size="$(jq -r '.data.blockSize' <<< ${logentry})"
-      echo "ADOPTED: slot[${slot}] size=${size} hash=${block_hash}"
+      echo "ADOPTED: slot[${slot}] size=${size} hash=${hash}"
       sqlite3 "${BLOCKLOG_DB}" "UPDATE blocklog SET status = 'adopted', size = ${size}, hash = '${hash}' WHERE slot = ${slot};"
       ;;
     *TraceForgedInvalidBlock* )


### PR DESCRIPTION
Major rewrite of cncli.sh and blocklog in general.

- json blocklog storage replaced with SQLite DB
- cncli.sh rewritten to to work with sqlite and additional functionality added
  - validate now able to take epoch number to revalidate
  - init function added that adds all confirmed blocks
- logMonitor.sh no longer required to get block hash for validation but still available for faster adopted status and invalid blocks. Service deployed but disabled by default.
- Documentation updated