### PR TITLE
Update prereqs.sh - CNCLI integration (latest tag instead of master, automake for libsodium)

### DIFF
--- a/scripts/cnode-helper-scripts/prereqs.sh
+++ b/scripts/cnode-helper-scripts/prereqs.sh
@@ -242,7 +242,7 @@ if [[ "${INSTALL_CNCLI}" = "Y" ]]; then
     pushd ./cncli >/dev/null || err_exit
   fi
   cncli_git_latestTag=$(git tag | tail -n 1)
-  cncli_git_version=$(echo $cncli_git_latestTag | sed 's/v//')
+  cncli_git_version=$(echo ${cncli_git_latestTag//v/}) 
   if [[ "${cncli_version}" != "${cncli_git_version}" ]]; then
     # install rust if not available
     if ! command -v "rustup" &>/dev/null; then

--- a/scripts/cnode-helper-scripts/prereqs.sh
+++ b/scripts/cnode-helper-scripts/prereqs.sh
@@ -242,7 +242,7 @@ if [[ "${INSTALL_CNCLI}" = "Y" ]]; then
     pushd ./cncli >/dev/null || err_exit
   fi
   cncli_git_latestTag=$(git tag | tail -n 1)
-  cncli_git_version=$(echo ${cncli_git_latestTag//v/}) 
+  cncli_git_version=${cncli_git_latestTag//v/} 
   if [[ "${cncli_version}" != "${cncli_git_version}" ]]; then
     # install rust if not available
     if ! command -v "rustup" &>/dev/null; then


### PR DESCRIPTION
fixed cncli integration:
- automake needed for libsodium build
- only the latest tag should be build not the latest master (otherwise alpha builds of cncli are build)