### PR TITLE
Topology Updater systemd deployment based on input from #588

### DIFF
--- a/scripts/cnode-helper-scripts/cnode.sh
+++ b/scripts/cnode-helper-scripts/cnode.sh
@@ -4,7 +4,7 @@
 
 [[ -z "${CNODE_HOME}" ]] && CNODE_HOME="/opt/cardano/cnode"
 
-. "${CNODE_HOME}"/scripts/env
+. "${CNODE_HOME}"/scripts/env offline
 
 ######################################
 # User Variables - Change as desired #

--- a/scripts/cnode-helper-scripts/createAddr.sh
+++ b/scripts/cnode-helper-scripts/createAddr.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # shellcheck disable=SC2086,SC1090
-. "$(dirname $0)"/env
+. "$(dirname $0)"/env offline
 
 if  [ "$1" = "--help" ] || [ $# -ne 1 ]; then
   echo "Usage: $0 <Path with name (prefix) for keys to be created>"

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -23,6 +23,11 @@ CNODE_PORT=6000                                         # Set node port
 # Do NOT modify code below           #
 ######################################
 
+OFFLINE_MODE='N'
+[[ $1 = "offline" ]] && OFFLINE_MODE='Y'
+[[ $(basename $0) = "cnode.sh" ]] && OFFLINE_MODE='Y' # for backwards compatibility
+[[ $(basename $0) = "topologyUpdater.sh" ]] && OFFLINE_MODE='Y' # for backwards compatibility
+
 export LC_ALL=C.UTF-8
 
 [[ -z ${CURL_TIMEOUT} ]] && CURL_TIMEOUT=10
@@ -51,8 +56,8 @@ fi
 if [[ -z "${SOCKET}" ]]; then
   if [[ "$(ps -ef | grep "[c]ardano-node.*.${CNODE_HOME}/")" =~ --socket-path[[:space:]]([^[:space:]]+) ]]; then
     export CARDANO_NODE_SOCKET_PATH="${BASH_REMATCH[1]}"
-  else
-    [[ $(basename $0) != "cnode.sh" ]] && [[ $(basename $0) != "createAddr.sh" ]] && echo "Node socket not set in env file and automatic detection failed!"
+  elif [[ ${OFFLINE_MODE} = "N" ]]; then
+    echo "Node socket not set in env file and automatic detection failed! [source: $(basename $0)]"
     return 1
   fi
 else
@@ -62,7 +67,9 @@ fi
 if [[ -z "${CONFIG}" ]]; then
   if [[ "$(ps -ef | grep "[c]ardano-node.*.${CNODE_HOME}/")" =~ --config[[:space:]]([^[:space:]]+) ]]; then
     CONFIG=${BASH_REMATCH[1]}
-  else
+  elif [[ -f "${CNODE_HOME}/files/config.json" ]]; then
+    CONFIG="${CNODE_HOME}/files/config.json"
+  elif [[ ${OFFLINE_MODE} = "N" ]]; then
     echo "Node config not set in env file and automatic detection failed!"
     return 1
   fi
@@ -86,8 +93,10 @@ fi
 
 if [[ -z ${EKG_PORT} ]]; then
   if ! EKG_PORT=$(jq -er '.hasEKG' "${CONFIG}" 2>/dev/null); then
-    echo "Could not get 'hasEKG' port from the node configuration file"
-    return 1
+    if [[ ${OFFLINE_MODE} = "N" ]]; then
+      echo "Could not get 'hasEKG' port from the node configuration file"
+      return 1
+    fi
   fi
 elif [[ ! ${EKG_PORT} =~ ^[0-9]+$ ]]; then
   echo "Please set a valid EKG port number in env file!"
@@ -95,8 +104,17 @@ elif [[ ! ${EKG_PORT} =~ ^[0-9]+$ ]]; then
 fi
 
 if ! GENESIS_JSON=$(jq -er '.ShelleyGenesisFile' "${CONFIG}" 2>/dev/null); then
-  echo "Could not get 'ShelleyGenesisFile' from the node configuration file"
-  return 1
+  if [[ ${OFFLINE_MODE} = "Y" ]]; then
+    if [[ -f "${CNODE_HOME}/files/genesis.json" ]]; then
+      GENESIS_JSON="${CNODE_HOME}/files/genesis.json"
+    else
+      echo "Could not find shelley genesis file in default location or 'ShelleyGenesisFile' from the node configuration file"
+      return 1
+    fi
+  else
+    echo "Could not get 'ShelleyGenesisFile' from the node configuration file"
+    return 1
+  fi
 else
   # if relative path is used, assume same parent dir as config
   [[ ! ${GENESIS_JSON} =~ ^/ ]] && GENESIS_JSON="$(dirname "${CONFIG}")/${GENESIS_JSON}"
@@ -104,8 +122,17 @@ else
 fi
 
 if ! BYRON_GENESIS_JSON=$(jq -er '.ByronGenesisFile' "${CONFIG}" 2>/dev/null); then
-  echo "Could not get 'ByronGenesisFile' from the node configuration file"
-  return 1
+  if [[ ${OFFLINE_MODE} = "Y" ]]; then
+    if [[ -f "${CNODE_HOME}/files/genesis.json" ]]; then
+      GENESIS_JSON="${CNODE_HOME}/files/genesis.json"
+    else
+      echo "Could not find byron genesis file in default location or 'ByronGenesisFile' from the node configuration file"
+      return 1
+    fi
+  else
+    echo "Could not get 'ByronGenesisFile' from the node configuration file"
+    return 1
+  fi
 else
   # if relative path is used, assume same parent dir as config
   [[ ! ${BYRON_GENESIS_JSON} =~ ^/ ]] && BYRON_GENESIS_JSON="$(dirname "${CONFIG}")/${BYRON_GENESIS_JSON}"

--- a/scripts/cnode-helper-scripts/topologyUpdater.sh
+++ b/scripts/cnode-helper-scripts/topologyUpdater.sh
@@ -3,14 +3,14 @@
 # shellcheck source=/dev/null
 
 PARENT="$(dirname $0)"
-[[ -f "${PARENT}"/env ]] && . "${PARENT}"/env
+[[ -f "${PARENT}"/env ]] && . "${PARENT}"/env offline
 
 ######################################
 # User Variables - Change as desired #
 ######################################
 
 CNODE_HOSTNAME="CHANGE ME"                                # (Optional) Must resolve to the IP you are requesting from
-CNODE_LOG_DIR="${CNODE_HOME}/logs/"                       # Folder where your logs will be sent to (must pre-exist)
+CNODE_LOG_DIR="${CNODE_HOME}/logs"                        # Folder where your logs will be sent to (must pre-exist)
 CNODE_VALENCY=1                                           # (Optional) for multi-IP hostnames
 CNODE_TOPOLOGY="${CNODE_HOME}/files/topology.json"        # Destination topology.json file you'd want to write output to
 MAX_PEERS=15                                              # Maximum number of peers to return on successful fetch
@@ -25,20 +25,27 @@ PARENT="$(dirname $0)"
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [-b <branch name>]
+Usage: $(basename "$0") [-b <branch name>] [-f] [-p]
 Topology Updater - Build topology with community pools
 
+-f    Disable fetch of a fresh topology file
+-p    Disable node alive push to Topology Updater API
 -b    Use alternate branch to check for updates - only for testing/development (Default: master)
 
 EOF
   exit 1
 }
 
-while getopts :b: opt; do
+TU_FETCH='Y'
+TU_PUSH='Y'
+
+while getopts :fpb: opt; do
   case ${opt} in
+    f ) TU_FETCH='N' ;;
+    p ) TU_PUSH='N' ;;
     b ) BRANCH=${OPTARG}; echo "${BRANCH}" > "${PARENT}"/.env_branch ;;
     \? ) usage ;;
-    esac
+  esac
 done
 shift $((OPTIND -1))
 
@@ -65,10 +72,18 @@ else
 fi
 rm -f "${PARENT}"/env.tmp
 
-# source common env variables in case it was updated
-if ! . "${PARENT}"/env; then exit 1; fi
+# source common env variables in case it was updated and run in offline mode, even for TU_PUSH mode as this will be cought by failed EKG query
+if ! . "${PARENT}"/env offline; then exit 1; fi
 
-blockNo=$(curl -s -m ${EKG_TIMEOUT} -H 'Accept: application/json' "http://${EKG_HOST}:${EKG_PORT}/" 2>/dev/null | jq '.cardano.node.ChainDB.metrics.blockNum.int.val //0' )
+if [[ ${TU_PUSH} = "Y" ]]; then
+  fail_cnt=0
+  while ! blockNo=$(curl -s -m ${EKG_TIMEOUT} -H 'Accept: application/json' "http://${EKG_HOST}:${EKG_PORT}/" 2>/dev/null | jq -er '.cardano.node.ChainDB.metrics.blockNum.int.val //0' ); do
+    ((fail_cnt++))
+    [[ ${fail_cnt} -eq 5 ]] && echo "5 consecutive EKG queries failed, aborting!"
+    echo "(${fail_cnt}/5) Failed to grab blockNum from node EKG metrics, sleeping for 30s before retrying... (ctrl-c to exit)"
+    sleep 30
+  done
+fi
 
 # Note: 
 # if you run your node in IPv4/IPv6 dual stack network configuration and want announced the 
@@ -81,8 +96,8 @@ fi
 
 [[ -z "${CUSTOM_PEERS}" ]] && CUSTOM_PEERS_PARAM="" || CUSTOM_PEERS_PARAM="&customPeers=${CUSTOM_PEERS}"
 
-curl -s "https://api.clio.one/htopology/v1/?port=${CNODE_PORT}&blockNo=${blockNo}&valency=${CNODE_VALENCY}&magic=${NWMAGIC}${T_HOSTNAME}" | tee -a $CNODE_LOG_DIR/topologyUpdater_lastresult.json && \
-curl -s -o "${CNODE_TOPOLOGY}".tmp "https://api.clio.one/htopology/v1/fetch/?max=${MAX_PEERS}&magic=${NWMAGIC}${CUSTOM_PEERS_PARAM}" && \
+[[ ${TU_PUSH} = "Y" ]] && curl -s "https://api.clio.one/htopology/v1/?port=${CNODE_PORT}&blockNo=${blockNo}&valency=${CNODE_VALENCY}&magic=${NWMAGIC}${T_HOSTNAME}" | tee -a $CNODE_LOG_DIR/topologyUpdater_lastresult.json
+[[ ${TU_FETCH} = "Y" ]] && curl -s -o "${CNODE_TOPOLOGY}".tmp "https://api.clio.one/htopology/v1/fetch/?max=${MAX_PEERS}&magic=${NWMAGIC}${CUSTOM_PEERS_PARAM}" && \
 mv "${CNODE_TOPOLOGY}".tmp "${CNODE_TOPOLOGY}"
 
-
+exit 0


### PR DESCRIPTION
Changes in PR is done with full backwards compatibility for old crontab job style execution. By default, topologyUpdater.sh still does a combined push/fetch call when run. Two new flags added, `-f` & `-p` to either disable fetch or push. Added to be able to separate the calls.

Adds option in `deploy-as-systemd.sh` script to deploy topologyUpdater.sh as systemd services. This will deploy both push & fetch oneshot service files as well as timers for a scheduled 60 min node alive message and cnode restart at the user set interval when running the deploy script.
```
- cnode.timer            : handles the scheduled restart of cardano-node(cnode.sh), default every 24h
- cnode-tu-fetch.service : fetches a fresh topology file before cnode.service file is started/restarted
- cnode-tu-push.service  : pushes a node alive message to Topology Updater API
- cnode-tu-push.timer    : schedules the push service to execute once every hour
```
env now takes an 'offline' arg to replace the previous static check when sourced. This change was required for some scripts to be able to source the entire env file even when there is no node alive.

Topology Updater docs updated to reflect changes.