### PR TITLE
cncli validation logic fix & logMonitor hardening

### DIFF
--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -142,25 +142,6 @@ fi
 [[ -z ${BLOCKLOG_DIR} ]] && BLOCKLOG_DIR="${CNODE_HOME}/guild-db/blocklog"
 BLOCKLOG_DB="${BLOCKLOG_DIR}/blocklog.db"
 [[ -z ${BLOCKLOG_TZ} ]] && BLOCKLOG_TZ="UTC"
-createBlocklogDB() {
-  if ! mkdir -p "${BLOCKLOG_DIR}"; then echo "ERROR: failed to create directory to store blocklog: ${BLOCKLOG_DIR}" && return 1; fi
-  if ! command -v sqlite3 >/dev/null; then echo "ERROR: sqlite3 not found, please install before activating blocklog function" && return 1; fi
-  if [[ ! -f ${BLOCKLOG_DB} ]]; then
-    sqlite3 ${BLOCKLOG_DB} <<EOF
-CREATE TABLE blocklog (id INTEGER PRIMARY KEY AUTOINCREMENT, slot INTEGER NOT NULL UNIQUE, at TEXT NOT NULL UNIQUE, epoch INTEGER NOT NULL, block INTEGER NOT NULL DEFAULT 0, slot_in_epoch INTEGER NOT NULL DEFAULT 0, hash TEXT NOT NULL DEFAULT '', size INTEGER NOT NULL DEFAULT 0, status TEXT NOT NULL);
-CREATE UNIQUE INDEX idx_blocklog_slot ON blocklog (slot);
-CREATE INDEX idx_blocklog_epoch ON blocklog (epoch);
-CREATE INDEX idx_blocklog_status ON blocklog (status);
-EOF
-    echo "SQLite blocklog DB created: ${BLOCKLOG_DB}"
-  else
-    sqlite3 ${BLOCKLOG_DB} <<EOF
-CREATE TABLE IF NOT EXISTS epochdata (id INTEGER PRIMARY KEY AUTOINCREMENT, epoch INTEGER NOT NULL, epoch_nonce TEXT NOT NULL, pool_id TEXT NOT NULL, sigma TEXT NOT NULL, d REAL NOT NULL, epoch_slots_ideal INTEGER NOT NULL, max_performance REAL NOT NULL, UNIQUE(epoch,pool_id));
-CREATE INDEX IF NOT EXISTS idx_epochdata_epoch ON epochdata (epoch);
-CREATE INDEX IF NOT EXISTS idx_epochdata_pool_id ON epochdata (pool_id);
-EOF
-  fi
-}
 
 CNODE_PID=$(pgrep -fn "[c]ardano-node*.*--port ${CNODE_PORT}")
 

--- a/scripts/cnode-helper-scripts/logMonitor.sh
+++ b/scripts/cnode-helper-scripts/logMonitor.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#shellcheck disable=SC2086
+#shellcheck disable=SC2086,SC2001
 #shellcheck source=/dev/null
 
 ######################################


### PR DESCRIPTION
env
- createBlocklogDB() moved to cncli.sh where it belongs

cncli.sh
- validation logic modification, previously marked blocks as missed in some cases
- CONFIRM_SLOT_CNT & CONFIRM_BLOCK_CNT increased to wait a bit longer before validating blocks
- `INSERT OR REPLACE` changed to `UPDATE OR IGNORE` & `INSERT OR IGNORE`
- active stake and total active stake added (cncli 0.2.9)
- DB schema versioning added to be able to gracefully add DB changes in the future.

logMonitor.sh
- Validate each jq query in case of cardano-node json logging schema changes.