### PR TITLE
cncli sync failed due to missing cncli folder

### DIFF
--- a/scripts/cnode-helper-scripts/cncli.sh
+++ b/scripts/cnode-helper-scripts/cncli.sh
@@ -257,6 +257,7 @@ cncliInit() {
   if ! versionCheck "0.4.1" "${CNCLI_VERSION}"; then echo "ERROR: cncli ${CNCLI_VERSION} installed, please upgrade to v0.4.1 or newer!"; exit 1; fi
   
   [[ -z "${CNCLI_DIR}" ]] && CNCLI_DIR="${CNODE_HOME}/guild-db/cncli"
+  mkdir -p "${CNCLI_DIR}"
   CNCLI_DB="${CNCLI_DIR}/cncli.db"
   [[ -z "${SLEEP_RATE}" ]] && SLEEP_RATE=60
   [[ -z "${CONFIRM_SLOT_CNT}" ]] && CONFIRM_SLOT_CNT=600


### PR DESCRIPTION
cncli doesn't create the folder structure needed for set db path. Not sure if this is a recent change as I haven't seen this issue previously.