### PR TITLE
Update and move node version check to env

### DIFF
--- a/scripts/cnode-helper-scripts/cncli.sh
+++ b/scripts/cnode-helper-scripts/cncli.sh
@@ -102,8 +102,6 @@ getDateFromSlot() {
 
 createBlocklogDB() {
   if ! mkdir -p "${BLOCKLOG_DIR}"; then echo "ERROR: failed to create directory to store blocklog: ${BLOCKLOG_DIR}" && return 1; fi
-  
-  [[ ${cncli_version_nbr} -lt 209 ]] && echo "ERROR: $(${CNCLI} -V) installed, too old, please upgrade to 0.2.9 or newer" && return 1
   if [[ ! -f ${BLOCKLOG_DB} ]]; then # create a fresh DB with latest schema
     sqlite3 ${BLOCKLOG_DB} <<EOF
 CREATE TABLE blocklog (id INTEGER PRIMARY KEY AUTOINCREMENT, slot INTEGER NOT NULL UNIQUE, at TEXT NOT NULL UNIQUE, epoch INTEGER NOT NULL, block INTEGER NOT NULL DEFAULT 0, slot_in_epoch INTEGER NOT NULL DEFAULT 0, hash TEXT NOT NULL DEFAULT '', size INTEGER NOT NULL DEFAULT 0, status TEXT NOT NULL);
@@ -269,8 +267,8 @@ cncliInit() {
   rm -f "${PARENT}"/cncli.sh.tmp
   
   [[ ! -f "${CNCLI}" ]] && echo "ERROR: failed to locate cncli executable, please update and run 'prereqs.sh -h' to show options" && exit 1
-  IFS=" " read -r -a cncli_version <<< "$(${CNCLI} -V | cut -d' ' -f2 | tr '.' ' ')"
-  cncli_version_nbr=$(( ${cncli_version[0]:-0}*10000 + ${cncli_version[1]:-0}*100 + ${cncli_version[2]:-0} ))
+  CNCLI_VERSION="$(cncli -V | cut -d' ' -f2)"
+  if ! versionCheck "v0.4.1" "${CNCLI_VERSION}"; then echo "ERROR: cncli ${CNCLI_VERSION} installed, please upgrade to v0.4.1 or newer!"; exit 1; fi
 
   return 0
 }
@@ -278,7 +276,6 @@ cncliInit() {
 #################################
 
 cncliSync() {
-  if ! mkdir -p "${CNCLI_DIR}"; then echo "ERROR: failed to create CNCLI DB folder: ${CNCLI_DIR}" && exit 1; fi
   ${CNCLI} sync --host 127.0.0.1 --network-magic "${NWMAGIC}" --port "${CNODE_PORT}" --db "${CNCLI_DB}"
 }
 
@@ -627,7 +624,6 @@ EOF"
 #################################
 
 cncliPTsendslots() {
-  [[ ${cncli_version_nbr} -lt 301 ]] && echo "ERROR: $(${CNCLI} -V) installed, too old, please upgrade to 0.3.1 or newer" && exit 1
   [[ -z ${POOL_ID} || -z ${POOL_TICKER} || -z ${PT_API_KEY} ]] && echo "'POOL_ID' and/or 'POOL_TICKER' and/or 'PT_API_KEY' not set in $(basename "$0"), exiting!" && exit 1
   # Generate a temporary pooltool config
   pt_config="/tmp/${vname}-pooltool.json"

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -1027,8 +1027,8 @@ sendADA() {
 
   say "" 1
   say "# Calculate fee, new amount and remaining balance" 1 "log"
-  say "$ ${CCLI} transaction build-raw ${txIn} --tx-out ${dAddr}+0 --upper-bound ${ttlValue} --fee 0 ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp" 2
-  if ! ${CCLI} transaction build-raw ${txIn} --tx-out ${dAddr}+0 --upper-bound ${ttlValue} --fee 0 ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
+  say "$ ${CCLI} transaction build-raw ${txIn} --tx-out ${dAddr}+0 --invalid-hereafter ${ttlValue} --fee 0 ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp" 2
+  if ! ${CCLI} transaction build-raw ${txIn} --tx-out ${dAddr}+0 --invalid-hereafter ${ttlValue} --fee 0 ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
   minFeeArgs=(
     transaction calculate-min-fee
     --tx-body-file "${TMP_FOLDER}"/tx0.tmp
@@ -1082,7 +1082,7 @@ sendADA() {
   buildArgs=(
     ${txIn}
     ${txOut}
-    --upper-bound ${ttlValue}
+    --invalid-hereafter ${ttlValue}
     --fee ${minFee}
     --out-file "${TMP_FOLDER}"/tx.raw
   )
@@ -1159,8 +1159,8 @@ sendMetadata() {
 
   say "" 1
   say "# Calculate fee, new amount and remaining balance" 1 "log"
-  say "$ ${CCLI} transaction build-raw ${tx_in} --tx-out ${addr}+0 --upper-bound ${ttlValue} --fee 0 ${metadata} ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp" 2
-  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out ${addr}+0 --upper-bound ${ttlValue} --fee 0 ${metadata} ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
+  say "$ ${CCLI} transaction build-raw ${tx_in} --tx-out ${addr}+0 --invalid-hereafter ${ttlValue} --fee 0 ${metadata} ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp" 2
+  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out ${addr}+0 --invalid-hereafter ${ttlValue} --fee 0 ${metadata} ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
   minFeeArgs=(
     transaction calculate-min-fee
     --tx-body-file "${TMP_FOLDER}"/tx0.tmp
@@ -1190,7 +1190,7 @@ sendMetadata() {
   buildArgs=(
     ${tx_in}
     ${tx_out}
-    --upper-bound ${ttlValue}
+    --invalid-hereafter ${ttlValue}
     --fee ${minFee}
     ${metadata}
     --out-file "${TMP_FOLDER}"/tx.raw
@@ -1282,8 +1282,8 @@ registerStakeWallet() {
 
   say "" 1
   say "# Calculate fee" 1 "log"
-  say "$ ${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --upper-bound ${ttlValue} --fee 0 --certificate-file ${stake_cert_file} ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp" 2
-  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --upper-bound ${ttlValue} --fee 0 --certificate-file ${stake_cert_file} ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
+  say "$ ${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --invalid-hereafter ${ttlValue} --fee 0 --certificate-file ${stake_cert_file} ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp" 2
+  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --invalid-hereafter ${ttlValue} --fee 0 --certificate-file ${stake_cert_file} ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
   minFeeArgs=(
     transaction calculate-min-fee
     --tx-body-file "${TMP_FOLDER}"/tx0.tmp
@@ -1314,7 +1314,7 @@ registerStakeWallet() {
   buildArgs=(
     ${tx_in}
     ${tx_out}
-    --upper-bound ${ttlValue}
+    --invalid-hereafter ${ttlValue}
     --fee ${minFee}
     --certificate-file ${stake_cert_file}
     --out-file "${TMP_FOLDER}"/tx.raw
@@ -1414,8 +1414,8 @@ deregisterStakeWallet() {
 
   say "" 1
   say "# Calculate fee" 1 "log"
-  say "$ ${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --upper-bound ${ttlValue} --fee 0 --certificate-file ${stake_dereg_file} ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp" 2
-  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --upper-bound ${ttlValue} --fee 0 --certificate-file ${stake_dereg_file} ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
+  say "$ ${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --invalid-hereafter ${ttlValue} --fee 0 --certificate-file ${stake_dereg_file} ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp" 2
+  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --invalid-hereafter ${ttlValue} --fee 0 --certificate-file ${stake_dereg_file} ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
   minFeeArgs=(
     transaction calculate-min-fee
     --tx-body-file "${TMP_FOLDER}"/tx0.tmp
@@ -1446,7 +1446,7 @@ deregisterStakeWallet() {
   buildArgs=(
     ${tx_in}
     ${tx_out}
-    --upper-bound ${ttlValue}
+    --invalid-hereafter ${ttlValue}
     --fee ${minFee}
     --certificate-file ${stake_dereg_file}
     --out-file "${TMP_FOLDER}"/tx.raw
@@ -1554,8 +1554,8 @@ registerPool() {
 
   say "" 1
   say "# Calculate fee, new amount and remaining balance" 1 "log"
-  say "$ ${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --upper-bound ${ttlValue} --certificate-file ${pool_regcert_file} --certificate-file ${owner_delegation_cert_file} ${reward_delegation_cert} --fee 0 ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp" 2
-  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --upper-bound ${ttlValue} --certificate-file ${pool_regcert_file} --certificate-file ${owner_delegation_cert_file} ${reward_delegation_cert} --fee 0 ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
+  say "$ ${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --invalid-hereafter ${ttlValue} --certificate-file ${pool_regcert_file} --certificate-file ${owner_delegation_cert_file} ${reward_delegation_cert} --fee 0 ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp" 2
+  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --invalid-hereafter ${ttlValue} --certificate-file ${pool_regcert_file} --certificate-file ${owner_delegation_cert_file} ${reward_delegation_cert} --fee 0 ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
   minFeeArgs=(
     transaction calculate-min-fee
     --tx-body-file "${TMP_FOLDER}"/tx0.tmp
@@ -1585,7 +1585,7 @@ registerPool() {
   buildArgs=(
     ${tx_in}
     ${tx_out}
-    --upper-bound ${ttlValue}
+    --invalid-hereafter ${ttlValue}
     --fee ${minFee}
     --certificate-file ${pool_regcert_file}
     --certificate-file ${owner_delegation_cert_file}
@@ -1686,8 +1686,8 @@ modifyPool() {
 
   say "" 1
   say "# Calculate fee, new amount and remaining balance" 1 "log"
-  say "$ ${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --upper-bound ${ttlValue} --certificate-file ${pool_regcert_file} --fee 0 ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp" 2
-  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --upper-bound ${ttlValue} --certificate-file ${pool_regcert_file} --fee 0 ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
+  say "$ ${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --invalid-hereafter ${ttlValue} --certificate-file ${pool_regcert_file} --fee 0 ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp" 2
+  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --invalid-hereafter ${ttlValue} --certificate-file ${pool_regcert_file} --fee 0 ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
   minFeeArgs=(
     transaction calculate-min-fee
     --tx-body-file "${TMP_FOLDER}"/tx0.tmp
@@ -1717,7 +1717,7 @@ modifyPool() {
   buildArgs=(
     ${tx_in}
     ${tx_out}
-    --upper-bound ${ttlValue}
+    --invalid-hereafter ${ttlValue}
     --fee ${minFee}
     --certificate-file ${pool_regcert_file}
     --out-file "${TMP_FOLDER}"/tx.raw
@@ -1791,8 +1791,8 @@ withdrawRewards() {
 
   say "" 1
   say "# Calculate fee, new amount and remaining balance" 1 "log"
-  say "$ ${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --upper-bound ${ttlValue} --fee 0 ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp" 2
-  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --upper-bound ${ttlValue} --fee 0 ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
+  say "$ ${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --invalid-hereafter ${ttlValue} --fee 0 ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp" 2
+  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --invalid-hereafter ${ttlValue} --fee 0 ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
   minFeeArgs=(
     transaction calculate-min-fee
     --tx-body-file "${TMP_FOLDER}"/tx0.tmp
@@ -1823,7 +1823,7 @@ withdrawRewards() {
     ${tx_in}
     ${tx_out}
     --withdrawal ${stake_addr}+${reward_lovelace}
-    --upper-bound ${ttlValue}
+    --invalid-hereafter ${ttlValue}
     --fee ${minFee}
     --out-file "${TMP_FOLDER}"/tx.raw
   )
@@ -1903,8 +1903,8 @@ delegate() {
 
   say "" 1
   say "# Calculate fee, new amount and remaining balance" 1 "log"
-  say "$ ${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --upper-bound ${ttlValue} --fee 0 --certificate-file ${pool_delegcert_file} ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp" 2
-  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --upper-bound ${ttlValue} --fee 0 --certificate-file ${pool_delegcert_file} ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
+  say "$ ${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --invalid-hereafter ${ttlValue} --fee 0 --certificate-file ${pool_delegcert_file} ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp" 2
+  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --invalid-hereafter ${ttlValue} --fee 0 --certificate-file ${pool_delegcert_file} ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
   minFeeArgs=(
     transaction calculate-min-fee
     --tx-body-file "${TMP_FOLDER}"/tx0.tmp
@@ -1934,7 +1934,7 @@ delegate() {
   buildArgs=(
     ${tx_in}
     ${tx_out}
-    --upper-bound ${ttlValue}
+    --invalid-hereafter ${ttlValue}
     --fee ${minFee}
     --certificate-file ${pool_delegcert_file}
     --out-file "${TMP_FOLDER}"/tx.raw
@@ -2012,8 +2012,8 @@ deRegisterPool() {
 
   say "" 1
   say "# Calculate fee, new amount and remaining balance" 1 "log"
-  say "$ ${CCLI} transaction build-raw ${tx_in} --tx-out ${wallet_addr}+0 --upper-bound ${ttlValue} --fee 0 --certificate-file ${pool_deregcert_file} ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp" 2
-  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out ${wallet_addr}+0 --upper-bound ${ttlValue} --fee 0 --certificate-file ${pool_deregcert_file} ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
+  say "$ ${CCLI} transaction build-raw ${tx_in} --tx-out ${wallet_addr}+0 --invalid-hereafter ${ttlValue} --fee 0 --certificate-file ${pool_deregcert_file} ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp" 2
+  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out ${wallet_addr}+0 --invalid-hereafter ${ttlValue} --fee 0 --certificate-file ${pool_deregcert_file} ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
   minFeeArgs=(
     transaction calculate-min-fee
     --tx-body-file "${TMP_FOLDER}"/tx0.tmp
@@ -2043,7 +2043,7 @@ deRegisterPool() {
   buildArgs=(
     ${tx_in}
     ${tx_out}
-    --upper-bound ${ttlValue}
+    --invalid-hereafter ${ttlValue}
     --fee ${minFee}
     --certificate-file ${pool_deregcert_file}
     --out-file "${TMP_FOLDER}"/tx.raw

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -58,9 +58,6 @@ fi
 # get helper functions from library file
 . "${CNODE_HOME}"/scripts/cntools.library
 
-IFS=" " read -r -a cardano_version <<< "$(${CCLI} version | head -1 | cut -d' ' -f2 | tr '.' ' ')"
-[[ $(( ${cardano_version[0]:-0}*10000 + ${cardano_version[1]:-0}*100 + ${cardano_version[2]:-0} )) -lt 12401 ]] && myExit 1 "ERROR!! CNTools has now been upgraded to support cardano-node 1.23 or higher. Please update cardano-node or use node-1.21 branch for CNTools\n"
-
 URL_RAW="https://raw.githubusercontent.com/cardano-community/guild-operators/${BRANCH}"
 URL="${URL_RAW}/scripts/cnode-helper-scripts"
 URL_DOCS="${URL_RAW}/docs/Scripts"

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -56,6 +56,8 @@ CNODE_PORT=6000                                         # Set node port
 # Do NOT modify code below           #
 ######################################
 
+versionCheck() { printf '%s\n%s' "$1" "$2" | sort -C -V; } #$1=minimal_needed_version, $2=current_node_version
+
 OFFLINE_MODE='N'
 [[ $1 = "offline" ]] && OFFLINE_MODE='Y'
 [[ $(basename $0 2>/dev/null) = "cnode.sh" ]] && OFFLINE_MODE='Y' # for backwards compatibility
@@ -83,6 +85,11 @@ if [[ -z "${CCLI}" ]]; then
 else
   CCLI_PARENT="$(dirname ${CCLI})"
   export PATH="${CCLI_PARENT}":$PATH
+fi
+node_version="$(${CCLI} version | head -1 | cut -d' ' -f2)"
+if ! versionCheck "1.24.2" "${node_version}"; then
+  echo -e "\nGuild scripts has now been upgraded to support cardano-node 1.24.2 or higher (${node_version} found).\nPlease update cardano-node or use tagged branches for older node version.\n\n"
+  return 1
 fi
 
 if [[ -z "${CNCLI}" ]]; then

--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -172,9 +172,6 @@ else
   read -r -n 1 -s -p "press any key to proceed" answer
 fi
 
-IFS=" " read -r -a cardano_version <<< "$(${CCLI} version | head -1 | cut -d' ' -f2 | tr '.' ' ')"
-[[ $(( ${cardano_version[0]:-0}*10000 + ${cardano_version[1]:-0}*100 + ${cardano_version[2]:-0} )) -lt 12401 ]] && echo -e "\nERROR!! gLiveView has now been upgraded to support cardano-node 1.23 or higher. Please update cardano-node or use node-1.21 branch for gLiveView\n\n" && exit 1
-
 #######################################################
 # Validate config variables                           #
 # Can be overridden in 'User Variables' section above #


### PR DESCRIPTION
Removed version check in gLiveView and CNTools and moved to env file. At the same time the version comparison logic was updated to use built in version sorting in sort command. Credit to Martin for code suggestion.

--upper-bound replaced with --invalid-hereafter (previously --ttl)