### PR TITLE
fix wallet import failing because of missing missing argument to cardano-address key public

### DIFF
--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -410,8 +410,8 @@ case $OPERATION in
     payment_xprv=$(cardano-address key child 1852H/1815H/0H/0/0 <<< ${root_prv})
     stake_xprv=$(cardano-address key child 1852H/1815H/0H/2/0 <<< ${root_prv})
     
-    payment_xpub=$(cardano-address key public <<< ${payment_xprv})
-    stake_xpub=$(cardano-address key public <<< ${stake_xprv})
+    payment_xpub=$(cardano-address key public --with-chain-code <<< ${payment_xprv})
+    stake_xpub=$(cardano-address key public --with-chain-code <<< ${stake_xprv})
     [[ "${NETWORKID}" = "Mainnet" ]] && network_tag=1 || network_tag=0
     base_addr_candidate=$(cardano-address address delegation ${stake_xpub} <<< "$(cardano-address address payment --network-tag ${network_tag} <<< ${payment_xpub})")
     if [[ "${NETWORKID}" = "Testnet" ]]; then


### PR DESCRIPTION
When I use the Wallet Import option with the latest version of cardano-address (3.0.0), cardano-wallet (2020.12.8), I get an error:

```
Usage: cardano-address key public (--without-chain-code | --with-chain-code)
  Get the public counterpart of a private key

Available options:
  -h,--help                Show this help text

The private key is read from stdin.To get extended public key pass '--with-chain-code'. To get public key pass '--without-chain-code'.
user error (Bech32 error: string is too short)
user error (Bech32 error: string is too short)
Error: Wrong input size of 0
bech32: user error (StringToDecodeTooShort)
Shelley command failed: key verification-key  Error: /opt/cardano/cnode/priv/wallet/adwdada/payment.skey: Invalid key.
Shelley command failed: key non-extended-key  Error: /tmp/cntools/payment.evkey: /tmp/cntools/payment.evkey: openBinaryFile: does not exist (No such file or directory)
```

Adding the `--with-chain-code` option solves the issue and imports the wallet correctly.