### PR TITLE
Add default CNODE_PORT

### DIFF
--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -188,6 +188,7 @@ fi
 [[ -z ${BLOCKLOG_DIR} ]] && BLOCKLOG_DIR="${CNODE_HOME}/guild-db/blocklog"
 BLOCKLOG_DB="${BLOCKLOG_DIR}/blocklog.db"
 [[ -z ${BLOCKLOG_TZ} ]] && BLOCKLOG_TZ="UTC"
+[[ -z ${CNODE_PORT} ]] && CNODE_PORT=6000
 
 CNODE_PID=$(pgrep -fn "[c]ardano-node*.*--port ${CNODE_PORT}")
 


### PR DESCRIPTION
We didnt have a default for this variable if user does not have it in user variables section (upgrading from old version)