### PR TITLE
CNTools 7.0.0

### DIFF
--- a/docs/Scripts/cntools-changelog.md
+++ b/docs/Scripts/cntools-changelog.md
@@ -5,13 +5,13 @@ All notable changes to this tool will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.0.0] - 2021-01-XX
-Though mostly unchanged in the user interface, this is a mayor update with most of the code re-written/touched in the back-end.  
+## [7.0.0] - 2021-01-08
+Though mostly unchanged in the user interface, this is a major update with most of the code re-written/touched in the back-end.  
 Only the most noticeable changes added to changelog. 
 
 ##### Added
 - HW Wallet support through Vacuumlabs cardano-hw-cli (Ledger Nano X/S & Trezor T)
-  - Vacuumlabs cardano-hw-cli added as build option to prereqs.sh, option '-w' incl Ledger udev rules. Software from Vacuumlabs and Ledger app still early in development and may contain limitations that require workarounds.
+  - Vacuumlabs cardano-hw-cli added as build option to prereqs.sh, option '-w' incl Ledger udev rules. Software from Vacuumlabs and Ledger app still early in development and may contain limitations that require workarounds. Users are recommended to familiarise their usage using test wallets first.
   - Because of HW wallet support, transaction signing has been re-designed. For CLI and HW wallet pool reg, raw tx is first witnessed by all signing keys separately and then assembled and signed instead of signing directly with all signing keys. But for all other HW wallet transactions, signing is done directly without first witnessing.
   - Requires updated Cardano app in Ledger/Trezor set to be released in January 2021 to use in pool registration/modification.
 - Option added to disable Dialog for file/dir input in cntools.config
@@ -27,6 +27,8 @@ Only the most noticeable changes added to changelog.
   - Sign Tx moved to Transaction >> Sign
   - Submit Tx moved to Transaction >> Submit
 
+##### Fixed
+- Remove intermediate prompt for showing changelog, so that it's directly visible.
 
 ## [6.3.1] - 2020-12-14
 

--- a/docs/Scripts/cntools-changelog.md
+++ b/docs/Scripts/cntools-changelog.md
@@ -5,6 +5,29 @@ All notable changes to this tool will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.0] - 2021-01-XX
+Though mostly unchanged in the user interface, this is a mayor update with most of the code re-written/touched in the back-end.  
+Only the most noticeable changes added to changelog. 
+
+##### Added
+- HW Wallet support through Vacuumlabs cardano-hw-cli (Ledger Nano X/S & Trezor T)
+  - Vacuumlabs cardano-hw-cli added as build option to prereqs.sh, option '-w' incl Ledger udev rules. Software from Vacuumlabs and Ledger app still early in development and may contain limitations that require workarounds.
+  - Because of HW wallet support, transaction signing has been re-designed. For CLI and HW wallet pool reg, raw tx is first witnessed by all signing keys separately and then assembled and signed instead of signing directly with all signing keys. But for all other HW wallet transactions, signing is done directly without first witnessing.
+  - Requires updated Cardano app in Ledger/Trezor set to be released in January 2021 to use in pool registration/modification.
+- Option added to disable Dialog for file/dir input in cntools.config
+
+##### Changed
+- Logging completely re-designed from the ground. Previous selective logging wasn't very useful. All output(almost) now outputted to both the screen and to a timestamped log file. One log file is created per CNTools session. Old log file archived in logs/archive subfolder and last 10 log files kept, rest is pruned on CNTools startup.
+  - DEBUG    : Verbose output, most output printed on screen is logged as debug messages except explicitly disabled, like menu printing.
+  - INFO     : Informational and the most important output.
+  - ACTION   : e.g cardano-cli executions etc
+  - ERROR    : error messages and stderr output
+- Verbosity setting in cntools.config removed.
+- Offline workflow now use a single JSON transaction file holding all data needed. This allows us to bake in additional data in the JSON file in addition to the tx body to make it much more clear what the offline transaction do. Like signing key verification, transaction data like fee, source wallet, pool name etc. It also lets the user know on offline computer what signing keys is needed to sign the transaction.
+  - Sign Tx moved to Transaction >> Sign
+  - Submit Tx moved to Transaction >> Submit
+
+
 ## [6.3.1] - 2020-12-14
 
 ##### Fixed
@@ -26,13 +49,11 @@ and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ##### Fixed
 - Error output for prerequisite checks
  
-
 ## [6.2.1] - 2020-11-28
 
 ##### Changed
 - Compatibility changes for cardano-node 1.23.0, now minimum version to run CNTools 6.2.1
 - Cleanup of old code
-
 
 ## [6.2.0] - (alpha branch)
 

--- a/docs/Scripts/cntools-common.md
+++ b/docs/Scripts/cntools-common.md
@@ -194,34 +194,3 @@ Cost   : 500 ADA
 
 **8.**  Start or restart your cardano-node (eg: if using cnode.sh, update parameters in that file) with the parameters as shown.  This will ensure your node has all the information necessary to create blocks.
 
-#### Offline Workflow
-
-For offline workflow all wallet and pool keys should be kept on the offline node. The backup function in CNTools has an option to create a backup without private keys to be transfered to online node.
-
-Keys excluded from backup when created without private keys:  
-**Wallet** - payment.skey, stake.skey
-**Pool**   - cold.skey
-
-All other files are included in the backup to be transfered to the online node.
-
-``` mermaid
-
-sequenceDiagram
-    Note over Offline: Create/Import a new wallet
-    Note over Offline: Create a new pool
-    Note over Offline: Rotate KES keys to generate op.cert
-    Note over Offline: Create a backup w/o private keys
-    Offline->>Online: Transfer backup to online node
-    Note over Online: Fund the wallet base address with enough Ada
-    Note over Online: Register wallet using ' Wallet » Register ' in hybrid mode
-    Online->>Offline: Transfer built tx back to offline node
-    Note over Offline: Use ' Sign Tx ' with payment.skey from wallet to sign transaction
-    Offline->>Online: Transfer signed tx back to online node
-    Note over Online: Use ' Submit Tx ' to send signed transaction to blockchain
-    Note over Online: Register pool in hybrid mode
-    loop
-        Offline-->Online: Repeat steps to sign and submit built pool registration transaction
-    end
-    Note over Online: Verify that pool was successfully registered with ' Pool » Show '
-
-```

--- a/docs/Scripts/cntools.md
+++ b/docs/Scripts/cntools.md
@@ -15,50 +15,85 @@ The tool consist of three files.
 * `cntools.library` - internal script with helper functions.
 * `cntools.config` - configuration file to modify certain behaviours, paths and name schema used.
 
-In addition to the above files, there is also a dependency on the common `env` file. CNTools connects to your node through the configuration in the `env` file located in the same directory as the script. Customize `env` and `cntools.config` files for your needs. CNTools can operate in an Offline mode without node access by providing the `-o` runtime argument. This launches CNTools with a limited set of features with Hybrid or Online v/s Offline workflow in mind.
+In addition to the above files, there is also a dependency on the common `env` file. CNTools connects to your node through the configuration in the `env` file located in the same directory as the script. Customize `env` and `cntools.config` files for your needs. CNTools can operate in an Offline mode without node access by providing the `-o` runtime argument. This launches CNTools with a limited set of features.
+* Online - When all wallet and pool keys are available on the hot node, use this option.
+* Hybrid - Option on hot node with offline workflow in mind when signing keys are kept off the hot node to create an offline transaction file.
+* Offline - When CNTools is launched with `-o` runtime argument. Mainly used to access `Transaction >> Sign` to sign an offline transaction file created in Hybrid mode.
 
 `cncli.sh` is a companion script that are optional to run on the core node(block producer) to be able to monitor blocks created and by running leader schedule calculation and block validation.  
 `logMonitor.sh` is another companion script meant to be run together with cncli.sh script to give a complete picture.  
 See [CNCLI](Scripts/cncli.md) and [Log Monitor](Scripts/logmonitor.md) sections for more details.  
 
-> The tool in its default state uses the folder structure [here](basics.md#folder-structure). Everyone is free to customise, but while doing so beware that you may introduce changes that were not tested.
-
-##### Download and Update
-
-The update functionality is provided from within cntools. In case of breaking changes, please follow the prompts post upgrade. If stuck, its always best to re-run latest prereqs before proceeding.
-
-CNTools can be run in online and offline mode. At a very high level, for working with offline devices, remember that you need to use cntools on an online node to generate a staging transaction for the desired type of transaction, and then move the staging transaction to offline mode to sign (authorize) using your offline node keys - and then bring back updated transaction to the online node for submission to chain.
+> The tool in it's default state uses the folder structure [here](basics.md#folder-structure). Everyone is free to customise, but while doing so beware that you may introduce changes that were not tested.
 
 !> It is important that you familiarise yourself with the usage using Testnet network (on a seperate machine) first, read the warnings/messages, maintain your keys and backups with passwords (no one other than yourself can retrieve the funds if you make an accident), before performing actions on mainnet.
+
+##### Download and Update
+The update functionality is provided from within CNTools. In case of breaking changes, please follow the prompts post upgrade. If stuck, it's always best to re-run latest prereqs before proceeding.
+
+##### Navigation
+The scripts menu supports both arrow key navigation and shortcut key selection. The character within the square brackets is the shortcut to press for quick navigation. For other selections like wallet and pool menu that doesn't contain shortcuts, there is a third way to navigate. Key pressed is compared to the first character of the menu option and if there is a match selection jumps to this location. A handy way to quickly navigate a large menu. 
+
+##### Offline Workflow
+CNTools can be run in online and offline mode. At a very high level, for working with offline devices, remember that you need to use CNTools on an online node to generate a staging transaction for the desired type of transaction, and then move the staging transaction to offline node to sign (authorize) using your offline node signing keys - and then bring back updated transaction to the online node for submission to chain. 
+
+For offline workflow all wallet and pool keys should be kept on the offline node. The backup function in CNTools has an option to create a backup without private keys(sensitive signing keys) to be transfered to online node. All other files are included in the backup to be transfered to the online node. 
+
+Keys excluded from backup when created without private keys:  
+**Wallet** - payment.skey, stake.skey
+**Pool**   - cold.skey
+
+Example workflow for creating a wallet and pool
+
+``` mermaid
+
+sequenceDiagram
+    Note over Offline: Create/Import a wallet
+    Note over Offline: Create a new pool
+    Note over Offline: Rotate KES keys to generate op.cert
+    Note over Offline: Create a backup w/o private keys
+    Offline->>Online: Transfer backup to online node
+    Note over Online: Fund the wallet base address with enough Ada
+    Note over Online: Register wallet using ' Wallet » Register ' in hybrid mode
+    Online->>Offline: Transfer built tx file back to offline node
+    Note over Offline: Use ' Transaction >> Sign ' with payment.skey from wallet to sign transaction
+    Offline->>Online: Transfer signed tx back to online node
+    Note over Online: Use ' Transaction >> Submit ' to send signed transaction to blockchain
+    Note over Online: Register pool in hybrid mode
+    loop
+        Offline-->Online: Repeat steps to sign and submit built pool registration transaction
+    end
+    Note over Online: Verify that pool was successfully registered with ' Pool » Show '
+
+```
 
 ##### Start CNTools in Online Mode
 `$ ./cntools.sh`
 
 You should get a screen that looks something like this:
 ```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  >> CNTools vX.X.X - CONNECTED <<                    A Guild Operators collaboration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  Main Menu
 
- ) Wallet    -  create, show, remove and protect wallets
- ) Funds     -  send, withdraw and delegate
- ) Pool      -  pool creation and management
- ) Sign Tx   -  Sign a built transaction file (hybrid/offline mode)
- ) Submit Tx -  Submit a signed transaction file (hybrid/offline mode)
- ) Metadata  -  Post metadata on-chain (e.g voting)
- ) Blocks    -  show core node leader slots
- ) Update    -  update cntools script and library config files
- ) Backup    -  backup & restore of wallet/pool/config
- ) Refresh   -  reload home screen content
+ ) Wallet      - create, show, remove and protect wallets
+ ) Funds       - send, withdraw and delegate
+ ) Pool        - pool creation and management
+ ) Transaction - Witness, Sign and Submit a cold transaction (hybrid/offline mode)
+ ) Metadata    - Post metadata on-chain (e.g voting)
+ ) Blocks      - show core node leader slots
+ ) Update      - update cntools script and library config files
+ ) Backup      - backup & restore of wallet/pool/config
+ ) Refresh     - reload home screen content
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                                                   Epoch 95 - 04h:34m:47s until next
- What would you like to do?                                         Node Sync: 22 :)
+                                                 Epoch 106 - 106h:14m:26s until next
+ What would you like to do?                                         Node Sync: 14 :)
 
   [w] Wallet
   [f] Funds
   [p] Pool
-  [s] Sign Tx
-  [t] Submit Tx
+  [t] Transaction
   [m] Metadata
   [b] Blocks
   [u] Update
@@ -75,6 +110,3 @@ The main menu header should let you know that node is started in offline mode:
  >> CNTools vX.X.X - OFFLINE <<                      A Guild Operators collaboration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```
-
-##### Navigation
-The scripts menu supports both arrow key navigation and shortcut key selection. The character within the square brackets is the shortcut to press for quick navigation. For other selections like wallet and pool menu that doesn't contain shortcuts, there is a third way to navigate. Key pressed is compared to the first character of the menu option and if there is a match selection jumps to this location. A handy way to quickly navigate a large menu. 

--- a/docs/Scripts/env.md
+++ b/docs/Scripts/env.md
@@ -1,0 +1,71 @@
+A common environment file called `env` is sourced by most scripts in the Guild Operators repository. This file holds common variables and functions needed by more than one script. There are several benefits to this, not have duplicate settings in several files being one of them decreasing the risk of missconfiguration.
+
+#### Installation
+`env` file is downloaded together with the rest of the scripts when [Pre-Requisites](basics.md#pre-requisites) if followed. The file is also automatically downloaded/updated by some of the individual scripts if missing, like `cntools.sh`, `gLiveView.sh` and `topologyUpdater.sh`. All custom changes in User Variables section are untouched on updates unless a forced overwrite is selected when running `prereqs.sh`.
+
+#### Configuration
+Most variables can be left commented to use the automatically detected or default value. But there are some that needs to be set explained below.
+
+* CNODE_PORT - This is the most important variable and **needs** to be set. Used when launching the node through `cnode.sh` and to identify the correct process of the node.
+* CNODE_HOME - The root folder of the cardano node holding all the files needed. Can be left commented if prereqs.sh has been run as this variable is then exported and added as a system env variable.
+* POOL_NAME - If the node is to be started as a block producer by `cnode.sh` this variable needs to be uncommented and set. This is the name given to the pool in CNTools(not ticker), ie folder name under .../priv/pool/
+
+Take your time and look through the different variables and their explaination and decide if you need/want to change the default setting. For a default deployment using `prereqs.sh` **CNODE_PORT**(all installs) and **POOL_NAME**(only block producer) should be the only variables needed to be set. 
+ 
+``` bash
+######################################
+# User Variables - Change as desired #
+# Leave as is if unsure              #
+######################################
+
+#CCLI="${HOME}/.cabal/bin/cardano-cli"                  # Override automatic detection of path to cardano-cli executable
+#CNCLI="${HOME}/.cargo/bin/cncli"                       # Override automatic detection of path to cncli executable (https://github.com/AndrewWestberg/cncli)
+#CNODE_HOME="/opt/cardano/cnode"                        # Override default CNODE_HOME path (defaults to /opt/cardano/cnode)
+CNODE_PORT=6000                                         # Set node port
+#CONFIG="${CNODE_HOME}/files/config.json"               # Override automatic detection of node config path
+#SOCKET="${CNODE_HOME}/sockets/node0.socket"            # Override automatic detection of path to socket
+#TOPOLOGY="${CNODE_HOME}/files/topology.json"           # Override default topology.json path
+#LOG_DIR="${CNODE_HOME}/logs"                           # Folder where your logs will be sent to (must pre-exist)
+#DB_DIR="${CNODE_HOME}/db"                              # Folder to store the cardano-node blockchain db
+#EKG_HOST=127.0.0.1                                     # Set node EKG host
+#EKG_PORT=12788                                         # Override automatic detection of node EKG port
+#EKG_TIMEOUT=3                                          # Maximum time in seconds that you allow EKG request to take before aborting (node metrics)
+#CURL_TIMEOUT=10                                        # Maximum time in seconds that you allow curl file download to take before aborting (GitHub update process)
+#BLOCKLOG_DIR="${CNODE_HOME}/guild-db/blocklog"         # Override default directory used to store block data for core node
+#BLOCKLOG_TZ="UTC"                                      # TimeZone to use when displaying blocklog - https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+
+#WALLET_FOLDER="${CNODE_HOME}/priv/wallet"              # Root folder for Wallets
+#POOL_FOLDER="${CNODE_HOME}/priv/pool"                  # Root folder for Pools
+                                                        # Each wallet and pool has a friendly name and subfolder containing all related keys, certificates, ...
+#POOL_NAME=""                                           # Set the pool's name to run node as a core node (the name, NOT the ticker, ie folder name)
+                                                        
+TG_BOT_TOKEN=""                                         # to enable telegramSend function create your own BOT-token and Chat-Id
+TG_CHAT_ID=""                                           # see https://cardano-community.github.io/guild-operators/#/Scripts/logmonitor#telegram-alerts 
+
+#WALLET_PAY_VK_FILENAME="payment.vkey"                  # Standardized names for all wallet related files
+#WALLET_PAY_SK_FILENAME="payment.skey"
+#WALLET_HW_PAY_SK_FILENAME="payment.hwsfile"
+#WALLET_PAY_ADDR_FILENAME="payment.addr"
+#WALLET_BASE_ADDR_FILENAME="base.addr"
+#WALLET_STAKE_VK_FILENAME="stake.vkey"
+#WALLET_STAKE_SK_FILENAME="stake.skey"
+#WALLET_HW_STAKE_SK_FILENAME="stake.hwsfile"
+#WALLET_STAKE_ADDR_FILENAME="reward.addr"
+#WALLET_STAKE_CERT_FILENAME="stake.cert"
+#WALLET_STAKE_DEREG_FILENAME="stake.dereg"
+#WALLET_DELEGCERT_FILENAME="delegation.cert"
+
+#POOL_ID_FILENAME="pool.id"                             # Standardized names for all pool related files
+#POOL_HOTKEY_VK_FILENAME="hot.vkey"
+#POOL_HOTKEY_SK_FILENAME="hot.skey"
+#POOL_COLDKEY_VK_FILENAME="cold.vkey"
+#POOL_COLDKEY_SK_FILENAME="cold.skey"
+#POOL_OPCERT_COUNTER_FILENAME="cold.counter"
+#POOL_OPCERT_FILENAME="op.cert"
+#POOL_VRF_VK_FILENAME="vrf.vkey"
+#POOL_VRF_SK_FILENAME="vrf.skey"
+#POOL_CONFIG_FILENAME="pool.config"
+#POOL_REGCERT_FILENAME="pool.cert"
+#POOL_CURRENT_KES_START="kes.start"
+#POOL_DEREGCERT_FILENAME="pool.dereg"
+```

--- a/docs/Scripts/env.md
+++ b/docs/Scripts/env.md
@@ -10,7 +10,7 @@ Most variables can be left commented to use the automatically detected or defaul
 * CNODE_HOME - The root folder of the cardano node holding all the files needed. Can be left commented if prereqs.sh has been run as this variable is then exported and added as a system env variable.
 * POOL_NAME - If the node is to be started as a block producer by `cnode.sh` this variable needs to be uncommented and set. This is the name given to the pool in CNTools(not ticker), ie folder name under .../priv/pool/
 
-Take your time and look through the different variables and their explaination and decide if you need/want to change the default setting. For a default deployment using `prereqs.sh` **CNODE_PORT**(all installs) and **POOL_NAME**(only block producer) should be the only variables needed to be set. 
+Take your time and look through the different variables and their explaination and decide if you need/want to change the default setting. For a default deployment using `prereqs.sh` **CNODE_PORT**(all installs) and **POOL_NAME**(only block producer) should be the only variables needed to be set. A snippet of `env` file shown below.
  
 ``` bash
 ######################################
@@ -24,48 +24,5 @@ Take your time and look through the different variables and their explaination a
 CNODE_PORT=6000                                         # Set node port
 #CONFIG="${CNODE_HOME}/files/config.json"               # Override automatic detection of node config path
 #SOCKET="${CNODE_HOME}/sockets/node0.socket"            # Override automatic detection of path to socket
-#TOPOLOGY="${CNODE_HOME}/files/topology.json"           # Override default topology.json path
-#LOG_DIR="${CNODE_HOME}/logs"                           # Folder where your logs will be sent to (must pre-exist)
-#DB_DIR="${CNODE_HOME}/db"                              # Folder to store the cardano-node blockchain db
-#EKG_HOST=127.0.0.1                                     # Set node EKG host
-#EKG_PORT=12788                                         # Override automatic detection of node EKG port
-#EKG_TIMEOUT=3                                          # Maximum time in seconds that you allow EKG request to take before aborting (node metrics)
-#CURL_TIMEOUT=10                                        # Maximum time in seconds that you allow curl file download to take before aborting (GitHub update process)
-#BLOCKLOG_DIR="${CNODE_HOME}/guild-db/blocklog"         # Override default directory used to store block data for core node
-#BLOCKLOG_TZ="UTC"                                      # TimeZone to use when displaying blocklog - https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-
-#WALLET_FOLDER="${CNODE_HOME}/priv/wallet"              # Root folder for Wallets
-#POOL_FOLDER="${CNODE_HOME}/priv/pool"                  # Root folder for Pools
-                                                        # Each wallet and pool has a friendly name and subfolder containing all related keys, certificates, ...
-#POOL_NAME=""                                           # Set the pool's name to run node as a core node (the name, NOT the ticker, ie folder name)
-                                                        
-TG_BOT_TOKEN=""                                         # to enable telegramSend function create your own BOT-token and Chat-Id
-TG_CHAT_ID=""                                           # see https://cardano-community.github.io/guild-operators/#/Scripts/logmonitor#telegram-alerts 
-
-#WALLET_PAY_VK_FILENAME="payment.vkey"                  # Standardized names for all wallet related files
-#WALLET_PAY_SK_FILENAME="payment.skey"
-#WALLET_HW_PAY_SK_FILENAME="payment.hwsfile"
-#WALLET_PAY_ADDR_FILENAME="payment.addr"
-#WALLET_BASE_ADDR_FILENAME="base.addr"
-#WALLET_STAKE_VK_FILENAME="stake.vkey"
-#WALLET_STAKE_SK_FILENAME="stake.skey"
-#WALLET_HW_STAKE_SK_FILENAME="stake.hwsfile"
-#WALLET_STAKE_ADDR_FILENAME="reward.addr"
-#WALLET_STAKE_CERT_FILENAME="stake.cert"
-#WALLET_STAKE_DEREG_FILENAME="stake.dereg"
-#WALLET_DELEGCERT_FILENAME="delegation.cert"
-
-#POOL_ID_FILENAME="pool.id"                             # Standardized names for all pool related files
-#POOL_HOTKEY_VK_FILENAME="hot.vkey"
-#POOL_HOTKEY_SK_FILENAME="hot.skey"
-#POOL_COLDKEY_VK_FILENAME="cold.vkey"
-#POOL_COLDKEY_SK_FILENAME="cold.skey"
-#POOL_OPCERT_COUNTER_FILENAME="cold.counter"
-#POOL_OPCERT_FILENAME="op.cert"
-#POOL_VRF_VK_FILENAME="vrf.vkey"
-#POOL_VRF_SK_FILENAME="vrf.skey"
-#POOL_CONFIG_FILENAME="pool.config"
-#POOL_REGCERT_FILENAME="pool.cert"
-#POOL_CURRENT_KES_START="kes.start"
-#POOL_DEREGCERT_FILENAME="pool.dereg"
+...
 ```

--- a/docs/Scripts/gliveview.md
+++ b/docs/Scripts/gliveview.md
@@ -55,28 +55,7 @@ Once the analysis is finished, it will display the RTTs for the peers and group 
 
 ##### Troubleshooting/Customisations
 
-In case you run into trouble while running the script, you might want to edit `env` & `gLiveView.sh` and look at User Variables section shown below. You can override the values if the automatic detection do not provide the right information, but we would appreciate if you could also notify us by raising an issue against github repo:
-
-**env**
-```
-######################################
-# User Variables - Change as desired #
-# Leave as is if unsure              #
-######################################
-
-#CCLI="${HOME}/.cabal/bin/cardano-cli"                  # Override automatic detection of path to cardano-cli executable
-#CNCLI="${HOME}/.cargo/bin/cncli"                       # Override automatic detection of path to cncli executable (https://github.com/AndrewWestberg/cncli)
-#CNODE_HOME="/opt/cardano/cnode"                        # Override default CNODE_HOME path (defaults to /opt/cardano/cnode)
-CNODE_PORT=6000                                         # Set node port
-#CONFIG="${CNODE_HOME}/files/config.json"               # Override automatic detection of node config path
-#SOCKET="${CNODE_HOME}/sockets/node0.socket"            # Override automatic detection of path to socket
-#EKG_HOST=127.0.0.1                                     # Set node EKG host
-#EKG_PORT=12788                                         # Override automatic detection of node EKG port
-#EKG_TIMEOUT=3                                          # Maximum time in seconds that you allow EKG request to take before aborting (node metrics)
-#CURL_TIMEOUT=10                                        # Maximum time in seconds that you allow curl file download to take before aborting (GitHub update process)
-#BLOCKLOG_DIR="${CNODE_HOME}/guild-db/blocklog"         # Override default directory used to store block data for core node
-#BLOCKLOG_TZ="UTC"                                      # TimeZone to use when displaying blocklog - https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-```
+In case you run into trouble while running the script, you might want to edit `env` & `gLiveView.sh` and look at User Variables section. You can override the values if the automatic detection do not provide the right information, but we would appreciate if you could also notify us by raising an issue against github repo:
 
 **gLiveView.sh**
 ```bash

--- a/docs/Scripts/topologyupdater.md
+++ b/docs/Scripts/topologyupdater.md
@@ -19,7 +19,7 @@ chmod 750 topologyUpdater.sh
 
 #### Examine and modify the variables within topologyUpdater.sh script
 
-Out of the box, the scripts might come with some assumptions, that may or may not be valid for your environment. One of the common changes as a SPO would be to **complete CUSTOM_PEERS section** as below to include your local relays/BP nodes, and any additional peers you'd like to be always available at minimum. Please do take time to update the variables in respective files below:
+Out of the box, the scripts might come with some assumptions, that may or may not be valid for your environment. One of the common changes as a SPO would be to **complete CUSTOM_PEERS section** as below to include your local relays/BP nodes, and any additional peers you'd like to be always available at minimum. Please do take time to update the variables in User Variables section in  `env` & `topologyUpdater.sh`:
 
 ``` bash
 ### topologyUpdater.sh
@@ -29,34 +29,10 @@ Out of the box, the scripts might come with some assumptions, that may or may no
 ######################################
 
 CNODE_HOSTNAME="CHANGE ME"                                # (Optional) Must resolve to the IP you are requesting from
-CNODE_LOG_DIR="${CNODE_HOME}/logs"                        # Folder where your logs will be sent to (must pre-exist)
 CNODE_VALENCY=1                                           # (Optional) for multi-IP hostnames
-CNODE_TOPOLOGY="${CNODE_HOME}/files/topology.json"        # Destination topology.json file you'd want to write output to
 MAX_PEERS=15                                              # Maximum number of peers to return on successful fetch
-CUSTOM_PEERS="None"                                       # Additional custom peers to (IP:port[:valency]) to add to your target topology.json, eg: "10.0.0.1:3001|10.0.0.2:3002|relays.mydomain.com:3003:3"
-
-```
-
-``` bash
-### env
-
-######################################
-# User Variables - Change as desired #
-# Leave as is if unsure              #
-######################################
-
-#CCLI="${HOME}/.cabal/bin/cardano-cli"                  # Override automatic detection of path to cardano-cli executable
-#CNCLI="${HOME}/.cargo/bin/cncli"                       # Override automatic detection of path to cncli executable (https://github.com/AndrewWestberg/cncli)
-#CNODE_HOME="/opt/cardano/cnode"                        # Override default CNODE_HOME path (defaults to /opt/cardano/cnode)
-CNODE_PORT=6000                                         # Set node port
-#CONFIG="${CNODE_HOME}/files/config.json"               # Override automatic detection of node config path
-#SOCKET="${CNODE_HOME}/sockets/node0.socket"            # Override automatic detection of path to socket
-#EKG_HOST=127.0.0.1                                     # Set node EKG host
-#EKG_PORT=12788                                         # Override automatic detection of node EKG port
-#EKG_TIMEOUT=3                                          # Maximum time in seconds that you allow EKG request to take before aborting (node metrics)
-#CURL_TIMEOUT=10                                        # Maximum time in seconds that you allow curl file download to take before aborting (GitHub update process)
-#BLOCKLOG_DIR="${CNODE_HOME}/guild-db/blocklog"         # Override default directory used to store block data for core node
-#BLOCKLOG_TZ="UTC"                                      # TimeZone to use when displaying blocklog - https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+#CUSTOM_PEERS="None"                                      # Additional custom peers to (IP:port[:valency]) to add to your target topology.json
+                                                          # eg: "10.0.0.1:3001|10.0.0.2:3002|relays.mydomain.com:3003:3"
 ```
 
 Upon first run,

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -7,6 +7,7 @@
     * [REST](Build/rest.md "Cardano Rest")
     * [GraphQL](Build/graphql.md "Cardano GraphQL")
   * Scripts
+    * [Common env](Scripts/env.md)
     * [CNTools](Scripts/cntools.md)
       - [Common tasks](Scripts/cntools-common.md)
       - [Changelog](Scripts/cntools-changelog.md)

--- a/scripts/cnode-helper-scripts/cncli.sh
+++ b/scripts/cnode-helper-scripts/cncli.sh
@@ -32,7 +32,7 @@
 usage() {
   cat <<EOF >&2
 
-Usage: $(basename "$0") [sync] [leaderlog] [validate [all] [epoch]] [ptsendtip] [migrate <path>]
+Usage: $(basename "$0") [operation <sub arg>]
 Script to run CNCLI, best launched through systemd deployed by 'deploy-as-systemd.sh'
 
 sync        Start CNCLI chainsync process that connects to cardano-node to sync blocks stored in SQLite DB (deployed as service)

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -9,9 +9,9 @@
 # Any breaking changes (eg: that requires change of cntools.config, env or a change in priv folder would be considered breaking and will be exempt from auto-update)
 CNTOOLS_MAJOR_VERSION=6
 # Changes that can be applied without breaking existing functionality that can be applied from within CNTools
-CNTOOLS_MINOR_VERSION=4
+CNTOOLS_MINOR_VERSION=9
 # Backwards compatible bug fixes. No additional functionality or major changes and can be applied from within CNTools
-CNTOOLS_PATCH_VERSION=0
+CNTOOLS_PATCH_VERSION=999
 CNTOOLS_VERSION="${CNTOOLS_MAJOR_VERSION}.${CNTOOLS_MINOR_VERSION}.${CNTOOLS_PATCH_VERSION}"
 
 ############################################################
@@ -290,8 +290,7 @@ key_input()        { key2=""
 opt_shortcut()     { [[ "$1" =~ ^\[([[:alnum:]]+)\].* ]] && echo ${BASH_REMATCH[1]}; }
 opt_firstchar()    { printf "${1:0:1}" | tr '[:upper:]' '[:lower:]'; }
 selectOption() {
-  # sleep for a short time to get tty in sync
-  sleep 0.1
+  sleep 0.1 # sleep for a short time to get tty in sync
 
   # initially print empty new lines (scroll down if at bottom of screen)
   printf "\n" && for opt; do printf "\n"; done
@@ -746,14 +745,14 @@ kesExpiration() {
 waitNewBlockCreated() {
   counter=${TIMEOUT_NO_OF_SLOTS}
   [[ $# -eq 0 ]] && println "DEBUG" "Waiting for new block to be created (timeout = ${counter} slots, $(( counter * SLOT_LENGTH ))s)"
-  [[ $# -eq 0 ]] && println "DEBUG" "${FG_BLUE}INFO${NC}: press any key to cancel balance check and return"
+  [[ $# -eq 0 ]] && println "DEBUG" "${FG_BLUE}INFO${NC}: press any key to cancel and return (won't stop transaction)"
   initialTip=$(getBlockTip)
   actualTip=${initialTip}
 
   while [ "${actualTip}" = "${initialTip}" ]; do
     read -r -n 1 -s -t ${SLOT_LENGTH} abort
     if [[ $? -eq 0 ]]; then
-      println "${FG_YELLOW}WARN${NC}: Balance check aborted, transaction still in queue!"
+      println "${FG_YELLOW}WARN${NC}: aborted!! transaction still in queue!"
       return 1
     fi
     actualTip=$(getBlockTip)
@@ -997,8 +996,11 @@ getBalance() {
 getRewards() {
   reward_lovelace=-1
   if isWalletRegistered $1; then
-    reward_lovelace=$(jq -r '.rewardAccountBalance' <<< "${stakeAddressInfo}")
-    [[ "${reward_lovelace}" =~ ^[0-9]+$ ]] || reward_lovelace=0
+    reward_lovelace=0
+    for reward_entry in $(jq -r '.[] | @base64' <<< "${stake_address_info}"); do
+      _jq() { base64 -d <<< ${reward_entry} | jq -r "${1}"; }
+      reward_lovelace=$(( reward_lovelace + $(_jq '.rewardAccountBalance //0') ))
+    done
   fi
 }
 # Command     : getRewardsFromAddr [stake address]
@@ -1006,9 +1008,13 @@ getRewards() {
 # Parameters  : stake address  >  the address from stake.vkey
 # Return      : populates ${reward_lovelace}
 getRewardsFromAddr() {
-  println "ACTION" "${CCLI} query stake-address-info ${ERA_IDENTIFIER} ${PROTOCOL_IDENTIFIER} ${NETWORK_IDENTIFIER} --address ${1} | jq -r '.[0].rewardAccountBalance // empty'"
-  reward_lovelace=$(${CCLI} query stake-address-info ${ERA_IDENTIFIER} ${PROTOCOL_IDENTIFIER} ${NETWORK_IDENTIFIER} --address ${1} | jq -r '.[0].rewardAccountBalance // empty')
-  [[ "${reward_lovelace}" =~ ^[0-9]+$ ]] || reward_lovelace=0
+  println "ACTION" "${CCLI} query stake-address-info ${ERA_IDENTIFIER} ${PROTOCOL_IDENTIFIER} ${NETWORK_IDENTIFIER} --address ${1}"
+  stake_address_info=$(${CCLI} query stake-address-info ${ERA_IDENTIFIER} ${PROTOCOL_IDENTIFIER} ${NETWORK_IDENTIFIER} --address ${1})
+  reward_lovelace=0
+  for reward_entry in $(jq -r '.[] | @base64' <<< "${stake_address_info}"); do
+    _jq() { base64 -d <<< ${reward_entry} | jq -r "${1}"; }
+    reward_lovelace=$(( reward_lovelace + $(_jq '.rewardAccountBalance //0') ))
+  done
 }
 
 # Command     : isWalletRegistered [wallet name]
@@ -1016,35 +1022,38 @@ getRewardsFromAddr() {
 # Parameters  : wallet name  >  the name of the wallet
 isWalletRegistered() {
   if getRewardAddress $1; then
-    println "ACTION" "${CCLI} query stake-address-info ${ERA_IDENTIFIER} ${PROTOCOL_IDENTIFIER} ${NETWORK_IDENTIFIER} --address ${reward_addr} | jq -r '.[0] // empty'"
-    stakeAddressInfo=$(${CCLI} query stake-address-info ${ERA_IDENTIFIER} ${PROTOCOL_IDENTIFIER} ${NETWORK_IDENTIFIER} --address ${reward_addr} | jq -r '.[0] // empty')
-    [[ -n "${stakeAddressInfo}" ]] && return 0
+    println "ACTION" "${CCLI} query stake-address-info ${ERA_IDENTIFIER} ${PROTOCOL_IDENTIFIER} ${NETWORK_IDENTIFIER} --address ${reward_addr}"
+    stake_address_info=$(${CCLI} query stake-address-info ${ERA_IDENTIFIER} ${PROTOCOL_IDENTIFIER} ${NETWORK_IDENTIFIER} --address ${reward_addr})
+    [[ -n "${stake_address_info}" && $(jq -r 'length' <<< ${stake_address_info}) -gt 0 ]] && return 0
   fi
   return 1
 }
 
 # Command     : getWalletType [wallet name|sign key]
-# Description : check if wallet is a hardware wallet, 0=yes, 1=cli, 2=cli & encrypted, 3=missing keys
+# Description : check if wallet is a hardware wallet, 0=yes, 1=cli, 2=cli & encrypted, 3=signing keys missing, 4=verification keys missing
 # Parameters  : wallet name|sign key  >  the name of the wallet or path to sign key
 getWalletType() {
   if [[ -f $1 ]]; then # Sign key
     [[ $(jq -r '.description' "${1}") = *"Hardware"* ]] && return 0
     [[ -f "${1}" ]] && return 1
     [[ -f "${1}.gpg" ]] && return 2
-  else # CNTools wallet
-    if [[ -f "${WALLET_FOLDER}/${1}/${WALLET_HW_PAY_SK_FILENAME}" && -f "${WALLET_FOLDER}/${1}/${WALLET_HW_STAKE_SK_FILENAME}" && $(jq -r '.description' "${WALLET_FOLDER}/${1}/${WALLET_HW_STAKE_SK_FILENAME}") = *"Hardware"* ]]; then
+  elif [[ -f "${WALLET_FOLDER}/${1}/${WALLET_PAY_VK_FILENAME}" && -f "${WALLET_FOLDER}/${1}/${WALLET_STAKE_VK_FILENAME}" ]]; then # CNTools wallet
+    payment_vk_file="${WALLET_FOLDER}/${1}/${WALLET_PAY_VK_FILENAME}"
+    payment_sk_file="${WALLET_FOLDER}/${1}/${WALLET_PAY_SK_FILENAME}"
+    stake_vk_file="${WALLET_FOLDER}/${1}/${WALLET_STAKE_VK_FILENAME}"
+    stake_sk_file="${WALLET_FOLDER}/${1}/${WALLET_STAKE_SK_FILENAME}"
+    if [[ $(jq -r '.description' "${payment_vk_file}") = *"Hardware"* ]]; then
       payment_sk_file="${WALLET_FOLDER}/${1}/${WALLET_HW_PAY_SK_FILENAME}"
       stake_sk_file="${WALLET_FOLDER}/${1}/${WALLET_HW_STAKE_SK_FILENAME}"
-      return 0
-    elif [[ -f "${WALLET_FOLDER}/${1}/${WALLET_PAY_SK_FILENAME}" && -f "${WALLET_FOLDER}/${1}/${WALLET_STAKE_SK_FILENAME}" ]]; then
-      payment_sk_file="${WALLET_FOLDER}/${1}/${WALLET_PAY_SK_FILENAME}"
-      stake_sk_file="${WALLET_FOLDER}/${1}/${WALLET_STAKE_SK_FILENAME}"
-      return 1
-    elif [[ -f "${WALLET_FOLDER}/${1}/${WALLET_PAY_SK_FILENAME}.gpg" && -f "${WALLET_FOLDER}/${1}/${WALLET_STAKE_SK_FILENAME}.gpg" ]]; then
+      ([[ ${op_mode} = "online" && ( ! -f ${payment_sk_file} || ! -f ${stake_sk_file} ) ]]) && return 3 || return 0
+    elif [[ -f "${WALLET_FOLDER}/${1}/${WALLET_PAY_SK_FILENAME}.gpg" || -f "${WALLET_FOLDER}/${1}/${WALLET_STAKE_SK_FILENAME}.gpg" ]]; then
       return 2
+    else    
+      ([[ ${op_mode} = "online" && ( ! -f ${payment_sk_file} || ! -f ${stake_sk_file} ) ]]) && return 3 || return 1
     fi
+  else
+    return 4
   fi
-  return 3
 }
 
 # Command     : getSlotAndTTL
@@ -1054,12 +1063,12 @@ getSlotAndTTL() {
   if [[ ${op_mode} = "hybrid" ]]; then
     println "DEBUG" "\nHow long do you want the transaction to be valid?"
     sleep 0.1 && read -r -p "TTL (in seconds, default: 1800/30min): " ttl_enter 2>&6 && println "LOG" "TTL (in seconds, default: 1800/30min): ${ttl_enter}"
-    if [[ -n ${ttl_enter} && ! ${ttl_enter} =~ ^[0-9]+$ ]]; then
+    ttl_enter=${ttl_enter:-1800}
+    if [[ ! ${ttl_enter} =~ ^[0-9]+$ ]]; then
       println "ERROR" "\n${FG_RED}ERROR${NC}: invalid TTL number, non digit characters found: ${ttl_enter}"
       return 1
     fi
-    ttl=$(( currSlot + (${ttl_enter:-1800}/SLOT_LENGTH) ))
-    echo
+    ttl=$(( currSlot + (ttl_enter/SLOT_LENGTH) ))
   else
     ttl=$(( currSlot + (600/SLOT_LENGTH) )) # TTL default: 10min
   fi
@@ -1083,24 +1092,36 @@ parseWalletUTXOs() {
   done <"${TMP_FOLDER}"/balance.out
 }
 
+# Command     : buildOfflineJSON [type]
+# Description : construct a json containing all data for offline signing
+# Parameters  : type  >  type of transaction, e.g 'payment'
+buildOfflineJSON() {
+  offlineJSON="{}"
+  if ! offlineJSON=$(jq ". += { id: $(date +%s) }" <<< ${offlineJSON}); then return 1; fi
+  if ! offlineJSON=$(jq ". += { type: \"${1}\" }" <<< ${offlineJSON}); then return 1; fi
+  if ! offlineJSON=$(jq ". += { \"date-created\": \"$(date --iso-8601=s)\" }" <<< ${offlineJSON}); then return 1; fi
+  if ! offlineJSON=$(jq ". += { \"date-expire\": \"$(date --iso-8601=s --date="@$(($(date +%s)+ttl_enter))")\" }" <<< ${offlineJSON}); then return 1; fi
+  if ! offlineJSON=$(jq ". += { ttl: ${ttl} }" <<< ${offlineJSON}); then return 1; fi
+}
+
 # Command     : registerStakeWallet [wallet name] [optional: skip validation]
 # Description : Register stake keys on chain and move funds from payment address to payment base address
 # Parameters  : wallet name      >  the name of the wallet
 # Parameters  : skip validation  >  [optional] [true|false] if true, skip wallet registration check
 registerStakeWallet() {
 
+  wallet_name=$1
+  wallet_source="base"
+
   if [[ -z $2 || $2 = "false" ]]; then
-    println "DEBUG" "Wallet ${FG_GREEN}${1}${NC} not registered on chain"
-    waitForInput "press any key to continue with registration" && echo
+    println "DEBUG" "Wallet ${FG_GREEN}${wallet_name}${NC} not registered on chain"
+    waitForInput "press any key to continue with registration"
   fi
 
-  # Wallet key filenames
-  # payment_sk_file - set by getWalletType function called from CNTools main script
-  # stake_sk_file - set by getWalletType function called from CNTools main script
-  stake_vk_file="${WALLET_FOLDER}/${1}/${WALLET_STAKE_VK_FILENAME}"
-  stake_cert_file="${WALLET_FOLDER}/${1}/${WALLET_STAKE_CERT_FILENAME}"
+  stake_vk_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_STAKE_VK_FILENAME}"
+  stake_cert_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_STAKE_CERT_FILENAME}"
   
-  getBaseAddress "${1}"
+  getBaseAddress "${wallet_name}"
   getBalance ${base_addr}
   if ! parseWalletUTXOs; then return 1; fi
   
@@ -1148,52 +1169,45 @@ registerStakeWallet() {
   if ! buildTx; then return 1; fi
   
   if [[ ${op_mode} = "hybrid" ]]; then
+    if ! buildOfflineJSON "Wallet Registration"; then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"wallet-name\": \"${wallet_name}\" }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txFee: $(( min_fee + keyDeposit )) }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_FOLDER}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"signing-file\": [] }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Wallet '${wallet_name}' payment signing key\", vkey: $(jq -c . "${payment_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Wallet '${wallet_name}' stake signing key\", vkey: $(jq -c . "${stake_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"signed-txBody\": {} }" <<< ${offlineJSON}); then return 1; fi
+    offline_tx="${TMP_FOLDER}/offline_tx_$(jq .id <<< ${offlineJSON})"
+    jq -r . <<< "${offlineJSON}" > "${offline_tx}"
     echo
-    tx_tmp="/tmp/tx.raw_$(date +%s)"
-    if ! cp -f "${TMP_FOLDER}/tx.raw" "${tx_tmp}"; then
-      println "ERROR" "${FG_RED}ERROR${NC}: unable to copy tx file to: ${tx_tmp}"
-      return 1
-    fi
-    println "Transaction successfully built and saved to: ${FG_CYAN}${tx_tmp}${NC}" 
-    println "DEBUG" "Copy file to offline computer and sign it using CNTools in offline mode '-o' [Sign Tx] with:" 
-    println "DEBUG" "Wallet ${FG_GREEN}$(basename ${payment_sk_file})${NC}" 
-    println "DEBUG" "Wallet ${FG_GREEN}$(basename ${stake_sk_file})${NC}" 
-    echo
+    println "Offline transaction successfully built and saved to: ${FG_CYAN}${offline_tx}${NC}" 
+    println "DEBUG" "move file to offline computer and sign it using CNTools in offline mode '-o' [Transaction >> Sign] with:" 
+    println "DEBUG" "Wallet ${FG_GREEN}${wallet_name} ${FG_CYAN}$(basename ${payment_sk_file})${NC}" 
+    println "DEBUG" "Wallet ${FG_GREEN}${wallet_name} ${FG_CYAN}$(basename ${stake_sk_file})${NC}" 
     return 2 # return as failed to stop main processing and return to home menu
   fi
   
-  getWalletType ${1}
-  case $? in
-    0) if ! signTx "${TMP_FOLDER}/tx.raw" "${stake_sk_file}" "${payment_sk_file}"; then return 1; fi ;;
-    1) if ! witnessTx "${TMP_FOLDER}/tx.raw" "${stake_sk_file}" "${payment_sk_file}"; then return 1; fi
-       if ! signTx "${TMP_FOLDER}/tx.raw"; then return 1; fi ;;
-  esac
-
+  if ! signTx "${TMP_FOLDER}/tx.raw" "${stake_sk_file}" "${payment_sk_file}"; then return 1; fi
   if ! submitTx "${tx_signed}"; then return 1; fi
+  echo
   if ! verifyTx ${base_addr}; then return 1; fi
 
   reward_lovelace=0
 }
 
-# Command     : deregisterStakeWallet [wallet name]
+# Command     : deregisterStakeWallet
 # Description : Deregister stake keys/wallet from chain, key deposit fee returned to wallets base address
-# Parameters  : wallet name  >  the name of the wallet
 deregisterStakeWallet() {
 
-  # Wallet key filenames
-  # payment_sk_file - set by getWalletType function called from CNTools main script
-  # stake_sk_file - set by getWalletType function called from CNTools main script
-  stake_vk_file="${WALLET_FOLDER}/${1}/${WALLET_STAKE_VK_FILENAME}"
-  stake_dereg_file="${WALLET_FOLDER}/${1}/${WALLET_STAKE_DEREG_FILENAME}"
-  
-  getBaseAddress "${1}"
-  getBalance ${base_addr}
-  if ! parseWalletUTXOs; then return 1; fi
-  
+  wallet_source="base"
+
+  stake_dereg_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_STAKE_DEREG_FILENAME}"
   println "ACTION" "${CCLI} stake-address deregistration-certificate --stake-verification-key-file ${stake_vk_file} --out-file ${stake_dereg_file}"
   if ! ${CCLI} stake-address deregistration-certificate --stake-verification-key-file "${stake_vk_file}" --out-file "${stake_dereg_file}"; then return 1; fi
 
+  if ! parseWalletUTXOs; then return 1; fi
   if ! getSlotAndTTL; then return 1; fi
+  
   keyDeposit=$(jq -r '.keyDeposit' "${TMP_FOLDER}"/protparams.json)
   println "LOG" "Key Deposit is ${keyDeposit}"
 
@@ -1234,57 +1248,45 @@ deregisterStakeWallet() {
   if ! buildTx; then return 1; fi
   
   if [[ ${op_mode} = "hybrid" ]]; then
+    if ! buildOfflineJSON "Wallet De-Registration"; then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"wallet-name\": \"${wallet_name}\" }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"amount-returned\": ${keyDeposit} }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txFee: ${min_fee} }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_FOLDER}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"signing-file\": [] }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Wallet '${wallet_name}' payment signing key\", vkey: $(jq -c . "${payment_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Wallet '${wallet_name}' stake signing key\", vkey: $(jq -c . "${stake_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"signed-txBody\": {} }" <<< ${offlineJSON}); then return 1; fi
+    offline_tx="${TMP_FOLDER}/offline_tx_$(jq .id <<< ${offlineJSON})"
+    jq -r . <<< "${offlineJSON}" > "${offline_tx}"
     echo
-    tx_tmp="/tmp/tx.raw_$(date +%s)"
-    if ! cp -f "${TMP_FOLDER}/tx.raw" "${tx_tmp}"; then
-      println "ERROR" "${FG_RED}ERROR${NC}: unable to copy tx file to: ${tx_tmp}"
-      return 1
-    fi
-    println "Transaction successfully built and saved to: ${FG_CYAN}${tx_tmp}${NC}" 
-    println "DEBUG" "Copy file to offline computer and sign it using CNTools in offline mode '-o' [Sign Tx] with:"
-    println "DEBUG" "Wallet ${FG_GREEN}$(basename ${payment_sk_file})${NC}" 
-    println "DEBUG" "Wallet ${FG_GREEN}$(basename ${stake_sk_file})${NC}"
-    echo
+    println "Offline transaction successfully built and saved to: ${FG_CYAN}${offline_tx}${NC}" 
+    println "DEBUG" "move file to offline computer and sign it using CNTools in offline mode '-o' [Transaction >> Sign] with:" 
+    println "DEBUG" "Wallet ${FG_GREEN}${wallet_name} ${FG_CYAN}$(basename ${payment_sk_file})${NC}" 
+    println "DEBUG" "Wallet ${FG_GREEN}${wallet_name} ${FG_CYAN}$(basename ${stake_sk_file})${NC}" 
     return 2 # return as failed to stop main processing and return to home menu
   fi
   
-  getWalletType ${1}
-  case $? in
-    0) if ! signTx "${TMP_FOLDER}/tx.raw" "${stake_sk_file}" "${payment_sk_file}"; then return 1; fi ;;
-    1) if ! witnessTx "${TMP_FOLDER}/tx.raw" "${stake_sk_file}" "${payment_sk_file}"; then return 1; fi
-       if ! signTx "${TMP_FOLDER}/tx.raw"; then return 1; fi ;;
-  esac
-
+  if ! signTx "${TMP_FOLDER}/tx.raw" "${stake_sk_file}" "${payment_sk_file}"; then return 1; fi
   if ! submitTx "${tx_signed}"; then return 1; fi
 }
 
-# Command     : sendADA [destination address] [amount] [source address] [source sign key] [Include Fee]
+# Command     : sendAda
 # Description : send Ada from source to destination
 #             : can also be used to defrag address by sending all to self
 #             : supports fee to be payed by sender(default) or receiver by reducing amount to send
-# Parameters  : Destination Address   >   Destination address.
-#             : Amount                >   Amount in lovelace.
-#             : Source Address        >   Source address.
-#             : Source Sign Key       >   Path to Signature (skey) file. For stake wallet, payment skey is to be used.
-#             : Include Fee           >   Optional argument to specify that amount to send should be reduced by fee instead of payed by sender.
-sendADA() {
+sendAda() {
 
-  # Handle script arguments
-  dAddr="$1"
-  amount="$2"
-  sAddr="$3"
-  sKey="$4"
-  inclFee="$5"
-  
-  getBalance ${sAddr}
+  [[ $(cat "${WALLET_FOLDER}/${s_wallet}/${WALLET_PAY_ADDR_FILENAME}" 2>/dev/null) = "${s_addr}" ]] && wallet_source="enterprise" || wallet_source="base"
+
+  getBalance ${s_addr}
   if ! parseWalletUTXOs; then return 1; fi
-  
   if ! getSlotAndTTL; then return 1; fi
 
-  [[ ${lovelace} -eq ${amount} ]] && outCount=1 || outCount=2
+  [[ ${lovelace} -eq ${amount_lovelace} ]] && outCount=1 || outCount=2
 
-  println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out ${dAddr}+0 --invalid-hereafter ${ttl} --fee 0 ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp"
-  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out ${dAddr}+0 --invalid-hereafter ${ttl} --fee 0 ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
+  println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out ${d_addr}+0 --invalid-hereafter ${ttl} --fee 0 ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp"
+  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out ${d_addr}+0 --invalid-hereafter ${ttl} --fee 0 ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
   min_fee_args=(
     transaction calculate-min-fee
     --tx-body-file "${TMP_FOLDER}"/tx0.tmp
@@ -1300,36 +1302,36 @@ sendADA() {
   println "LOG" "fee is $(formatLovelace ${min_fee}) Ada"
 
   # Sanity checks
-  if [[ ${inclFee} = "no" ]]; then
-    if [[ ${lovelace} -lt $(( amount + min_fee )) ]]; then
-      println "ERROR" "${FG_RED}ERROR${NC}: Not enough Ada in address ($(formatLovelace ${lovelace}) < $(formatLovelace ${amount}) + $(formatLovelace ${min_fee}))"
+  if [[ ${include_fee} = "no" ]]; then
+    if [[ ${lovelace} -lt $(( amount_lovelace + min_fee )) ]]; then
+      println "ERROR" "${FG_RED}ERROR${NC}: Not enough Ada in address ($(formatLovelace ${lovelace}) < $(formatLovelace ${amount_lovelace}) + $(formatLovelace ${min_fee}))"
       return 1
     fi
   else
-    if [[ ${amount} -lt ${min_fee} ]]; then
-      println "ERROR" "${FG_RED}ERROR${NC}: Fee deducted from Ada to send, amount can not be less than fee ($(formatLovelace ${amount}) < $(formatLovelace ${min_fee}))"
+    if [[ ${amount_lovelace} -lt ${min_fee} ]]; then
+      println "ERROR" "${FG_RED}ERROR${NC}: Fee deducted from Ada to send, amount can not be less than fee ($(formatLovelace ${amount_lovelace}) < $(formatLovelace ${min_fee}))"
       return 1
-    elif [[ ${lovelace} -lt ${amount} ]]; then
-      println "ERROR" "${FG_RED}ERROR${NC}: Not enough Ada in address ($(formatLovelace ${lovelace}) < $(formatLovelace ${amount}))"
+    elif [[ ${lovelace} -lt ${amount_lovelace} ]]; then
+      println "ERROR" "${FG_RED}ERROR${NC}: Not enough Ada in address ($(formatLovelace ${lovelace}) < $(formatLovelace ${amount_lovelace}))"
       return 1
     fi
   fi
 
-  if [[ ${inclFee} = "no" ]]; then
-    tx_out="--tx-out ${dAddr}+${amount}"
+  if [[ ${include_fee} = "no" ]]; then
+    tx_out="--tx-out ${d_addr}+${amount_lovelace}"
   else
-    tx_out="--tx-out ${dAddr}+$(( amount - min_fee ))"
-    println "LOG" "New amount to send after fee deduction is $(formatLovelace $(( amount - min_fee ))) Ada ($(formatLovelace ${amount}) - $(formatLovelace ${min_fee}))"
+    tx_out="--tx-out ${d_addr}+$(( amount_lovelace - min_fee ))"
+    println "LOG" "New amount to send after fee deduction is $(formatLovelace $(( amount_lovelace - min_fee ))) Ada ($(formatLovelace ${amount_lovelace}) - $(formatLovelace ${min_fee}))"
   fi
 
-  newBalance=$(( lovelace - amount ))
-  if [[ ${inclFee} = "no" ]]; then
-    newBalance=$(( lovelace - amount - min_fee ))
-    tx_out="${tx_out} --tx-out ${sAddr}+${newBalance}"
-    println "LOG" "Balance left to be returned in used UTxO's is $(formatLovelace ${newBalance}) Ada ($(formatLovelace ${lovelace}) - $(formatLovelace ${amount}) - $(formatLovelace ${min_fee}))"
+  newBalance=$(( lovelace - amount_lovelace ))
+  if [[ ${include_fee} = "no" ]]; then
+    newBalance=$(( lovelace - amount_lovelace - min_fee ))
+    tx_out="${tx_out} --tx-out ${s_addr}+${newBalance}"
+    println "LOG" "Balance left to be returned in used UTxO's is $(formatLovelace ${newBalance}) Ada ($(formatLovelace ${lovelace}) - $(formatLovelace ${amount_lovelace}) - $(formatLovelace ${min_fee}))"
   elif [[ ${outCount} -eq 2 ]]; then
-    tx_out="${tx_out} --tx-out ${sAddr}+$(( lovelace - amount ))"
-    println "LOG" "Balance left to be returned in used UTxO's is $(formatLovelace $(( lovelace - amount ))) Ada ($(formatLovelace ${lovelace}) - $(formatLovelace ${amount}))"
+    tx_out="${tx_out} --tx-out ${s_addr}+$(( lovelace - amount_lovelace ))"
+    println "LOG" "Balance left to be returned in used UTxO's is $(formatLovelace $(( lovelace - amount_lovelace ))) Ada ($(formatLovelace ${lovelace}) - $(formatLovelace ${amount_lovelace}))"
   fi
   
   build_args=(
@@ -1342,43 +1344,36 @@ sendADA() {
   if ! buildTx; then return 1; fi
   
   if [[ ${op_mode} = "hybrid" ]]; then
-    tx_tmp="/tmp/tx.raw_$(date +%s)"
-    if ! cp -f "${TMP_FOLDER}/tx.raw" "${tx_tmp}"; then
-      println "ERROR" "${FG_RED}ERROR${NC}: unable to copy tx file to: ${tx_tmp}"
-      return 1
-    fi
-    println "Transaction successfully built and saved to: ${FG_CYAN}${tx_tmp}${NC}" 
-    println "DEBUG" "Copy file to offline computer and sign it using CNTools in offline mode '-o' [Sign Tx] with:" 
-    println "DEBUG" "Source wallet ${FG_GREEN}$(basename ${sKey})${NC}" 
+    if ! buildOfflineJSON "Payment"; then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"wallet-name\": \"${s_wallet}\" }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"source-address\": \"${s_addr}\" }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { amount: ${amount_lovelace} }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"destination-address\": \"${d_addr}\" }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txFee: ${min_fee} }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_FOLDER}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"signing-file\": [] }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Wallet '${s_wallet}' payment signing key\", vkey: $(jq -c . "${s_payment_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"signed-txBody\": {} }" <<< ${offlineJSON}); then return 1; fi
+    offline_tx="${TMP_FOLDER}/offline_tx_$(jq .id <<< ${offlineJSON})"
+    jq -r . <<< "${offlineJSON}" > "${offline_tx}"
+    echo
+    println "Offline transaction successfully built and saved to: ${FG_CYAN}${offline_tx}${NC}" 
+    println "DEBUG" "move file to offline computer and sign it using CNTools in offline mode '-o' [Transaction >> Sign] with:" 
+    println "DEBUG" "Source Wallet ${FG_GREEN}${s_wallet} ${FG_CYAN}$(basename ${s_payment_sk_file})${NC}"  
     return 2 # return as failed to stop main processing and return to home menu
   fi
   
-  getWalletType "${sKey}"
-  case $? in
-    0) if ! signTx "${TMP_FOLDER}/tx.raw" "${sKey}"; then return 1; fi ;;
-    1) if ! witnessTx "${TMP_FOLDER}/tx.raw" "${sKey}"; then return 1; fi
-       if ! signTx "${TMP_FOLDER}/tx.raw"; then return 1; fi ;;
-  esac
-
+  if ! signTx "${TMP_FOLDER}/tx.raw" "${s_payment_sk_file}"; then return 1; fi
   if ! submitTx "${tx_signed}"; then return 1; fi
 }
 
-# Command     : Delegate [wallet name] [pool vkey] [deleg cert]
+# Command     : Delegate
 # Description : Register pool with pledge on chain
-# Parameters  : wallet name  >  the wallet to delegate
-#             : pool vkey    >  the pools vkey wallet is to be delegated to
-#             : deleg cert   >  the created delegation certificate
 delegate() {
-  # wallet keys
-  # payment_sk_file - set by getWalletType function called from CNTools main script
-  # stake_sk_file - set by getWalletType function called from CNTools main script
-  pool_coldkey_vk_file="${2}"
-  pool_delegcert_file="${3}"
-  
-  getBaseAddress "${1}"
-  getBalance ${base_addr}
+
+  wallet_source="base"
+
   if ! parseWalletUTXOs; then return 1; fi
-  
   if ! getSlotAndTTL; then return 1; fi
 
   println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --invalid-hereafter ${ttl} --fee 0 --certificate-file ${pool_delegcert_file} ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp"
@@ -1415,46 +1410,37 @@ delegate() {
     --out-file "${TMP_FOLDER}"/tx.raw
   )
   if ! buildTx; then return 1; fi
-  
+
   if [[ ${op_mode} = "hybrid" ]]; then
-    tx_tmp="/tmp/tx.raw_$(date +%s)"
-    if ! cp -f "${TMP_FOLDER}/tx.raw" "${tx_tmp}"; then
-      println "ERROR" "${FG_RED}ERROR${NC}: unable to copy tx file to: ${tx_tmp}"
-      return 1
-    fi
-    println "Transaction successfully built and saved to: ${FG_CYAN}${tx_tmp}${NC}" 
-    println "DEBUG" "Copy file to offline computer and sign it using CNTools in offline mode '-o' [Sign Tx] with:"
-    println "DEBUG" "Wallet ${FG_GREEN}$(basename ${payment_sk_file})${NC}" 
-    println "DEBUG" "Wallet ${FG_GREEN}$(basename ${stake_sk_file})${NC}"
+    if ! buildOfflineJSON "Wallet Delegation"; then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"wallet-name\": \"${wallet_name}\" }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txFee: ${min_fee} }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_FOLDER}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"signing-file\": [] }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Wallet '${wallet_name}' payment signing key\", vkey: $(jq -c . "${payment_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Wallet '${wallet_name}' stake signing key\", vkey: $(jq -c . "${stake_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"signed-txBody\": {} }" <<< ${offlineJSON}); then return 1; fi
+    offline_tx="${TMP_FOLDER}/offline_tx_$(jq .id <<< ${offlineJSON})"
+    jq -r . <<< "${offlineJSON}" > "${offline_tx}"
+    echo
+    println "Offline transaction successfully built and saved to: ${FG_CYAN}${offline_tx}${NC}" 
+    println "DEBUG" "move file to offline computer and sign it using CNTools in offline mode '-o' [Transaction >> Sign] with:" 
+    println "DEBUG" "Wallet ${FG_GREEN}${wallet_name} ${FG_CYAN}$(basename ${payment_sk_file})${NC}" 
+    println "DEBUG" "Wallet ${FG_GREEN}${wallet_name} ${FG_CYAN}$(basename ${stake_sk_file})${NC}" 
     return 2 # return as failed to stop main processing and return to home menu
   fi
-
-  getWalletType "${1}"
-  case $? in
-    0) if ! signTx "${TMP_FOLDER}/tx.raw" "${stake_sk_file}" "${payment_sk_file}"; then return 1; fi ;;
-    1) if ! witnessTx "${TMP_FOLDER}/tx.raw" "${stake_sk_file}" "${payment_sk_file}"; then return 1; fi
-       if ! signTx "${TMP_FOLDER}/tx.raw"; then return 1; fi ;;
-  esac
-
+  
+  if ! signTx "${TMP_FOLDER}/tx.raw" "${stake_sk_file}" "${payment_sk_file}"; then return 1; fi
   if ! submitTx "${tx_signed}"; then return 1; fi
 }
 
-# Command     : withdrawRewards [wallet name]
+# Command     : withdrawRewards
 # Description : withdraw rewards earned and send to wallet base address
-# Parameters  : wallet name  >  the name of the wallet
 withdrawRewards() {
 
-  # Wallet key filenames
-  # payment_sk_file - set by getWalletType function called from CNTools main script
-  # stake_sk_file - set by getWalletType function called from CNTools main script
-  
-  getBaseAddress "${1}"
-  getRewardAddress "${1}"
-  getRewards "${1}"
-  
-  getBalance ${base_addr}
+  wallet_source="base"
+
   if ! parseWalletUTXOs; then return 1; fi
-  
   if ! getSlotAndTTL; then return 1; fi
 
   println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --invalid-hereafter ${ttl} --fee 0 ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp"
@@ -1491,72 +1477,65 @@ withdrawRewards() {
     --out-file "${TMP_FOLDER}"/tx.raw
   )
   if ! buildTx; then return 1; fi
-  
+
   if [[ ${op_mode} = "hybrid" ]]; then
-    tx_tmp="/tmp/tx.raw_$(date +%s)"
-    if ! cp -f "${TMP_FOLDER}/tx.raw" "${tx_tmp}"; then
-      println "ERROR" "${FG_RED}ERROR${NC}: unable to copy tx file to: ${tx_tmp}"
-      return 1
-    fi
-    println "Transaction successfully built and saved to: ${FG_CYAN}${tx_tmp}${NC}"
-    println "DEBUG" "Copy file to offline computer and sign it using CNTools in offline mode '-o' [Sign Tx] with:"
-    println "DEBUG" "Wallet ${FG_GREEN}$(basename ${payment_sk_file})${NC}"
-    println "DEBUG" "Wallet ${FG_GREEN}$(basename ${stake_sk_file})${NC}"
+    if ! buildOfflineJSON "Wallet Rewards Withdrawal"; then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"wallet-name\": \"${wallet_name}\" }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { rewards: ${reward_lovelace} }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txFee: ${min_fee} }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_FOLDER}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"signing-file\": [] }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Wallet '${wallet_name}' payment signing key\", vkey: $(jq -c . "${payment_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Wallet '${wallet_name}' stake signing key\", vkey: $(jq -c . "${stake_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"signed-txBody\": {} }" <<< ${offlineJSON}); then return 1; fi
+    offline_tx="${TMP_FOLDER}/offline_tx_$(jq .id <<< ${offlineJSON})"
+    jq -r . <<< "${offlineJSON}" > "${offline_tx}"
+    echo
+    println "Offline transaction successfully built and saved to: ${FG_CYAN}${offline_tx}${NC}" 
+    println "DEBUG" "move file to offline computer and sign it using CNTools in offline mode '-o' [Transaction >> Sign] with:" 
+    println "DEBUG" "Wallet ${FG_GREEN}${wallet_name} ${FG_CYAN}$(basename ${payment_sk_file})${NC}" 
+    println "DEBUG" "Wallet ${FG_GREEN}${wallet_name} ${FG_CYAN}$(basename ${stake_sk_file})${NC}" 
     return 2 # return as failed to stop main processing and return to home menu
   fi
-
-  getWalletType "${1}"
-  case $? in
-    0) if ! signTx "${TMP_FOLDER}/tx.raw" "${stake_sk_file}" "${payment_sk_file}"; then return 1; fi ;;
-    1) if ! witnessTx "${TMP_FOLDER}/tx.raw" "${stake_sk_file}" "${payment_sk_file}"; then return 1; fi
-       if ! signTx "${TMP_FOLDER}/tx.raw"; then return 1; fi ;;
-  esac
-
+  
+  if ! signTx "${TMP_FOLDER}/tx.raw" "${stake_sk_file}" "${payment_sk_file}"; then return 1; fi
   if ! submitTx "${tx_signed}"; then return 1; fi
 }
 
-# Command     : registerPool [pool name] [reward wallet] [delegate reward wallet] [owner wallet] [delegate owner wallet] [multi-owner skeys ...]
+# Command     : registerPool
 # Description : Register pool with pledge on chain
-# Parameters  : pool name               >  pool to register on chain
-#             : reward wallet           >  name of wallet that collects the pool rewards
-#             : delegate reward wallet  >  [Y|N] should reward wallet be delegated to pool
-#             : owner wallet            >  the pool owner, also pays for the pool registration fee
-#             : delegate owner wallet   >  [Y|N] should owner wallet be delegated to pool
-#             : multi-owner skeys       >  a list of extra extra owner skeys to sign pool registration with
 registerPool() {
 
-  pool_coldkey_sk_file="${POOL_FOLDER}/${1}/${POOL_COLDKEY_SK_FILENAME}"
-  pool_regcert_file="${POOL_FOLDER}/${1}/${POOL_REGCERT_FILENAME}"
-  getWalletType ${2}
-  reward_stake_sk_file="${stake_sk_file}"
-  reward_delegation_cert_file="${WALLET_FOLDER}/${2}/${WALLET_DELEGCERT_FILENAME}"
-  delegate_reward_wallet="${3}"
-  owner_payment_sk_file="${WALLET_FOLDER}/${4}/${WALLET_PAY_SK_FILENAME}"
-  owner_stake_sk_file="${WALLET_FOLDER}/${4}/${WALLET_STAKE_SK_FILENAME}"
-  owner_delegation_cert_file="${WALLET_FOLDER}/${4}/${WALLET_DELEGCERT_FILENAME}"
-  getBaseAddress "${4}"
+  getBaseAddress ${owner_wallets[0]}
   getBalance ${base_addr}
-  delegate_owner_wallet="${5}"
-  shift 5
-  multi_owner_count=$#
-  multi_owner_keys=( "$@" )
-
   if ! parseWalletUTXOs; then return 1; fi
   
   if ! getSlotAndTTL; then return 1; fi
+  
   poolDeposit=$(jq -r '.poolDeposit' "${TMP_FOLDER}"/protparams.json)
   println "LOG" "Pool Deposit is ${poolDeposit}"
   
-  reward_delegation_cert=""
-  [[ ${delegate_reward_wallet} = 'Y' ]] && reward_delegation_cert="--certificate-file ${reward_delegation_cert_file}"
   owner_delegation_cert=""
   [[ ${delegate_owner_wallet} = 'Y' ]] && owner_delegation_cert="--certificate-file ${owner_delegation_cert_file}"
   
-  reward_wallet_key=""
-  witness_count=$(( 3 + multi_owner_count ))
-  if [[ ! "${owner_stake_sk_file}" = "${reward_stake_sk_file}" ]]; then
-    reward_wallet_key="${reward_stake_sk_file}"
-    ((witness_count++))
+  witness_count=$(( 2 + ${#owner_wallets[@]} )) # owner payment + cold + multi-owners(main owner included)
+  
+  reward_delegation_cert=""
+  reward_wallet_stake_key=""
+  if [[ ${delegate_reward_wallet} = 'Y' ]]; then
+    reward_delegation_cert="--certificate-file ${reward_delegation_cert_file}"
+    reward_mu='N'
+    for wallet_name in ${owner_wallets[@]}; do
+      [[ "${wallet_name}" = "${reward_wallet}" ]] && reward_mu='Y' && break # reward wallet is also a multi owner, witness count already include reward wallet stake key
+    done
+    [[ ${reward_mu} = 'N' ]] && ((witness_count++)) # reward wallet to be delegated but not a multi-owner, increase witness count
+  else
+    reward_stake_sk_file=""
+  fi
+  
+  owner_delegation_cert=""
+  if [[ ${delegate_owner_wallet} = 'Y' ]]; then
+    owner_delegation_cert="--certificate-file ${owner_delegation_cert_file}"
   fi
 
   println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --invalid-hereafter ${ttl} --certificate-file ${pool_regcert_file} ${owner_delegation_cert} ${reward_delegation_cert} --fee 0 ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp"
@@ -1576,7 +1555,7 @@ registerPool() {
   println "LOG" "fee is $(formatLovelace ${min_fee}) Ada"
 
   if [[ ${lovelace} -lt $(( min_fee + poolDeposit )) ]]; then
-    println "ERROR" "${FG_RED}ERROR${NC}: Not enough Ada in base address ( $(formatLovelace ${lovelace}) < $(formatLovelace ${min_fee}) + $(formatLovelace ${poolDeposit}) )"
+    println "ERROR" "\n${FG_RED}ERROR${NC}: Not enough Ada in base address ( $(formatLovelace ${lovelace}) < $(formatLovelace ${min_fee}) + $(formatLovelace ${poolDeposit}) )"
     return 1
   fi
 
@@ -1597,57 +1576,65 @@ registerPool() {
   if ! buildTx; then return 1; fi
   
   if [[ ${op_mode} = "hybrid" ]]; then
-    tx_tmp="/tmp/tx.raw_$(date +%s)"
-    if ! cp -f "${TMP_FOLDER}/tx.raw" "${tx_tmp}"; then
-      println "ERROR" "${FG_RED}ERROR${NC}: unable to copy tx file to: ${tx_tmp}"
-      return 1
-    fi
-    println "Transaction successfully built and saved to: ${FG_CYAN}${tx_tmp}${NC}" 
-    println "DEBUG" "Copy file to offline computer and sign it using CNTools in offline mode '-o' [Sign Tx] with:" 
-    println "DEBUG" "Owner wallet ${FG_GREEN}${WALLET_PAY_SK_FILENAME}${NC}" 
-    println "DEBUG" "Owner wallet ${FG_GREEN}${WALLET_STAKE_SK_FILENAME}${NC}" 
-    println "DEBUG" "Pool ${FG_GREEN}${POOL_COLDKEY_SK_FILENAME}${NC}" 
-    [[ -n ${reward_wallet_key} ]] && println "DEBUG" "Reward wallet ${FG_GREEN}$(basename ${reward_wallet_key})${NC}"
-    [[ ${multi_owner_count} -gt 0 ]] && println "DEBUG" "Additional owners ${FG_GREEN}stake signing key${NC}"
-    return 2
+    if ! buildOfflineJSON "Pool Registration"; then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"pool-metadata\": $(jq -c . "${pool_meta_file}") }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"pool-pledge\": ${pledge_ada} }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"pool-margin\": \"${margin}\" }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"pool-cost\": ${cost_ada} }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txFee: $(( min_fee + poolDeposit )) }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_FOLDER}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"signing-file\": [] }" <<< ${offlineJSON}); then return 1; fi
+    for index in "${!owner_wallets[@]}"; do
+      if [[ ${index} -eq 0 ]]; then
+        if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Owner #$((index+1)) '${wallet_name}' payment signing key\", vkey: $(jq -c . "${owner_payment_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
+      fi
+      stake_vk_file="${WALLET_FOLDER}/${owner_wallets[${index}]}/${WALLET_STAKE_VK_FILENAME}"
+      if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Owner #$((index+1)) '${wallet_name}' stake signing key\", vkey: $(jq -c . "${stake_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
+    done
+    [[ ${delegate_reward_wallet} = 'Y' && ${reward_mu} = 'N' ]] && if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Reward wallet '${wallet_name}' stake signing key\", vkey: $(jq -c . "${reward_stake_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Pool '${pool_name}' cold signing key\", vkey: $(jq -c . "${pool_coldkey_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { witness: [] }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"signed-txBody\": {} }" <<< ${offlineJSON}); then return 1; fi
+    offline_tx="${TMP_FOLDER}/offline_tx_$(jq .id <<< ${offlineJSON})"
+    jq -r . <<< "${offlineJSON}" > "${offline_tx}"
+    echo
+    println "Offline transaction successfully built and saved to: ${FG_CYAN}${offline_tx}${NC}" 
+    println "DEBUG" "move file to offline computer and sign it using CNTools in offline mode '-o' [Transaction >> Sign] with:" 
+    println "DEBUG" "Pool ${FG_GREEN}${pool_name} ${FG_CYAN}${POOL_COLDKEY_SK_FILENAME}${NC}" 
+    println "DEBUG" "Owner #1 ${FG_GREEN}${owner_wallets[0]} ${FG_CYAN}${WALLET_PAY_SK_FILENAME}${NC} & ${FG_CYAN}${WALLET_STAKE_SK_FILENAME}${NC}" 
+    for index in "${!owner_wallets[@]}"; do
+      [[ ${index} -eq 0 ]] && continue # skip main owner
+      println "DEBUG" "Owner #$((index+1)) ${FG_GREEN}${owner_wallets[${index}]} ${FG_CYAN}${WALLET_STAKE_SK_FILENAME}${NC}"
+    done
+    [[ delegate_reward_wallet = 'Y' ]] && println "DEBUG" "Reward wallet ${FG_GREEN}${reward_wallet} ${FG_CYAN}$(basename ${reward_stake_sk_file})${NC}"
+    return 2 # return as failed to stop main processing and return to home menu
   fi
   
-  if ! witnessTx "${TMP_FOLDER}/tx.raw" "${owner_payment_sk_file}" "${pool_coldkey_sk_file}" "${owner_stake_sk_file}" "${reward_wallet_key}" "${multi_owner_keys[@]}"; then return 1; fi
-  if ! signTx "${TMP_FOLDER}/tx.raw"; then return 1; fi
+  multi_owner_keys=()
+  for wallet_name in ${owner_wallets[@]}; do
+    [[ "${wallet_name}" = "${owner_wallets[0]}" ]] && continue # skip main owner
+    [[ "${wallet_name}" = "${reward_wallet}" && ${delegate_reward_wallet} = 'Y' ]] && continue # skip reward wallet, already included due to delegation
+    getWalletType ${wallet_name}
+    multi_owner_keys+=( "${stake_sk_file}" )
+  done
+  
+  if ! witnessTx "${TMP_FOLDER}/tx.raw" "${owner_payment_sk_file}" "${pool_coldkey_sk_file}" "${owner_stake_sk_file}" "${reward_stake_sk_file}" "${multi_owner_keys[@]}"; then return 1; fi
+  if ! assembleTx "${TMP_FOLDER}/tx.raw"; then return 1; fi
   if ! submitTx "${tx_signed}"; then return 1; fi
 }
 
 
-# Command     : modifyPool [pool name] [reward wallet] [owner wallet] [multi-owner skeys ...]
+# Command     : modifyPool
 # Description : Register pool with pledge on chain
-# Parameters  : pool name          >  pool to register on chain
-#             : reward wallet      >  name of wallet that collects the pool rewards
-#             : owner wallet       >  the pool owner, also pays for the pool registration fee
-#             : multi-owner skeys  >  a list of extra extra owner skeys to sign pool registration with
 modifyPool() {
 
-  pool_coldkey_sk_file="${POOL_FOLDER}/${1}/${POOL_COLDKEY_SK_FILENAME}"
-  pool_regcert_file="${POOL_FOLDER}/${1}/${POOL_REGCERT_FILENAME}"
-  getWalletType ${2}
-  reward_stake_sk_file="${stake_sk_file}"
-  owner_payment_sk_file="${WALLET_FOLDER}/${3}/${WALLET_PAY_SK_FILENAME}"
-  owner_stake_sk_file="${WALLET_FOLDER}/${3}/${WALLET_STAKE_SK_FILENAME}"
-  getBaseAddress "${3}"
+  getBaseAddress ${owner_wallets[0]}
   getBalance ${base_addr}
-  shift 3
-  multi_owner_count=$#
-  multi_owner_keys=( "$@" )
-  
   if ! parseWalletUTXOs; then return 1; fi
-
+  
   if ! getSlotAndTTL; then return 1; fi
 
-  reward_wallet_key=""
-  witness_count=$(( 3 + multi_owner_count ))
-  if [[ ! "${owner_stake_sk_file}" = "${reward_stake_sk_file}" ]]; then
-    reward_wallet_key="${reward_stake_sk_file}"
-    ((witness_count++))
-  fi
+  witness_count=$(( 2 + ${#owner_wallets[@]} )) # owner payment + cold + multi-owners(main owner included)
 
   println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --invalid-hereafter ${ttl} --certificate-file ${pool_regcert_file} --fee 0 ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp"
   if ! ${CCLI} transaction build-raw ${tx_in} --tx-out ${base_addr}+0 --invalid-hereafter ${ttl} --certificate-file ${pool_regcert_file} --fee 0 ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
@@ -1666,7 +1653,7 @@ modifyPool() {
   println "LOG" "fee is $(formatLovelace ${min_fee}) Ada"
 
   if [[ ${lovelace} -lt ${min_fee} ]]; then
-    println "ERROR" "${FG_RED}ERROR${NC}: Not enough Ada in base address ( $(formatLovelace ${lovelace}) < $(formatLovelace ${min_fee}) )"
+    println "ERROR" "\n${FG_RED}ERROR${NC}: Not enough Ada in base address ( $(formatLovelace ${lovelace}) < $(formatLovelace ${min_fee}) )"
     return 1
   fi
 
@@ -1685,47 +1672,62 @@ modifyPool() {
   if ! buildTx; then return 1; fi
   
   if [[ ${op_mode} = "hybrid" ]]; then
-    tx_tmp="/tmp/tx.raw_$(date +%s)"
-    if ! cp -f "${TMP_FOLDER}/tx.raw" "${tx_tmp}"; then
-      println "ERROR" "${FG_RED}ERROR${NC}: unable to copy tx file to: ${tx_tmp}"
-      return 1
-    fi
-    println "Transaction successfully built and saved to: ${FG_CYAN}${tx_tmp}${NC}" 
-    println "DEBUG" "Copy file to offline computer and sign it using CNTools in offline mode '-o' [Sign Tx] with:" 
-    println "DEBUG" "Owner wallet ${FG_GREEN}${WALLET_PAY_SK_FILENAME}${NC}" 
-    println "DEBUG" "Owner wallet ${FG_GREEN}${WALLET_STAKE_SK_FILENAME}${NC}" 
-    println "DEBUG" "Pool ${FG_GREEN}${POOL_COLDKEY_SK_FILENAME}${NC}"
-    [[ -n ${reward_wallet_key} ]] && println "DEBUG" "Reward wallet ${FG_GREEN}$(basename ${reward_wallet_key})${NC}"
-    [[ ${multi_owner_count} -gt 0 ]] && println "DEBUG" "Additional owners ${FG_GREEN}stake signing key${NC}"
-    return 2
+    if ! buildOfflineJSON "Pool Update"; then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"pool-metadata\": $(jq -c . "${pool_meta_file}") }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"pool-pledge\": ${pledge_ada} }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"pool-margin\": \"${margin}\" }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"pool-cost\": ${cost_ada} }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txFee: ${min_fee} }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_FOLDER}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"signing-file\": [] }" <<< ${offlineJSON}); then return 1; fi
+    for index in "${!owner_wallets[@]}"; do
+      if [[ ${index} -eq 0 ]]; then
+        if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Owner #$((index+1)) '${wallet_name}' payment signing key\", vkey: $(jq -c . "${owner_payment_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
+      fi
+      stake_vk_file="${WALLET_FOLDER}/${owner_wallets[${index}]}/${WALLET_STAKE_VK_FILENAME}"
+      if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Owner #$((index+1)) '${wallet_name}' stake signing key\", vkey: $(jq -c . "${stake_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
+    done
+    if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Pool '${pool_name}' cold signing key\", vkey: $(jq -c . "${pool_coldkey_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { witness: [] }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"signed-txBody\": {} }" <<< ${offlineJSON}); then return 1; fi
+    offline_tx="${TMP_FOLDER}/offline_tx_$(jq .id <<< ${offlineJSON})"
+    jq -r . <<< "${offlineJSON}" > "${offline_tx}"
+    echo
+    println "Offline transaction successfully built and saved to: ${FG_CYAN}${offline_tx}${NC}" 
+    println "DEBUG" "move file to offline computer and sign it using CNTools in offline mode '-o' [Transaction >> Sign] with:" 
+    println "DEBUG" "Pool ${FG_GREEN}${pool_name} ${FG_CYAN}${POOL_COLDKEY_SK_FILENAME}${NC}" 
+    println "DEBUG" "Owner #1 ${FG_GREEN}${owner_wallets[0]} ${FG_CYAN}${WALLET_PAY_SK_FILENAME}${NC} & ${FG_CYAN}${WALLET_STAKE_SK_FILENAME}${NC}" 
+    for index in "${!owner_wallets[@]}"; do
+      [[ ${index} -eq 0 ]] && continue # skip main owner
+      println "DEBUG" "Owner #$((index+1)) ${FG_GREEN}${owner_wallets[${index}]} ${FG_CYAN}${WALLET_STAKE_SK_FILENAME}${NC}"
+    done
+    return 2 # return as failed to stop main processing and return to home menu
   fi
   
-  if ! witnessTx "${TMP_FOLDER}/tx.raw" "${owner_payment_sk_file}" "${pool_coldkey_sk_file}" "${owner_stake_sk_file}" "${reward_wallet_key}" "${multi_owner_keys[@]}"; then return 1; fi
-  if ! signTx "${TMP_FOLDER}/tx.raw"; then return 1; fi
+  multi_owner_keys=()
+  for wallet_name in ${owner_wallets[@]}; do
+    [[ "${wallet_name}" = "${owner_wallets[0]}" ]] && continue # skip main owner
+    getWalletType ${wallet_name}
+    multi_owner_keys+=( "${stake_sk_file}" )
+  done
+  
+  if ! witnessTx "${TMP_FOLDER}/tx.raw" "${owner_payment_sk_file}" "${pool_coldkey_sk_file}" "${owner_stake_sk_file}" "${multi_owner_keys[@]}"; then return 1; fi
+  if ! assembleTx "${TMP_FOLDER}/tx.raw"; then return 1; fi
   if ! submitTx "${tx_signed}"; then return 1; fi
 }
 
-# Command     : deRegisterPool [pool cold skey] [pool dereg cert] [wallet addr] [wallet skey]
+# Command     : deRegisterPool
 # Description : Retire pool
-# Parameters  : pool cold skey   >  wallet stake skey
-#             : pool dereg cert  >  wallet payment skey
-#             : wallet addr      >  wallet base address
-#             : wallet skey      >  wallet base address
 deRegisterPool() {
 
-  # script arguments
-  pool_coldkey_sk_file="$1"
-  pool_deregcert_file="$2"
-  wallet_addr="$3"
-  wallet_payment_sk_file="$4"
-  
-  getBalance ${wallet_addr}
-  if ! parseWalletUTXOs; then return 1; fi
+  [[ $(cat "${WALLET_FOLDER}/${wallet_name}/${WALLET_PAY_ADDR_FILENAME}" 2>/dev/null) = "${addr}" ]] && wallet_source="enterprise" || wallet_source="base"
 
+  getBalance ${addr}
+  if ! parseWalletUTXOs; then return 1; fi
   if ! getSlotAndTTL; then return 1; fi
 
-  println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out ${wallet_addr}+0 --invalid-hereafter ${ttl} --fee 0 --certificate-file ${pool_deregcert_file} ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp"
-  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out ${wallet_addr}+0 --invalid-hereafter ${ttl} --fee 0 --certificate-file ${pool_deregcert_file} ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
+  println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out ${addr}+0 --invalid-hereafter ${ttl} --fee 0 --certificate-file ${pool_deregcert_file} ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp"
+  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out ${addr}+0 --invalid-hereafter ${ttl} --fee 0 --certificate-file ${pool_deregcert_file} ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
   min_fee_args=(
     transaction calculate-min-fee
     --tx-body-file "${TMP_FOLDER}"/tx0.tmp
@@ -1746,7 +1748,7 @@ deRegisterPool() {
   fi
 
   newBalance=$(( lovelace - min_fee ))
-  tx_out="--tx-out ${wallet_addr}+${newBalance}"
+  tx_out="--tx-out ${addr}+${newBalance}"
   println "LOG" "Balance left to be returned in used UTxO is $(formatLovelace ${newBalance}) Ada ( $(formatLovelace ${lovelace}) - $(formatLovelace ${min_fee}) )"
   
   build_args=(
@@ -1760,29 +1762,40 @@ deRegisterPool() {
   if ! buildTx; then return 1; fi
   
   if [[ ${op_mode} = "hybrid" ]]; then
-    tx_tmp="/tmp/tx.raw_$(date +%s)"
-    if ! cp -f "${TMP_FOLDER}/tx.raw" "${tx_tmp}"; then
-      println "ERROR" "${FG_RED}ERROR${NC}: unable to copy tx file to: ${tx_tmp}"
-      return 1
+    if ! buildOfflineJSON "Pool De-Registration"; then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"wallet-name\": \"${wallet_name}\" }" <<< ${offlineJSON}); then return 1; fi
+    if [[ -f "${POOL_FOLDER}/${pool_name}/poolmeta.json" ]]; then
+      if ! offlineJSON=$(jq ". += { \"pool-name\": \"$(jq -r .name "${POOL_FOLDER}/${pool_name}/poolmeta.json")\" }" <<< ${offlineJSON}); then return 1; fi
+      if ! offlineJSON=$(jq ". += { \"pool-ticker\": \"$(jq -r .ticker "${POOL_FOLDER}/${pool_name}/poolmeta.json")\" }" <<< ${offlineJSON}); then return 1; fi
+    else
+      if ! offlineJSON=$(jq ". += { \"pool-name\": \"${pool_name}\" }" <<< ${offlineJSON}); then return 1; fi
+      if ! offlineJSON=$(jq ". += { \"pool-ticker\": \"\" }" <<< ${offlineJSON}); then return 1; fi
     fi
-    println "Transaction successfully built and saved to: ${FG_CYAN}${tx_tmp}${NC}" 
-    println "DEBUG" "Copy file to offline computer and sign it using CNTools in offline mode '-o' [Sign Tx] with:" 
-    println "DEBUG" "Wallet ${FG_GREEN}${WALLET_PAY_SK_FILENAME}${NC}" 
-    println "DEBUG" "Pool ${FG_GREEN}${POOL_COLDKEY_SK_FILENAME}${NC}" 
+    if ! offlineJSON=$(jq ". += { \"retire-epoch\": ${epoch_enter} }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txFee: ${min_fee} }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_FOLDER}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"signing-file\": [] }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Wallet '${wallet_name}' payment signing key\", vkey: $(jq -c . "${payment_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Pool '${pool_name}' stake signing key\", vkey: $(jq -c . "${pool_coldkey_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"signed-txBody\": {} }" <<< ${offlineJSON}); then return 1; fi
+    offline_tx="${TMP_FOLDER}/offline_tx_$(jq .id <<< ${offlineJSON})"
+    jq -r . <<< "${offlineJSON}" > "${offline_tx}"
+    echo
+    println "Offline transaction successfully built and saved to: ${FG_CYAN}${offline_tx}${NC}" 
+    println "DEBUG" "move file to offline computer and sign it using CNTools in offline mode '-o' [Transaction >> Sign] with:" 
+    println "DEBUG" "Wallet ${FG_GREEN}${wallet_name} ${FG_CYAN}$(basename ${payment_sk_file})${NC}" 
+    println "DEBUG" "Pool ${FG_GREEN}${pool_name} ${FG_CYAN}$(basename ${pool_coldkey_sk_file})${NC}" 
     return 2 # return as failed to stop main processing and return to home menu
   fi
-
-  if ! witnessTx "${TMP_FOLDER}/tx.raw" "${wallet_payment_sk_file}" "${pool_coldkey_sk_file}"; then return 1; fi
-  if ! signTx "${TMP_FOLDER}/tx.raw"; then return 1; fi
+  
+  if ! signTx "${TMP_FOLDER}/tx.raw" "${payment_sk_file}" "${pool_coldkey_sk_file}"; then return 1; fi
   if ! submitTx "${tx_signed}"; then return 1; fi
 }
 
-# Command     : rotatePoolKeys [pool name]
+# Command     : rotatePoolKeys
 # Description : Rotate pool's KES keys
 # Parameters  : pool name   >  the pool name to rotate KES keys for
 rotatePoolKeys() {
-  pool_name="${1}"
-
   # cold keys
   pool_coldkey_sk_file="${POOL_FOLDER}/${pool_name}/${POOL_COLDKEY_SK_FILENAME}"
 
@@ -1805,31 +1818,25 @@ rotatePoolKeys() {
   kesExpiration "${current_kes_period}"
 }
 
-# Command     : sendMetadata [wallet address] [wallet sign key] [metadata file] [metadata type]
+# Command     : sendMetadata
 # Description : post metadata file on chain using specified wallet to pay for the transaction fee
-# Parameters  : wallet address  >  the address of wallet to pay for metadata transaction
-#             : wallet sign key >  signing key of wallet
-#             : metadata file   >  the metadata file to send
-#             : metadata type   >  the type of metadata to send (no-schema|detailed-schema|cbor)
 sendMetadata() {
-  # Handle script arguments
-  addr="$1"
-  payment_sk_file="$2"
-  metafile="$3"
-  if [[ $4 = "no-schema" ]]; then
+
+  [[ $(cat "${WALLET_FOLDER}/${wallet_name}/${WALLET_PAY_ADDR_FILENAME}" 2>/dev/null) = "${addr}" ]] && wallet_source="enterprise" || wallet_source="base"
+
+  if [[ ${metatype} = "no-schema" ]]; then
     metadata="--json-metadata-no-schema --metadata-json-file ${metafile}"
-  elif [[ $4 = "detailed-schema" ]]; then
+  elif [[ ${metatype} = "detailed-schema" ]]; then
     metadata="--json-metadata-detailed-schema --metadata-json-file ${metafile}"
-  elif [[ $4 = "cbor" ]]; then
+  elif [[ ${metatype} = "cbor" ]]; then
     metadata="--metadata-cbor-file ${metafile}"
   else
-    println "ERROR" "${FG_RED}ERROR${NC}: unknown metadata type '$4'"
+    println "ERROR" "${FG_RED}ERROR${NC}: unknown metadata type '${metatype}'"
     return 1
   fi
 
   getBalance ${addr}
   if ! parseWalletUTXOs; then return 1; fi
-  
   if ! getSlotAndTTL; then return 1; fi
 
   println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out ${addr}+0 --invalid-hereafter ${ttl} --fee 0 ${metadata} ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp"
@@ -1868,24 +1875,24 @@ sendMetadata() {
   if ! buildTx; then return 1; fi
   
   if [[ ${op_mode} = "hybrid" ]]; then
-    tx_tmp="/tmp/tx.raw_$(date +%s)"
-    if ! cp -f "${TMP_FOLDER}/tx.raw" "${tx_tmp}"; then
-      println "ERROR" "${FG_RED}ERROR${NC}: unable to copy tx file to: ${tx_tmp}"
-      return 1
-    fi
-    println "Transaction successfully built and saved to: ${FG_CYAN}${tx_tmp}${NC}" 
-    println "DEBUG" "Copy file to offline computer and sign it using CNTools in offline mode '-o' [Sign Tx] with:" 
-    println "DEBUG" "Wallet: ${FG_GREEN}${WALLET_PAY_SK_FILENAME}${NC}" 
+    if ! buildOfflineJSON "Metadata"; then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"wallet-name\": \"${wallet_name}\" }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { metadata: $(jq -c . "${metafile}") }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txFee: ${min_fee} }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_FOLDER}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"signing-file\": [] }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Wallet '${wallet_name}' payment signing key\", vkey: $(jq -c . "${payment_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"signed-txBody\": {} }" <<< ${offlineJSON}); then return 1; fi
+    offline_tx="${TMP_FOLDER}/offline_tx_$(jq .id <<< ${offlineJSON})"
+    jq -r . <<< "${offlineJSON}" > "${offline_tx}"
+    echo
+    println "Offline transaction successfully built and saved to: ${FG_CYAN}${offline_tx}${NC}" 
+    println "DEBUG" "move file to offline computer and sign it using CNTools in offline mode '-o' [Transaction >> Sign] with:" 
+    println "DEBUG" "Wallet ${FG_GREEN}${wallet_name} ${FG_CYAN}$(basename ${payment_sk_file})${NC}" 
     return 2 # return as failed to stop main processing and return to home menu
   fi
-
-  getWalletType "${payment_sk_file}"
-  case $? in
-    0) if ! signTx "${TMP_FOLDER}/tx.raw" "${payment_sk_file}"; then return 1; fi ;;
-    1) if ! witnessTx "${TMP_FOLDER}/tx.raw" "${payment_sk_file}"; then return 1; fi
-       if ! signTx "${TMP_FOLDER}/tx.raw"; then return 1; fi ;;
-  esac
-
+  
+  if ! signTx "${TMP_FOLDER}/tx.raw" "${payment_sk_file}"; then return 1; fi
   if ! submitTx "${tx_signed}"; then return 1; fi
 }
 
@@ -1905,14 +1912,12 @@ buildTx() {
 witnessTx() {
   tx_raw="$1"
   shift
-  parent_dir="$(dirname "${tx_raw}")"
   tx_witness_files=()
   for skey in "$@"; do
     [[ -z ${skey//[[:blank:]]/} ]] && continue
     if [[ -f "${skey}" && $(jq -r '.description' "${skey}") = *"Hardware"* ]]; then # HW signing key
-      waitForInput "${FG_BLUE}INFO${NC}: please unlock hardware device and open the Cardano app, after this press any key to continue"
-      println "DEBUG" "${FG_BLUE}INFO${NC}: follow directions on hardware device to witness the transaction"
-      tx_witness="$(mktemp "${parent_dir}/tx_witness.XXXXXXXXXX")"
+      if ! unlockHWDevice "witness the transaction"; then return 1; fi
+      tx_witness="$(mktemp "${TMP_FOLDER}/tx.witness_XXXXXXXXXX")"
       witness_command=(
         cardano-hw-cli shelley transaction witness
         --tx-body-file "${tx_raw}"
@@ -1924,7 +1929,7 @@ witnessTx() {
       if ! ${witness_command[@]}; then return 1; fi
       jq ".type = \"${ERA_WITNESS}\"" "${tx_witness}" > "${tx_witness}.tmp" && mv -f "${tx_witness}.tmp" "${tx_witness}" # due to cardano-hw-cli bug, not setting era type correctly
     elif [[ -f "${skey}" ]]; then
-      tx_witness="$(mktemp "${parent_dir}/tx_witness.XXXXXXXXXX")"
+      tx_witness="$(mktemp "${TMP_FOLDER}/tx.witness_XXXXXXXXXX")"
       witness_command=(
         ${CCLI} transaction witness
         --tx-body-file "${tx_raw}"
@@ -1942,38 +1947,15 @@ witnessTx() {
   done
 }
 
-# Command     : signTx [raw tx file] [optional: signing keys ...]
-# Description : Helper function to sign a raw transaction
-# Parameters  : raw tx file    >  the transaction file to sign
-#             : signing keys   >  [optional] list of signing keys to use when signing the transaction, used for HW wallet other than pool registration
-signTx() {
+# Command     : assembleTx [raw tx file]
+# Description : Helper function to witnessTx for assembling a signed tx using witnesses from tx_witness_files[] array
+assembleTx() {
   tx_raw="$1"
-  shift
-  #tx_witness_files - array assembled in witnessTx()
-  parent_dir="$(dirname "${tx_raw}")"
-  tx_signed="${parent_dir}/tx.signed_$(date +%s)"
-  if [[ $# -gt 0 ]]; then # sign directly, only used by hw wallet so this is assumed
-    tx_sign_out=()
-    for skey in "$@"; do
-      if [[ -f "${skey}" ]]; then
-        tx_sign_out+=( "--hw-signing-file ${skey}" )
-      else
-        println "ERROR" "${FG_RED}ERROR${NC}: sign key not found: ${skey}"
-        return 1
-      fi
-    done
-    sign_command=(
-      cardano-hw-cli shelley transaction sign
-      --tx-body-file "${tx_raw}"
-      ${tx_sign_out[@]}
-      ${NETWORK_IDENTIFIER}
-      --out-file "${tx_signed}"
-    )
-    waitForInput "${FG_BLUE}INFO${NC}: please unlock hardware device and open the Cardano app, after this press any key to continue"
-    println "DEBUG" "${FG_BLUE}INFO${NC}: follow directions on hardware device to witness the transaction"
-  else # assemble witness files and sign
+  tx_signed="${TMP_FOLDER}/tx.signed_$(date +%s)"
+  if [[ ${#tx_witness_files[@]} -gt 0 ]]; then # assemble witness files and sign
     tx_witness_out=()
     for witness in "${tx_witness_files[@]}"; do
+      [[ -z ${witness//[[:blank:]]/} ]] && continue
       if [[ -f "${witness}" ]]; then
         tx_witness_out+=( "--witness-file ${witness}" )
       else
@@ -1987,6 +1969,59 @@ signTx() {
       ${tx_witness_out[@]}
       --out-file "${tx_signed}"
     )
+    println "ACTION" "${sign_command[@]}"
+    ${sign_command[@]}
+  else
+    println "ERROR" "${FG_RED}ERROR${NC}: no witness files provided, unable to assemble tx!"
+    return 1
+  fi
+}
+
+# Command     : signTx [raw tx file] [signing keys ...]
+# Description : Helper function to sign a raw transaction
+# Parameters  : raw tx file    >  the transaction file to sign
+#             : signing keys   >  list of signing keys to use when signing the transaction, for direct signing
+signTx() {
+  tx_raw="$1"
+  shift
+  tx_signed="${TMP_FOLDER}/tx.signed_$(date +%s)"
+  if [[ $# -gt 0 ]]; then # sign directly
+    tx_sign_out=()
+    hw_wallet='N'
+    for skey in "$@"; do
+      [[ -z ${skey//[[:blank:]]/} ]] && continue
+      if [[ -f "${skey}" && $(jq -r '.description' "${skey}") = *"Hardware"* ]]; then # HW signing key
+        tx_sign_out+=( "--hw-signing-file ${skey}" )
+        [[ ${wallet_source} = "base" ]] && tx_sign_out+=( "--change-output-key-file ${skey}" )
+        hw_wallet='Y'
+      elif [[ -f "${skey}" ]]; then
+        tx_sign_out+=( "--signing-key-file ${skey}" )
+      else
+        println "ERROR" "\n${FG_RED}ERROR${NC}: sign key not found: ${skey}"
+        return 1
+      fi
+    done
+    if [[ ${hw_wallet} = 'Y' ]]; then
+      if ! unlockHWDevice "sign the transaction"; then return 1; fi
+      sign_command=(
+        cardano-hw-cli shelley transaction sign
+        --tx-body-file "${tx_raw}"
+        ${tx_sign_out[@]}
+        ${NETWORK_IDENTIFIER}
+        --out-file "${tx_signed}"
+      )
+    else
+      sign_command=(
+        ${CCLI} transaction sign
+        --tx-body-file "${tx_raw}"
+        ${tx_sign_out[@]}
+        ${NETWORK_IDENTIFIER}
+        --out-file "${tx_signed}"
+      )
+    fi
+  else
+    println "ERROR" "\n${FG_RED}ERROR${NC}: no signing keys provided, unable to sign tx!"
+    return 1
   fi
   
   println "ACTION" "${sign_command[@]}"
@@ -2008,6 +2043,23 @@ submitTx() {
   
   println "ACTION" "${submit_command[@]}"
   ${submit_command[@]}
+}
+
+# Command     : unlockHWDevice [action]
+# Description : Directions to unlock and open HW device
+# Parameters  : action  >  message for action to be taken
+unlockHWDevice() {
+  waitForInput "${FG_BLUE}INFO${NC}: please unlock hardware device and open the Cardano app, after this press any key to continue"
+  
+  println "ACTION" "cardano-hw-cli device version | cut -d' ' -f4"
+  device_app_version="$(cardano-hw-cli device version | cut -d' ' -f4)"
+  if [[ ${device_app_version} = "undefined.undefined.undefined" ]]; then
+    println "ERROR" "${FG_RED}ERROR${NC}: unable to identify cardano app installed on hardware device, is the device plugged in, unlocked and Cardano app opened?"
+    println "ERROR" "Make sure udev rules are correctly set up and device seen by OS using tools like lsusb etc"
+    waitForInput && return 1
+  fi
+  
+  println "DEBUG" "\n${FG_BLUE}INFO${NC}: follow directions on hardware device to $1"
 }
 
 

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -1990,9 +1990,14 @@ signTx() {
     hw_wallet='N'
     for skey in "$@"; do
       [[ -z ${skey//[[:blank:]]/} ]] && continue
-      if [[ -f "${skey}" && $(jq -r '.description' "${skey}") = *"Hardware"* ]]; then # HW signing key
+      skey_desc="$(jq -r '.description' "${skey}")"
+      if [[ -f "${skey}" && ${skey_desc} = *"Hardware"* ]]; then # HW signing key
         tx_sign_out+=( "--hw-signing-file ${skey}" )
-        [[ ${wallet_source} = "base" ]] && tx_sign_out+=( "--change-output-key-file ${skey}" )
+        if [[ ${wallet_source} = "base" && ${skey_desc} = "Payment"* ]]; then
+          tx_sign_out+=( "--change-output-key-file ${skey}" )
+          # Add stake.hwsfile as well as a change output
+          [[ -f "$(dirname "${skey}")/${WALLET_HW_STAKE_SK_FILENAME}" ]] && tx_sign_out+=( "--change-output-key-file $(dirname "${skey}")/${WALLET_HW_STAKE_SK_FILENAME}" )
+        fi
         hw_wallet='Y'
       elif [[ -f "${skey}" ]]; then
         tx_sign_out+=( "--signing-key-file ${skey}" )

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -1738,7 +1738,7 @@ EOF
     if [[ ${metadata_done} = false ]]; then
       echo
       if [[ ! -f "${pool_meta_file}" ]] || ! meta_name=$(jq -er .name "${pool_meta_file}"); then meta_name="${pool_name}"; fi
-      if [[ ! -f "${pool_meta_file}" ]] || ! meta_ticker=$(jq -er .ticker "${pool_meta_file}"); then meta_ticker="$(echo ${pool_name//[^[:alnum:]]/} | tr [:lower:] [:upper:] | cut -c-5)"; fi
+      if [[ ! -f "${pool_meta_file}" ]] || ! meta_ticker=$(jq -er .ticker "${pool_meta_file}"); then meta_ticker="$(echo ${pool_name//[^[:alnum:]]/} | tr '[:lower:]' '[:upper:]' | cut -c-5)"; fi
       if [[ ! -f "${pool_meta_file}" ]] || ! meta_description=$(jq -er .description "${pool_meta_file}"); then meta_description="No Description"; fi
       if [[ ! -f "${pool_meta_file}" ]] || ! meta_homepage=$(jq -er .homepage "${pool_meta_file}"); then meta_homepage="https://foo.com"; fi
       if [[ ! -f "${pool_meta_file}" ]] || ! meta_extended=$(jq -er .extended "${pool_meta_file}"); then meta_extended="https://foo.com/metadata/extended.json"; fi
@@ -1902,10 +1902,10 @@ EOF
       select_opt "[y] Yes" "[n] No" "[Esc] Cancel"
       case $? in
         0) reuse_wallets='Y'
-           for wallet_name in ${owner_wallets[@]}; do # Validate each wallet that they still exist and contain the correct keys
+           for wallet_name in "${owner_wallets[@]}"; do # Validate each wallet that they still exist and contain the correct keys
              getWalletType ${wallet_name}
              case $? in
-               0) if [[ ${wallet_name} = ${owner_wallets[0]} ]]; then # main owner, must be a CLI wallet
+               0) if [[ ${wallet_name} = "${owner_wallets[0]}" ]]; then # main owner, must be a CLI wallet
                     println "ERROR" "${FG_RED}ERROR${NC}: main/first pool owner can NOT be a hardware wallet!"
                     println "ERROR" "Use a CLI wallet as owner with enough funds to pay for pool deposit and registration transaction fee"
                     println "ERROR" "Add the hardware wallet as an additional multi-owner to the pool later in the pool registration wizard"
@@ -1938,7 +1938,7 @@ EOF
            getWalletType ${reward_wallet}
            case $? in
              0) hw_reward_is_mu='N'
-                for wallet_name in ${owner_wallets[@]}; do # HW reward wallet, make sure its also a multi-owner to the pool
+                for wallet_name in "${owner_wallets[@]}"; do # HW reward wallet, make sure its also a multi-owner to the pool
                   [[ "${wallet_name}" = "${reward_wallet}" ]] && hw_reward_is_mu='Y' && break
                 done
                 if [[ ${hw_reward_is_mu} = 'N' ]]; then # main owner, must be a CLI wallet
@@ -2095,7 +2095,7 @@ EOF
     fi
 
     multi_owner_output=""
-    for wallet_name in ${owner_wallets[@]}; do
+    for wallet_name in "${owner_wallets[@]}"; do
       [[ "${wallet_name}" = "${owner_wallets[0]}" ]] && continue # skip main owner
       multi_owner_output+="--pool-owner-stake-verification-key-file ${WALLET_FOLDER}/${wallet_name}/${WALLET_STAKE_VK_FILENAME} "
     done
@@ -2882,11 +2882,11 @@ EOF
     
     case "${otx_type}" in
       "Wallet Registration"|"Wallet De-Registration"|"Payment"|"Wallet Delegation"|"Wallet Rewards Withdrawal"|"Pool De-Registration"|"Metadata")
-        [[ ${otx_type} = "Wallet De-Registration" ]] && println "DEBUG" "\nAmount returned  : ${FG_CYAN}$(formatLovelace $(jq -r '."amount-returned"' <<< ${offlineJSON}))${NC} Ada"
+        [[ ${otx_type} = "Wallet De-Registration" ]] && println "DEBUG" "\nAmount returned  : ${FG_CYAN}$(formatLovelace "$(jq -r '."amount-returned"' <<< ${offlineJSON})")${NC} Ada"
         [[ ${otx_type} = "Payment" ]] && println "DEBUG" "\nSource addr      : ${FG_CYAN}$(jq -r '."source-address"' <<< ${offlineJSON})${NC}"
-        [[ ${otx_type} = "Payment" ]] && println "DEBUG" "Amount           : ${FG_CYAN}$(formatLovelace $(jq -r '.amount' <<< ${offlineJSON}))${NC} Ada"
+        [[ ${otx_type} = "Payment" ]] && println "DEBUG" "Amount           : ${FG_CYAN}$(formatLovelace "$(jq -r '.amount' <<< ${offlineJSON})")${NC} Ada"
         [[ ${otx_type} = "Payment" ]] && println "DEBUG" "Destination addr : ${FG_CYAN}$(jq -r '."destination-address"' <<< ${offlineJSON})${NC}"
-        [[ ${otx_type} = "Wallet Rewards Withdrawal" ]] && println "DEBUG" "\nRewards          : ${FG_CYAN}$(formatLovelace $(jq -r '.rewards' <<< ${offlineJSON}))${NC} Ada"
+        [[ ${otx_type} = "Wallet Rewards Withdrawal" ]] && println "DEBUG" "\nRewards          : ${FG_CYAN}$(formatLovelace "$(jq -r '.rewards' <<< ${offlineJSON})")${NC} Ada"
         [[ ${otx_type} = "Pool De-Registration" ]] && println "DEBUG" "\nPool name        : ${FG_CYAN}$(jq -r '."pool-name"' <<< ${offlineJSON})${NC}"
         [[ ${otx_type} = "Pool De-Registration" ]] && println "DEBUG" "Ticker           : ${FG_CYAN}$(jq -r '."pool-ticker"' <<< ${offlineJSON})${NC}"
         [[ ${otx_type} = "Pool De-Registration" ]] && println "DEBUG" "To be retired    : epoch ${FG_CYAN}$(jq -r '."retire-epoch"' <<< ${offlineJSON})${NC}"
@@ -2936,9 +2936,9 @@ EOF
         echo
         println "DEBUG" "Pool name        : ${FG_CYAN}$(jq -r '."pool-metadata".name' <<< ${offlineJSON})${NC}"
         println "DEBUG" "Ticker           : ${FG_CYAN}$(jq -r '."pool-metadata".ticker' <<< ${offlineJSON})${NC}"
-        println "DEBUG" "Pledge           : ${FG_CYAN}$(formatAda $(jq -r '."pool-pledge"' <<< ${offlineJSON}))${NC} Ada"
+        println "DEBUG" "Pledge           : ${FG_CYAN}$(formatAda "$(jq -r '."pool-pledge"' <<< ${offlineJSON})")${NC} Ada"
         println "DEBUG" "Margin           : ${FG_CYAN}$(jq -r '."pool-margin"' <<< ${offlineJSON})${NC} %"
-        println "DEBUG" "Cost             : ${FG_CYAN}$(formatAda $(jq -r '."pool-cost"' <<< ${offlineJSON}))${NC} Ada"
+        println "DEBUG" "Cost             : ${FG_CYAN}$(formatAda "$(jq -r '."pool-cost"' <<< ${offlineJSON})")${NC} Ada"
         for otx_signing_file in $(jq -r '."signing-file"[] | @base64' <<< "${offlineJSON}"); do
           _jq() { base64 -d <<< ${otx_signing_file} | jq -r "${1}"; }
           otx_signing_name=$(_jq '.name')
@@ -3052,20 +3052,20 @@ EOF
     
     case "${otx_type}" in
       "Wallet Registration"|"Wallet De-Registration"|"Payment"|"Wallet Delegation"|"Wallet Rewards Withdrawal"|"Pool De-Registration"|"Metadata"|"Pool Registration"|"Pool Update")
-        [[ ${otx_type} = "Wallet De-Registration" ]] && println "DEBUG" "\nAmount returned  : ${FG_CYAN}$(formatLovelace $(jq -r '."amount-returned"' <<< ${offlineJSON}))${NC} Ada"
+        [[ ${otx_type} = "Wallet De-Registration" ]] && println "DEBUG" "\nAmount returned  : ${FG_CYAN}$(formatLovelace "$(jq -r '."amount-returned"' <<< ${offlineJSON})")${NC} Ada"
         [[ ${otx_type} = "Payment" ]] && println "DEBUG" "\nSource addr      : ${FG_CYAN}$(jq -r '."source-address"' <<< ${offlineJSON})${NC}"
-        [[ ${otx_type} = "Payment" ]] && println "DEBUG" "Amount           : ${FG_CYAN}$(formatLovelace $(jq -r '.amount' <<< ${offlineJSON}))${NC} Ada"
+        [[ ${otx_type} = "Payment" ]] && println "DEBUG" "Amount           : ${FG_CYAN}$(formatLovelace "$(jq -r '.amount' <<< ${offlineJSON})")${NC} Ada"
         [[ ${otx_type} = "Payment" ]] && println "DEBUG" "Destination addr : ${FG_CYAN}$(jq -r '."destination-address"' <<< ${offlineJSON})${NC}"
-        [[ ${otx_type} = "Wallet Rewards Withdrawal" ]] && println "DEBUG" "\nRewards          : ${FG_CYAN}$(formatLovelace $(jq -r '.rewards' <<< ${offlineJSON}))${NC} Ada"
+        [[ ${otx_type} = "Wallet Rewards Withdrawal" ]] && println "DEBUG" "\nRewards          : ${FG_CYAN}$(formatLovelace "$(jq -r '.rewards' <<< ${offlineJSON})")${NC} Ada"
         [[ ${otx_type} = "Pool De-Registration" ]] && println "DEBUG" "\nPool name        : ${FG_CYAN}$(jq -r '."pool-name"' <<< ${offlineJSON})${NC}"
         [[ ${otx_type} = "Pool De-Registration" ]] && println "DEBUG" "Ticker           : ${FG_CYAN}$(jq -r '."pool-ticker"' <<< ${offlineJSON})${NC}"
         [[ ${otx_type} = "Pool De-Registration" ]] && println "DEBUG" "To be retired    : epoch ${FG_CYAN}$(jq -r '."retire-epoch"' <<< ${offlineJSON})${NC}"
         [[ ${otx_type} = "Metadata" ]] && println "DEBUG" "\nMetadata         :\n$(jq -r '.metadata' <<< ${offlineJSON})\n"
         [[ ${otx_type} = "Pool Registration" || ${otx_type} = "Pool Update" ]] && println "DEBUG" "\nPool name        : ${FG_CYAN}$(jq -r '."pool-metadata".name' <<< ${offlineJSON})${NC}"
         [[ ${otx_type} = "Pool Registration" || ${otx_type} = "Pool Update" ]] && println "DEBUG" "Ticker           : ${FG_CYAN}$(jq -r '."pool-metadata".ticker' <<< ${offlineJSON})${NC}"
-        [[ ${otx_type} = "Pool Registration" || ${otx_type} = "Pool Update" ]] && println "DEBUG" "Pledge           : ${FG_CYAN}$(formatAda $(jq -r '."pool-pledge"' <<< ${offlineJSON}))${NC} Ada"
+        [[ ${otx_type} = "Pool Registration" || ${otx_type} = "Pool Update" ]] && println "DEBUG" "Pledge           : ${FG_CYAN}$(formatAda "$(jq -r '."pool-pledge"' <<< ${offlineJSON})")${NC} Ada"
         [[ ${otx_type} = "Pool Registration" || ${otx_type} = "Pool Update" ]] && println "DEBUG" "Margin           : ${FG_CYAN}$(jq -r '."pool-margin"' <<< ${offlineJSON})${NC} %"
-        [[ ${otx_type} = "Pool Registration" || ${otx_type} = "Pool Update" ]] && println "DEBUG" "Cost             : ${FG_CYAN}$(formatAda $(jq -r '."pool-cost"' <<< ${offlineJSON}))${NC} Ada"
+        [[ ${otx_type} = "Pool Registration" || ${otx_type} = "Pool Update" ]] && println "DEBUG" "Cost             : ${FG_CYAN}$(formatAda "$(jq -r '."pool-cost"' <<< ${offlineJSON})")${NC} Ada"
         tx_signed="${TMP_FOLDER}/tx.signed_$(date +%s)"
         println "DEBUG" "\nProceed to submit transaction?"
         select_opt "[y] Yes" "[n] No"

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -151,19 +151,15 @@ if [[ ${CNTOOLS_MODE} = "CONNECTED" ]]; then
         if ! cmp -s "${TMP_FOLDER}"/cntools-changelog.md "${PARENT}/cntools-changelog.md"; then
           # Latest changes not shown, show whats new and copy changelog
           clear 
-          println "OFF" "~ CNTools - What's New ~"
-          waitForInput "Press any key to show what's new, use 'q' to quit viewer"
           exec >&6 # normal stdout
           sleep 0.1
           if [[ ! -f "${PARENT}/cntools-changelog.md" ]]; then 
             # special case for first installation or 5.0.0 upgrade, print release notes until previous major version
-            clear
-            sed -n "/\[${CNTOOLS_MAJOR_VERSION}\.${CNTOOLS_MINOR_VERSION}\.${CNTOOLS_PATCH_VERSION}\]/,/\[$((CNTOOLS_MAJOR_VERSION-1))\.[0-9]\.[0-9]\]/p" "${TMP_FOLDER}"/cntools-changelog.md | head -n -2 | less -X
+            println "OFF" "~ CNTools - What's New ~\n\n" "$(sed -n "/\[${CNTOOLS_MAJOR_VERSION}\.${CNTOOLS_MINOR_VERSION}\.${CNTOOLS_PATCH_VERSION}\]/,/\[$((CNTOOLS_MAJOR_VERSION-1))\.[0-9]\.[0-9]\]/p" "${TMP_FOLDER}"/cntools-changelog.md | head -n -2)" | less -X
           else
             # print release notes from current until previously installed version
-            clear
             [[ $(cat "${PARENT}/cntools-changelog.md") =~ \[([[:digit:]])\.([[:digit:]])\.([[:digit:]])\] ]]
-            cat <(awk "1;/\[${BASH_REMATCH[1]}\.${BASH_REMATCH[2]}\.${BASH_REMATCH[3]}\]/{exit}" "${TMP_FOLDER}"/cntools-changelog.md | head -n -2 | tail -n +7) <(echo -e "\n [Press 'q' to quit and proceed to CNTools main menu]\n") | less -X
+            cat <(println "OFF" "~ CNTools - What's New ~\n") <(awk "1;/\[${BASH_REMATCH[1]}\.${BASH_REMATCH[2]}\.${BASH_REMATCH[3]}\]/{exit}" "${TMP_FOLDER}"/cntools-changelog.md | head -n -2 | tail -n +7) <(echo -e "\n [Press 'q' to quit and proceed to CNTools main menu]\n") | less -X
           fi
           exec >&8 # custom stdout
           cp "${TMP_FOLDER}"/cntools-changelog.md "${PARENT}/cntools-changelog.md"

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -49,7 +49,33 @@ while getopts :ob: opt; do
 done
 shift $((OPTIND -1))
 
+URL_RAW="https://raw.githubusercontent.com/cardano-community/guild-operators/${BRANCH}"
+URL="${URL_RAW}/scripts/cnode-helper-scripts"
+URL_DOCS="${URL_RAW}/docs/Scripts"
+
 # get common env variables
+if curl -s -m 10 -o "${PARENT}"/env.tmp ${URL}/env; then
+  if [[ -f "${PARENT}"/env ]]; then
+    if [[ $(grep "_HOME=" "${PARENT}"/env) =~ ^#?([^[:space:]]+)_HOME ]]; then
+      vname=$(tr '[:upper:]' '[:lower:]' <<< ${BASH_REMATCH[1]})
+      sed -e "s@/opt/cardano/[c]node@/opt/cardano/${vname}@g" -e "s@[C]NODE_HOME@${BASH_REMATCH[1]}_HOME@g" -i "${PARENT}"/env.tmp
+    else
+      echo -e "Update failed! Please use prereqs.sh to force an update or manually download $(basename $0) + env from GitHub"
+      exit 1
+    fi
+    TEMPL_CMD=$(awk '/^# Do NOT modify/,0' "${PARENT}"/env)
+    TEMPL2_CMD=$(awk '/^# Do NOT modify/,0' "${PARENT}"/env.tmp)
+    if [[ "$(echo ${TEMPL_CMD} | sha256sum)" != "$(echo ${TEMPL2_CMD} | sha256sum)" ]]; then
+      cp "${PARENT}"/env "${PARENT}/env_bkp$(date +%s)"
+      STATIC_CMD=$(awk '/#!/{x=1}/^# Do NOT modify/{exit} x' "${PARENT}"/env)
+      printf '%s\n%s\n' "$STATIC_CMD" "$TEMPL2_CMD" > "${PARENT}"/env.tmp
+      mv "${PARENT}"/env.tmp "${PARENT}"/env
+    fi
+  else
+    mv "${PARENT}"/env.tmp "${PARENT}"/env
+  fi
+fi
+rm -f "${PARENT}"/env.tmp
 if ! . "${PARENT}"/env; then
   [[ ${CNTOOLS_MODE} = "CONNECTED" ]] && exit 1
   myExit 1 "\nERROR: CNTools run in offline mode and failed to automatically grab common env variables\nPlease uncomment all variables in 'User Variables' section and set values manually\n"
@@ -66,7 +92,6 @@ mkdir -p "${TMP_FOLDER}" # Create if missing
 if [[ ! -d "${TMP_FOLDER}" ]]; then
   myExit 1 "${FG_RED}ERROR${NC}: Failed to create directory for temporary files:\n${TMP_FOLDER}"
 fi
-[[ -f ${LOG_LOCKFILE} ]] && rm -f "${LOG_LOCKFILE}"
 
 archiveLog # archive current log and cleanup log archive folder
 
@@ -77,10 +102,6 @@ exec 7>&2 # Link file descriptor #7 with normal stderr.
 [[ -n ${CNTOOLS_LOG} ]] && exec 3> >( tee >( while read -r line; do logln "DEBUG" "${line}"; done ) >&6 )
 exec 8>&1 # Link file descriptor #8 with custom stdout.
 exec 9>&2 # Link file descriptor #9 with custom stderr.
-
-URL_RAW="https://raw.githubusercontent.com/cardano-community/guild-operators/${BRANCH}"
-URL="${URL_RAW}/scripts/cnode-helper-scripts"
-URL_DOCS="${URL_RAW}/docs/Scripts"
 
 # check for required command line tools
 if ! need_cmd "curl" || \
@@ -133,6 +154,7 @@ if [[ ${CNTOOLS_MODE} = "CONNECTED" ]]; then
           println "OFF" "~ CNTools - What's New ~"
           waitForInput "Press any key to show what's new, use 'q' to quit viewer"
           exec >&6 # normal stdout
+          sleep 0.1
           if [[ ! -f "${PARENT}/cntools-changelog.md" ]]; then 
             # special case for first installation or 5.0.0 upgrade, print release notes until previous major version
             clear
@@ -141,7 +163,7 @@ if [[ ${CNTOOLS_MODE} = "CONNECTED" ]]; then
             # print release notes from current until previously installed version
             clear
             [[ $(cat "${PARENT}/cntools-changelog.md") =~ \[([[:digit:]])\.([[:digit:]])\.([[:digit:]])\] ]]
-            sed -n "/\[${CNTOOLS_MAJOR_VERSION}\.${CNTOOLS_MINOR_VERSION}\.${CNTOOLS_PATCH_VERSION}\]/,/\[${BASH_REMATCH[1]}\.${BASH_REMATCH[2]}\.${BASH_REMATCH[3]}\]/p" "${TMP_FOLDER}"/cntools-changelog.md | head -n -2 | less -X
+            cat <(awk "1;/\[${BASH_REMATCH[1]}\.${BASH_REMATCH[2]}\.${BASH_REMATCH[3]}\]/{exit}" "${TMP_FOLDER}"/cntools-changelog.md | head -n -2 | tail -n +7) <(echo -e "\n [Press 'q' to quit and proceed to CNTools main menu]\n") | less -X
           fi
           exec >&8 # custom stdout
           cp "${TMP_FOLDER}"/cntools-changelog.md "${PARENT}/cntools-changelog.md"
@@ -236,7 +258,7 @@ function main {
 while true; do # Main loop
 
 # Start with a clean slate after each completed or canceled command excluding .dialogrc from purge
-find "${TMP_FOLDER:?}" -type f -not \( -name 'protparams.json' -o -name '.dialogrc' \) -delete
+find "${TMP_FOLDER:?}" -type f -not \( -name 'protparams.json' -o -name '.dialogrc' -o -name "offline_tx*" \) -delete
 
 clear
 println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
@@ -573,8 +595,7 @@ EOF
       stake_sk_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_HW_STAKE_SK_FILENAME}"
       stake_vk_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_STAKE_VK_FILENAME}"  
       
-      waitForInput "${FG_BLUE}INFO${NC}: please unlock hardware device and open the Cardano app, after this press any key to continue"
-      println "DEBUG" "${FG_BLUE}INFO${NC}: follow directions on hardware device to extract ${FG_CYAN}payment keys${NC}"
+      if ! unlockHWDevice "extract ${FG_CYAN}payment keys${NC}"; then continue; fi
       println "ACTION" "cardano-hw-cli shelley address key-gen --path 1852H/1815H/0H/0/0 --verification-key-file \"${payment_vk_file}\" --hw-signing-file \"${payment_sk_file}\""
       output=$(cardano-hw-cli shelley address key-gen --path 1852H/1815H/0H/0/0 --verification-key-file "${payment_vk_file}" --hw-signing-file "${payment_sk_file}" 2>&1)
       [[ -n ${output} ]] && println "ERROR" "${output}\n${FG_RED}ERROR${NC}: failure during payment key extraction!" && waitForInput && continue
@@ -624,6 +645,9 @@ EOF
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     println " >> WALLET >> REGISTER"
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    
+    [[ ! $(ls -A "${WALLET_FOLDER}" 2>/dev/null) ]] && echo && println "${FG_YELLOW}No wallets available!${NC}" && waitForInput && continue
+    
     if [[ ${CNTOOLS_MODE} = "OFFLINE" ]]; then
       println "ERROR" "${FG_RED}ERROR${NC}: CNTools started in offline mode, option not available!"
       waitForInput && continue
@@ -639,15 +663,15 @@ EOF
       fi
       getWalletType ${wallet_name}
       case $? in
-        2) println "ERROR" "${FG_RED}ERROR${NC}: payment and/or stake signing keys encrypted, please decrypt before use!" && waitForInput && continue ;;
+        2) println "ERROR" "${FG_RED}ERROR${NC}: signing keys encrypted, please decrypt before use!" && waitForInput && continue ;;
         3) println "ERROR" "${FG_RED}ERROR${NC}: payment and/or stake signing keys missing from wallet!" && waitForInput && continue ;;
       esac
     else
       if ! selectWallet "non-reg" "${WALLET_PAY_VK_FILENAME}" "${WALLET_STAKE_VK_FILENAME}"; then
         [[ "${dir_name}" != "[Esc] Cancel" ]] && waitForInput; continue
       fi
+      getWalletType ${wallet_name}
     fi
-    echo
     
     getBaseAddress ${wallet_name}
     getBalance ${base_addr}
@@ -655,10 +679,9 @@ EOF
     if [[ ${lovelace} -gt 0 ]]; then
       if [[ -n ${wallet_count} && ${wallet_count} -gt ${WALLET_SELECTION_FILTER_LIMIT} ]]; then
         println "DEBUG" "$(printf "%s\t${FG_CYAN}%s${NC} Ada" "Funds in wallet:"  "$(formatLovelace ${lovelace})")"
-        echo
       fi
     else
-      println "ERROR" "${FG_RED}ERROR${NC}: no funds available in base address for wallet ${FG_GREEN}${wallet_name}${NC}"
+      println "ERROR" "\n${FG_RED}ERROR${NC}: no funds available in base address for wallet ${FG_GREEN}${wallet_name}${NC}"
       keyDeposit=$(jq -r '.keyDeposit' "${TMP_FOLDER}"/protparams.json)
       println "DEBUG" "Funds for key deposit($(formatLovelace ${keyDeposit}) Ada) + transaction fee needed to register the wallet"
       waitForInput && continue
@@ -668,7 +691,7 @@ EOF
       waitForInput && continue
     fi
 
-    echo && println "${FG_GREEN}${wallet_name}${NC} successfully registered on chain!"
+    println "\n${FG_GREEN}${wallet_name}${NC} successfully registered on chain!"
     
     waitForInput && continue
 
@@ -680,6 +703,9 @@ EOF
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     println " >> WALLET >> DE-REGISTER"
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    
+    [[ ! $(ls -A "${WALLET_FOLDER}" 2>/dev/null) ]] && echo && println "${FG_YELLOW}No wallets available!${NC}" && waitForInput && continue
+    
     if [[ ${CNTOOLS_MODE} = "OFFLINE" ]]; then
       println "ERROR" "${FG_RED}ERROR${NC}: CNTools started in offline mode, option not available!"
       waitForInput && continue
@@ -690,24 +716,24 @@ EOF
     
     println "DEBUG" "# Select wallet to de-register (only registered wallets shown)"
     if [[ ${op_mode} = "online" ]]; then
-      if ! selectWallet "delegate" "${WALLET_PAY_VK_FILENAME}" "${WALLET_STAKE_VK_FILENAME}"; then
+      if ! selectWallet "reg" "${WALLET_PAY_VK_FILENAME}" "${WALLET_STAKE_VK_FILENAME}"; then
         [[ "${dir_name}" != "[Esc] Cancel" ]] && waitForInput; continue
       fi
       getWalletType ${wallet_name}
       case $? in
-        2) println "ERROR" "${FG_RED}ERROR${NC}: payment and/or stake signing keys encrypted, please decrypt before use!" && waitForInput && continue ;;
+        2) println "ERROR" "${FG_RED}ERROR${NC}: signing keys encrypted, please decrypt before use!" && waitForInput && continue ;;
         3) println "ERROR" "${FG_RED}ERROR${NC}: payment and/or stake signing keys missing from wallet!" && waitForInput && continue ;;
       esac
     else
-      if ! selectWallet "delegate" "${WALLET_PAY_VK_FILENAME}" "${WALLET_STAKE_VK_FILENAME}"; then
+      if ! selectWallet "reg" "${WALLET_PAY_VK_FILENAME}" "${WALLET_STAKE_VK_FILENAME}"; then
         [[ "${dir_name}" != "[Esc] Cancel" ]] && waitForInput; continue
       fi
+      getWalletType ${wallet_name}
     fi
-    echo
     
     getRewards ${wallet_name}
     if [[ "${reward_lovelace}" -gt 0 ]]; then
-      println "${FG_YELLOW}WARN${NC}: wallet has unclaimed rewards, please use 'Funds >> Withdraw Rewards' before de-registration to claim your rewards"
+      println "\n${FG_YELLOW}WARN${NC}: wallet has unclaimed rewards, please use 'Funds >> Withdraw Rewards' before de-registration to claim your rewards"
       waitForInput && continue
     fi
 
@@ -715,12 +741,12 @@ EOF
     getBalance ${base_addr}
     
     if [[ ${lovelace} -le 0 ]]; then
-      println "ERROR" "${FG_RED}ERROR${NC}: no funds available in base address for wallet ${FG_GREEN}${wallet_name}${NC}"
+      println "ERROR" "\n${FG_RED}ERROR${NC}: no funds available in base address for wallet ${FG_GREEN}${wallet_name}${NC}"
       println "ERROR" "Funds for transaction fee needed to deregister the wallet"
       waitForInput && continue
     fi
     
-    if ! deregisterStakeWallet ${wallet_name}; then
+    if ! deregisterStakeWallet; then
       [[ -f ${stake_dereg_file} ]] && rm -f ${stake_dereg_file}
       waitForInput && continue
     fi
@@ -742,12 +768,12 @@ EOF
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     println " >> WALLET >> LIST"
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    
+    [[ ! $(ls -A "${WALLET_FOLDER}" 2>/dev/null) ]] && echo && println "${FG_YELLOW}No wallets available!${NC}" && waitForInput && continue
 
     if [[ ${CNTOOLS_MODE} = "OFFLINE" ]]; then
       println "DEBUG" "${FG_CYAN}OFFLINE MODE${NC}: CNTools started in offline mode, wallet balance not shown!"
     fi
-    
-    [[ ! "$(ls -A "${WALLET_FOLDER}")" ]] && echo && println "${FG_YELLOW}No wallets available!${NC}"
 
     while IFS= read -r -d '' wallet; do
       wallet_name=$(basename ${wallet})
@@ -782,14 +808,14 @@ EOF
           fi
         fi
         if [[ -z ${base_addr} && -z ${pay_addr} ]]; then
-          println "${FG_RED}Not a supporeted wallet${NC} - genesis address?"
+          println "${FG_RED}Not a supported wallet${NC} - genesis address?"
           println "Use an external script to send funds to a CNTools compatible wallet"
           continue
         fi
         getRewards ${wallet_name}
         if [[ "${reward_lovelace}" -ge 0 ]]; then
           println "$(printf "%-19s : ${FG_CYAN}%s${NC} Ada" "Rewards" "$(formatLovelace ${reward_lovelace})")"
-          delegation_pool_id=$(jq -r '.delegation // empty' <<< "${stakeAddressInfo}")
+          delegation_pool_id=$(jq -r '.[0].delegation // empty' <<< "${stake_address_info}")
           if [[ -n ${delegation_pool_id} ]]; then
             unset poolName
             while IFS= read -r -d '' pool; do
@@ -814,12 +840,13 @@ EOF
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     println " >> WALLET >> SHOW"
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    echo
+    
+    [[ ! $(ls -A "${WALLET_FOLDER}" 2>/dev/null) ]] && echo && println "${FG_YELLOW}No wallets available!${NC}" && waitForInput && continue
 
     if [[ ${CNTOOLS_MODE} = "OFFLINE" ]]; then
       println "DEBUG" "${FG_CYAN}OFFLINE MODE${NC}: CNTools started in offline mode, limited wallet info shown!"
     fi
-    
+
     tput sc
     if ! selectWallet "none" "${WALLET_PAY_VK_FILENAME}"; then
       [[ "${dir_name}" != "[Esc] Cancel" ]] && waitForInput; continue
@@ -884,7 +911,7 @@ EOF
         println "$(printf "%-20s : %s" "Reward/Stake Address" "${reward_addr}")"
         println "$(printf "%-20s : ${FG_CYAN}%s${NC} Ada" "Rewards" "$(formatLovelace ${reward_lovelace})")"
         println "$(printf "%-20s : ${FG_CYAN}%s${NC} Ada" "Funds + Rewards" "$(formatLovelace $((base_lovelace + reward_lovelace)))")"
-        delegation_pool_id=$(jq -r '.delegation  // empty' <<< "${stakeAddressInfo}")
+        delegation_pool_id=$(jq -r '.[0].delegation  // empty' <<< "${stake_address_info}")
         if [[ -n ${delegation_pool_id} ]]; then
           unset poolName
           while IFS= read -r -d '' pool; do
@@ -909,6 +936,8 @@ EOF
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     println " >> WALLET >> REMOVE"
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+
+    [[ ! $(ls -A "${WALLET_FOLDER}" 2>/dev/null) ]] && echo && println "${FG_YELLOW}No wallets available!${NC}" && waitForInput && continue
 
     if [[ ${CNTOOLS_MODE} = "OFFLINE" ]]; then
       println "DEBUG" "${FG_CYAN}OFFLINE MODE${NC}: CNTools started in offline mode, unable to verify wallet balance"
@@ -999,7 +1028,9 @@ EOF
     println " >> WALLET >> DECRYPT"
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     echo
-
+    
+    [[ ! $(ls -A "${WALLET_FOLDER}" 2>/dev/null) ]] && println "${FG_YELLOW}No wallets available!${NC}" && waitForInput && continue
+    
     println "DEBUG" "# Select wallet to decrypt"
     if ! selectWallet "none"; then # ${wallet_name} populated by selectWallet function
       [[ "${dir_name}" != "[Esc] Cancel" ]] && waitForInput; continue
@@ -1054,6 +1085,8 @@ EOF
     println " >> WALLET >> ENCRYPT"
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     echo
+    
+    [[ ! $(ls -A "${WALLET_FOLDER}" 2>/dev/null) ]] && echo && println "${FG_YELLOW}No wallets available!${NC}" && waitForInput && continue
 
     println "DEBUG" "# Select wallet to encrypt"
     if ! selectWallet "none"; then # ${wallet_name} populated by selectWallet function
@@ -1141,6 +1174,8 @@ EOF
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     println " >> FUNDS >> SEND"
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    
+    [[ ! $(ls -A "${WALLET_FOLDER}" 2>/dev/null) ]] && echo && println "${FG_YELLOW}No wallets available!${NC}" && waitForInput && continue
 
     if [[ ${CNTOOLS_MODE} = "OFFLINE" ]]; then
       println "ERROR" "${FG_RED}ERROR${NC}: CNTools started in offline mode, option not available!"
@@ -1152,22 +1187,23 @@ EOF
 
     println "DEBUG" "# Select ${FG_CYAN}source${NC} wallet"
     if [[ ${op_mode} = "online" ]]; then
-      if ! selectWallet "balance"; then # ${wallet_name} populated by selectWallet function
+      if ! selectWallet "balance" "${WALLET_PAY_VK_FILENAME}"; then # ${wallet_name} populated by selectWallet function
         [[ "${dir_name}" != "[Esc] Cancel" ]] && waitForInput; continue
       fi
       getWalletType ${wallet_name}
       case $? in
-        2) println "ERROR" "${FG_RED}ERROR${NC}: payment and/or stake signing keys encrypted, please decrypt before use!" && waitForInput && continue ;;
+        2) println "ERROR" "${FG_RED}ERROR${NC}: signing keys encrypted, please decrypt before use!" && waitForInput && continue ;;
         3) println "ERROR" "${FG_RED}ERROR${NC}: payment and/or stake signing keys missing from wallet!" && waitForInput && continue ;;
       esac
-      s_payment_sk_file="${payment_sk_file}"
     else
-      if ! selectWallet "balance"; then # ${wallet_name} populated by selectWallet function
+      if ! selectWallet "balance" "${WALLET_PAY_VK_FILENAME}"; then # ${wallet_name} populated by selectWallet function
         [[ "${dir_name}" != "[Esc] Cancel" ]] && waitForInput; continue
       fi
-      s_payment_sk_file="none"
+      getWalletType ${wallet_name}
     fi
     s_wallet="${wallet_name}"
+    s_payment_vk_file="${payment_vk_file}"
+    s_payment_sk_file="${payment_sk_file}"
     echo
 
     getBaseAddress ${s_wallet}
@@ -1225,7 +1261,7 @@ EOF
       if ! AdaToLovelace "${amountADA}" >/dev/null; then
         waitForInput && continue
       fi
-      amountLovelace=$(AdaToLovelace "${amountADA}")
+      amount_lovelace=$(AdaToLovelace "${amountADA}")
       println "DEBUG" "Fee payed by sender? [else amount sent is reduced]"
       select_opt "[y] Yes" "[n] No" "[Esc] Cancel"
       case $? in
@@ -1235,8 +1271,8 @@ EOF
       esac
     else
       getBalance ${s_addr}
-      amountLovelace=${lovelace}
-      println "DEBUG" "Ada to send set to total supply: $(formatLovelace ${amountLovelace})"
+      amount_lovelace=${lovelace}
+      println "DEBUG" "Ada to send set to total supply: $(formatLovelace ${amount_lovelace})"
       include_fee="yes"
     fi
     echo
@@ -1283,7 +1319,7 @@ EOF
       waitForInput && continue
     fi
 
-    if ! sendADA "${d_addr}" "${amountLovelace}" "${s_addr}" "${s_payment_sk_file}" "${include_fee}"; then
+    if ! sendAda; then
       waitForInput && continue
     fi
 
@@ -1302,7 +1338,7 @@ EOF
     echo
     println "Transaction"
     println "  From          : ${FG_GREEN}${s_wallet}${NC}${s_wallet_type}"
-    println "  Amount        : $(formatLovelace ${amountLovelace}) Ada"
+    println "  Amount        : $(formatLovelace ${amount_lovelace}) Ada"
     if [[ -n "${d_wallet}" ]]; then
       println "  To            : ${FG_GREEN}${d_wallet}${NC}${d_wallet_type}"
     else
@@ -1323,6 +1359,8 @@ EOF
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     println " >> FUNDS >> DELEGATE"
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    
+    [[ ! $(ls -A "${WALLET_FOLDER}" 2>/dev/null) ]] && echo && println "${FG_YELLOW}No wallets available!${NC}" && waitForInput && continue
 
     if [[ ${CNTOOLS_MODE} = "OFFLINE" ]]; then
       println "ERROR" "${FG_RED}ERROR${NC}: CNTools started in offline mode, option not available!"
@@ -1334,20 +1372,20 @@ EOF
 
     println "DEBUG" "# Select wallet to delegate"
     if [[ ${op_mode} = "online" ]]; then
-      if ! selectWallet "delegate" "${WALLET_STAKE_VK_FILENAME}"; then # ${wallet_name} populated by selectWallet function
+      if ! selectWallet "delegate" "${WALLET_PAY_VK_FILENAME}" "${WALLET_STAKE_VK_FILENAME}"; then # ${wallet_name} populated by selectWallet function
         [[ "${dir_name}" != "[Esc] Cancel" ]] && waitForInput; continue
       fi
       getWalletType ${wallet_name}
       case $? in
-        2) println "ERROR" "${FG_RED}ERROR${NC}: payment and/or stake signing keys encrypted, please decrypt before use!" && waitForInput && continue ;;
+        2) println "ERROR" "${FG_RED}ERROR${NC}: signing keys encrypted, please decrypt before use!" && waitForInput && continue ;;
         3) println "ERROR" "${FG_RED}ERROR${NC}: payment and/or stake signing keys missing from wallet!" && waitForInput && continue ;;
       esac
     else
-      if ! selectWallet "delegate" "${WALLET_STAKE_VK_FILENAME}"; then # ${wallet_name} populated by selectWallet function
+      if ! selectWallet "delegate" "${WALLET_PAY_VK_FILENAME}" "${WALLET_STAKE_VK_FILENAME}"; then # ${wallet_name} populated by selectWallet function
         [[ "${dir_name}" != "[Esc] Cancel" ]] && waitForInput; continue
       fi
+      getWalletType ${wallet_name}
     fi
-    echo
 
     getBaseAddress ${wallet_name}
     getBalance ${base_addr}
@@ -1356,7 +1394,7 @@ EOF
         println "DEBUG" "$(printf "%s\t${FG_CYAN}%s${NC} Ada" "Funds in wallet:"  "$(formatLovelace ${lovelace})")"
       fi
     else
-      println "ERROR" "${FG_RED}ERROR${NC}: no funds available for wallet ${FG_GREEN}${wallet_name}${NC}"
+      println "ERROR" "\n${FG_RED}ERROR${NC}: no funds available for wallet ${FG_GREEN}${wallet_name}${NC}"
       waitForInput && continue
     fi
     getRewards ${wallet_name}
@@ -1365,7 +1403,7 @@ EOF
       if [[ ${op_mode} = "online" ]]; then
         if ! registerStakeWallet ${wallet_name}; then waitForInput && continue; fi
       else
-        println "ERROR" "The wallet is not a registered wallet on chain and CNTools run in hybrid mode"
+        println "ERROR" "\n${FG_YELLOW}The wallet is not a registered wallet on chain and CNTools run in hybrid mode${NC}"
         println "ERROR" "Please first register the wallet using 'Wallet >> Register'"
         waitForInput && continue
       fi
@@ -1390,15 +1428,15 @@ EOF
     esac
 
     stake_vk_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_STAKE_VK_FILENAME}"
-    delegation_cert_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_DELEGCERT_FILENAME}"
+    pool_delegcert_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_DELEGCERT_FILENAME}"
 
-    println "ACTION" "${CCLI} stake-address delegation-certificate --stake-verification-key-file ${stake_vk_file} --cold-verification-key-file ${pool_coldkey_vk_file} --out-file ${delegation_cert_file}"
-    ${CCLI} stake-address delegation-certificate --stake-verification-key-file "${stake_vk_file}" --cold-verification-key-file "${pool_coldkey_vk_file}" --out-file "${delegation_cert_file}"
+    println "ACTION" "${CCLI} stake-address delegation-certificate --stake-verification-key-file ${stake_vk_file} --cold-verification-key-file ${pool_coldkey_vk_file} --out-file ${pool_delegcert_file}"
+    ${CCLI} stake-address delegation-certificate --stake-verification-key-file "${stake_vk_file}" --cold-verification-key-file "${pool_coldkey_vk_file}" --out-file "${pool_delegcert_file}"
 
-    if ! delegate "${wallet_name}" "${pool_coldkey_vk_file}" "${delegation_cert_file}" ; then
+    if ! delegate; then
       if [[ ${op_mode} = "online" ]]; then
         echo && println "ERROR" "${FG_RED}ERROR${NC}: failure during delegation, removing newly created delegation certificate file"
-        rm -f "${delegation_cert_file}"
+        rm -f "${pool_delegcert_file}"
       fi
       waitForInput && continue
     fi
@@ -1422,6 +1460,8 @@ EOF
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     println " >> FUNDS >> WITHDRAW REWARDS"
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    
+    [[ ! $(ls -A "${WALLET_FOLDER}" 2>/dev/null) ]] && echo && println "${FG_YELLOW}No wallets available!${NC}" && waitForInput && continue
 
     if [[ ${CNTOOLS_MODE} = "OFFLINE" ]]; then
       println "ERROR" "${FG_RED}ERROR${NC}: CNTools started in offline mode, option not available!"
@@ -1433,18 +1473,19 @@ EOF
 
     println "DEBUG" "# Select wallet to withdraw funds from"
     if [[ ${op_mode} = "online" ]]; then
-      if ! selectWallet "reward"; then # ${wallet_name} populated by selectWallet function
+      if ! selectWallet "reward" "${WALLET_PAY_VK_FILENAME}" "${WALLET_STAKE_VK_FILENAME}"; then # ${wallet_name} populated by selectWallet function
         [[ "${dir_name}" != "[Esc] Cancel" ]] && waitForInput; continue
       fi
       getWalletType ${wallet_name}
       case $? in
-        2) println "ERROR" "${FG_RED}ERROR${NC}: payment and/or stake signing keys encrypted, please decrypt before use!" && waitForInput && continue ;;
+        2) println "ERROR" "${FG_RED}ERROR${NC}: signing keys encrypted, please decrypt before use!" && waitForInput && continue ;;
         3) println "ERROR" "${FG_RED}ERROR${NC}: payment and/or stake signing keys missing from wallet!" && waitForInput && continue ;;
       esac
     else
-      if ! selectWallet "reward"; then # ${wallet_name} populated by selectWallet function
+      if ! selectWallet "reward" "${WALLET_PAY_VK_FILENAME}" "${WALLET_STAKE_VK_FILENAME}"; then # ${wallet_name} populated by selectWallet function
         [[ "${dir_name}" != "[Esc] Cancel" ]] && waitForInput; continue
       fi
+      getWalletType ${wallet_name}
     fi
     echo
 
@@ -1463,7 +1504,7 @@ EOF
     println "DEBUG" "$(printf "%s\t${FG_CYAN}%s${NC} Ada" "Funds"  "$(formatLovelace ${lovelace})")"
     println "DEBUG" "$(printf "%s\t${FG_CYAN}%s${NC} Ada" "Rewards"  "$(formatLovelace ${reward_lovelace})")"
 
-    if ! withdrawRewards "${wallet_name}"; then
+    if ! withdrawRewards; then
       waitForInput && continue
     fi
 
@@ -1577,6 +1618,9 @@ EOF
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     println " >> POOL >> ${SUBCOMMAND^^}"
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    
+    [[ ! $(ls -A "${POOL_FOLDER}" 2>/dev/null) ]] && echo && println "${FG_YELLOW}No pools available!${NC}" && waitForInput && continue
+    [[ ! $(ls -A "${WALLET_FOLDER}" 2>/dev/null) ]] && echo && println "${FG_YELLOW}No wallets available!${NC}" && waitForInput && continue
 
     if [[ ${CNTOOLS_MODE} = "OFFLINE" ]]; then
       println "ERROR" "${FG_RED}ERROR${NC}: CNTools started in offline mode, option not available!"
@@ -1685,7 +1729,7 @@ EOF
       println "DEBUG" "Metadata exists at URL.  Use existing data?"
       select_opt "[y] Yes" "[n] No"
       case $? in
-        0) mv "${meta_tmp}" "${POOL_FOLDER}/${pool_name}/poolmeta.json"
+        0) mv "${meta_tmp}" "${pool_meta_file}"
            metadata_done=true
            ;;
         1) rm -f "${meta_tmp}" ;; # clean up temp file
@@ -1694,7 +1738,7 @@ EOF
     if [[ ${metadata_done} = false ]]; then
       echo
       if [[ ! -f "${pool_meta_file}" ]] || ! meta_name=$(jq -er .name "${pool_meta_file}"); then meta_name="${pool_name}"; fi
-      if [[ ! -f "${pool_meta_file}" ]] || ! meta_ticker=$(jq -er .ticker "${pool_meta_file}"); then meta_ticker="${pool_name}"; fi
+      if [[ ! -f "${pool_meta_file}" ]] || ! meta_ticker=$(jq -er .ticker "${pool_meta_file}"); then meta_ticker="$(echo ${pool_name//[^[:alnum:]]/} | tr [:lower:] [:upper:] | cut -c-5)"; fi
       if [[ ! -f "${pool_meta_file}" ]] || ! meta_description=$(jq -er .description "${pool_meta_file}"); then meta_description="No Description"; fi
       if [[ ! -f "${pool_meta_file}" ]] || ! meta_homepage=$(jq -er .homepage "${pool_meta_file}"); then meta_homepage="https://foo.com"; fi
       if [[ ! -f "${pool_meta_file}" ]] || ! meta_extended=$(jq -er .extended "${pool_meta_file}"); then meta_extended="https://foo.com/metadata/extended.json"; fi
@@ -1762,7 +1806,7 @@ EOF
     if [[ -f "${pool_config}" && $(jq '.relays | length' "${pool_config}") -gt 0 ]]; then
       println "DEBUG" "\nPrevious relay configuration:\n"
       jq -r '["TYPE","ADDRESS","PORT"], (.relays[] | [.type //"-",.address //"-",.port //"-"]) | @tsv' "${pool_config}" | column -t >&3
-      println "DEBUG" "\nReuse previous configuration?"
+      println "DEBUG" "\nReuse previous relay configuration?"
       select_opt "[y] Yes" "[n] No" "[Esc] Cancel"
       case $? in
         0) while read -r type address port; do
@@ -1833,192 +1877,236 @@ EOF
     fi
     echo
     
+    owner_wallets=()
+    reward_wallet=""
+    hw_reward_wallet='N'
+    hw_owner_wallets='N'
+    reuse_wallets='N'
+    
     # Old owner/reward wallets
     if [[ -f ${pool_config} ]]; then
-      println "DEBUG" "# Previous Owner/Reward wallets"
+      println "DEBUG" "# Previous Owner(s)/Reward wallets"
       if jq -er '.pledgeWallet' "${pool_config}" &>/dev/null; then # legacy support
-        println "DEBUG" "Owner wallet #1 : ${FG_GREEN}$(jq -r '.pledgeWallet' "${pool_config}")${NC}"
+        owner_wallets+=( "$(jq -r '.pledgeWallet' "${pool_config}")" )
+        println "DEBUG" "Owner wallet #1 : ${FG_GREEN}${owner_wallets[0]}${NC}"
       else
-        for owner_w in $(jq -c '.owners[]' "${pool_config}"); do
-          println "DEBUG" "Owner wallet #$(jq -r '.owner_id' <<< "${owner_w}") : ${FG_GREEN}$(jq -r '.wallet_name' <<< "${owner_w}")${NC}"
+        for owner in $(jq -c '.owners[]' "${pool_config}"); do
+          wallet_name=$(jq -r '.wallet_name' <<< "${owner}")
+          owner_wallets+=( "${wallet_name}" )
+          println "DEBUG" "Owner wallet #$(jq -r '.id' <<< "${owner}") : ${FG_GREEN}${wallet_name}${NC}"
         done
       fi
-      println "DEBUG" "                : ${FG_BLUE}INFO${NC}: additional multi-owner wallets added by stake keys not listed"
-      println "DEBUG" "Reward wallet   : ${FG_GREEN}$(jq -r '.rewardWallet //empty' "${pool_config}")${NC}"
-      echo
-      println "DEBUG" "${FG_YELLOW}If a new wallet is chosen for owner/reward, a manual delegation to the pool with new wallet is needed${NC}"
-      echo
-    fi
-
-    println "DEBUG" "# Select ${FG_CYAN}owner/pledge${NC} wallet"
-    if [[ ${op_mode} = "online" ]]; then
-      if ! selectWallet "delegate" "${WALLET_STAKE_VK_FILENAME}"; then # ${wallet_name} populated by selectWallet function
-        [[ "${dir_name}" != "[Esc] Cancel" ]] && waitForInput; continue
-      fi
-      getWalletType ${wallet_name}
+      reward_wallet=$(jq -r '.rewardWallet //empty' "${pool_config}")
+      println "DEBUG" "Reward wallet   : ${FG_GREEN}${reward_wallet}${NC}"
+      println "DEBUG" "\nReuse previous Owner(s)/Reward wallets?"
+      select_opt "[y] Yes" "[n] No" "[Esc] Cancel"
       case $? in
-        0) println "ERROR" "${FG_RED}ERROR${NC}: pool owner can NOT be a hardware wallet!"
-           println "ERROR" "Use a CLI wallet as owner with enough funds to pay for pool deposit and registration transaction fee"
-           println "ERROR" "Add the hardware wallet as an additional multi-owner to the pool later in the pool registration wizard"
-           waitForInput && continue ;;
-        2) println "ERROR" "${FG_RED}ERROR${NC}: payment and/or stake signing keys encrypted, please decrypt before use!" && waitForInput && continue ;;
-        3) println "ERROR" "${FG_RED}ERROR${NC}: payment and/or stake signing keys missing from wallet!" && waitForInput && continue ;;
-      esac
-    else
-      if ! selectWallet "delegate" "${WALLET_STAKE_VK_FILENAME}"; then # ${wallet_name} populated by selectWallet function
-        [[ "${dir_name}" != "[Esc] Cancel" ]] && waitForInput; continue
-      fi
-    fi
-    echo
-
-    owner_wallet="${wallet_name}"
-    pledge_wallets=( "${owner_wallet}" )
-    getBaseAddress ${owner_wallet}
-    getBalance ${base_addr}
-    getRewards ${owner_wallet}
-
-    if [[ ${lovelace} -gt 0 ]]; then
-      if [[ -n ${wallet_count} && ${wallet_count} -gt ${WALLET_SELECTION_FILTER_LIMIT} ]]; then
-        if [[ ${reward_lovelace} -gt 0 ]]; then
-          println "DEBUG" "$(printf "%s\t${FG_CYAN}%s${NC} Ada" "Funds in base address + rewards for owner wallet:"  "$(formatLovelace $((lovelace + reward_lovelace)))")"
-        else
-          println "DEBUG" "$(printf "%s\t${FG_CYAN}%s${NC} Ada" "Funds in owner wallet:"  "$(formatLovelace ${lovelace})")"
-        fi
-        echo
-      fi
-    else
-      println "ERROR" "${FG_RED}ERROR${NC}: no funds available in base address for wallet ${FG_GREEN}${owner_wallet}${NC}"
-      waitForInput && continue
-    fi
-    if [[ ${reward_lovelace} -eq -1 ]]; then # not registered, from previous getRewards check
-      if [[ ${op_mode} = "online" ]]; then
-        if ! registerStakeWallet ${owner_wallet}; then waitForInput && continue; fi
-        echo
-      else
-        println "ERROR" "Owner wallet not a registered wallet on chain and CNTools run in hybrid mode"
-        println "ERROR" "Please first register all wallets to use in pool registration using 'Wallet >> Register'"
-        waitForInput && continue
-      fi
-    fi
-    
-    hw_wallet_used='N'
-
-    println "DEBUG" "Use a different wallet for rewards?"
-    select_opt "[n] No" "[y] Yes" "[Esc] Cancel"
-    case $? in
-      0) reward_wallet="${owner_wallet}" ;;
-      1) if ! selectWallet "none" "${WALLET_STAKE_VK_FILENAME}" "${owner_wallet}"; then # ${wallet_name} populated by selectWallet function
-           [[ "${dir_name}" != "[Esc] Cancel" ]] && waitForInput; continue
-         fi
-         reward_wallet="${wallet_name}"
-         if ! isWalletRegistered ${reward_wallet}; then
-           if [[ ${op_mode} = "hybrid" ]]; then
-             println "ERROR" "\nOwner wallet not a registered wallet on chain and CNTools run in hybrid mode"
-             println "ERROR" "Please first register all wallets to use in pool registration using 'Wallet >> Register'"
-             waitForInput && continue
-           fi
+        0) reuse_wallets='Y'
+           for wallet_name in ${owner_wallets[@]}; do # Validate each wallet that they still exist and contain the correct keys
+             getWalletType ${wallet_name}
+             case $? in
+               0) if [[ ${wallet_name} = ${owner_wallets[0]} ]]; then # main owner, must be a CLI wallet
+                    println "ERROR" "${FG_RED}ERROR${NC}: main/first pool owner can NOT be a hardware wallet!"
+                    println "ERROR" "Use a CLI wallet as owner with enough funds to pay for pool deposit and registration transaction fee"
+                    println "ERROR" "Add the hardware wallet as an additional multi-owner to the pool later in the pool registration wizard"
+                    waitForInput "Unable to reuse old configuration, please set new owner(s) & reward wallet" && owner_wallets=() && reward_wallet="" && reuse_wallets='N' && break
+                  else hw_owner_wallets='Y'; fi ;;
+               2) if [[ ${op_mode} = "online" ]]; then
+                    println "ERROR" "${FG_RED}ERROR${NC}: signing keys encrypted for wallet ${FG_GREEN}${wallet_name}${NC}, please decrypt before use!"
+                    waitForInput && continue 2
+                  fi ;;
+               3) println "ERROR" "${FG_RED}ERROR${NC}: payment and/or stake signing keys missing from wallet ${FG_GREEN}${wallet_name}${NC}!"
+                  waitForInput "Did you mean to run in Hybrid mode?  press any key to return home!" && continue 2 ;;
+               4) println "ERROR" "${FG_RED}ERROR${NC}: payment and/or stake verification keys missing from wallet ${FG_GREEN}${wallet_name}${NC}!"
+                  waitForInput "Unable to reuse old configuration, please set new owner(s) & reward wallet" && owner_wallets=() && reward_wallet="" && reuse_wallets='N' && break ;;
+             esac
+             if ! isWalletRegistered ${wallet_name}; then
+               if [[ ${op_mode} = "hybrid" ]]; then
+                 println "ERROR" "\n${FG_RED}ERROR${NC}: wallet ${FG_GREEN}${wallet_name}${NC} not a registered wallet on chain and CNTools run in hybrid mode"
+                 println "ERROR" "Please first register all wallets to use in pool registration using 'Wallet >> Register'"
+                 waitForInput && continue 2
+               fi
+               getBaseAddress ${wallet_name}
+               getBalance ${base_addr}
+               if [[ ${lovelace} -eq 0 ]]; then
+                 println "ERROR" "${FG_RED}ERROR${NC}: no funds available in base address for wallet ${FG_GREEN}${wallet_name}${NC}, needed to pay for registration fee"
+                 waitForInput && continue 2
+               fi
+               if ! registerStakeWallet ${wallet_name}; then waitForInput && continue 2; fi
+             fi
+           done
            getWalletType ${reward_wallet}
            case $? in
-             0) hw_wallet_used='Y' ;;
-             2) println "ERROR" "${FG_RED}ERROR${NC}: payment and/or stake signing keys encrypted, please decrypt before use!" && waitForInput && continue ;;
-             3) println "ERROR" "${FG_RED}ERROR${NC}: payment and/or stake signing keys missing from wallet!" && waitForInput && continue ;;
+             0) hw_reward_is_mu='N'
+                for wallet_name in ${owner_wallets[@]}; do # HW reward wallet, make sure its also a multi-owner to the pool
+                  [[ "${wallet_name}" = "${reward_wallet}" ]] && hw_reward_is_mu='Y' && break
+                done
+                if [[ ${hw_reward_is_mu} = 'N' ]]; then # main owner, must be a CLI wallet
+                  println "ERROR" "${FG_RED}ERROR${NC}: reward wallet detected as hardware wallet but NOT a multi-owner to the pool!"
+                  println "ERROR" "If hardware wallet is to be used for rewards, it MUST also be a multi-owner to the pool"
+                  waitForInput "Unable to reuse old configuration, please set new owner(s) & reward wallet" && owner_wallets=() && reward_wallet="" && reuse_wallets='N'
+                else hw_reward_wallet='Y'; fi ;;
+             2) if [[ ${op_mode} = "online" && ${SUBCOMMAND} = "register" && ${hw_owner_wallets} = 'N' ]]; then
+                  println "ERROR" "${FG_RED}ERROR${NC}: signing keys encrypted for reward wallet ${FG_GREEN}${reward_wallet}${NC}, please decrypt before use!"
+                  waitForInput && continue
+                fi ;;
+             3) if [[ ${SUBCOMMAND} = "register" && ${hw_owner_wallets} = 'N' ]]; then
+                  println "ERROR" "${FG_RED}ERROR${NC}: payment and/or stake signing keys missing from reward wallet ${FG_GREEN}${reward_wallet}${NC}!"
+                  waitForInput "Did you mean to run in Hybrid mode?  press any key to return home!" && continue
+                fi ;;
+             4) println "ERROR" "${FG_RED}ERROR${NC}: payment and/or stake verification keys missing from reward wallet ${FG_GREEN}${reward_wallet}${NC}!"
+                waitForInput "Unable to reuse old configuration, please set new owner(s) & reward wallet" && owner_wallets=() && reward_wallet="" && reuse_wallets='N' ;;
            esac
-           getBaseAddress ${reward_wallet}
-           getBalance ${base_addr}
-           if [[ ${lovelace} -gt 0 ]]; then
-             println "DEBUG" "$(printf "%s\t${FG_CYAN}%s${NC} Ada" "Funds in reward wallet:"  "$(formatLovelace ${lovelace})")"
-             echo
-           else
-             println "ERROR" "${FG_RED}ERROR${NC}: no funds available in base address for wallet ${FG_GREEN}${reward_wallet}${NC}, needed to pay for registration fee"
-             waitForInput && continue
+           if ! isWalletRegistered ${reward_wallet}; then
+             if [[ ${op_mode} = "hybrid" ]]; then
+               println "ERROR" "\n${FG_RED}ERROR${NC}: reward wallet ${FG_GREEN}${reward_wallet}${NC} not a registered wallet on chain and CNTools run in hybrid mode"
+               println "ERROR" "Please first register all wallets to use in pool registration using 'Wallet >> Register'"
+               waitForInput && continue
+             fi
+             getBaseAddress ${reward_wallet}
+             getBalance ${base_addr}
+             if [[ ${lovelace} -eq 0 ]]; then
+               println "ERROR" "${FG_RED}ERROR${NC}: no funds available in base address for reward wallet ${FG_GREEN}${reward_wallet}${NC}, needed to pay for registration fee"
+               waitForInput && continue
+             fi
+             if ! registerStakeWallet ${reward_wallet}; then waitForInput && continue; fi
            fi
-           if ! registerStakeWallet ${reward_wallet}; then
-             waitForInput && continue
+           ;;
+        1) owner_wallets=() && reward_wallet="" && reuse_wallets='N'
+           println "DEBUG" "\n${FG_YELLOW}If new wallets are chosen for owner(s)/reward, a manual delegation to the pool for each wallet is needed if not done already!${NC}"
+           ;;
+        2) continue ;;
+      esac
+      echo
+    fi
+
+    if [[ ${reuse_wallets} = 'N' ]]; then
+      println "DEBUG" "# Select main ${FG_CYAN}owner/pledge${NC} wallet (normal CLI wallet)"
+      if [[ ${op_mode} = "online" ]]; then
+        if ! selectWallet "delegate" "${WALLET_PAY_VK_FILENAME}" "${WALLET_STAKE_VK_FILENAME}"; then # ${wallet_name} populated by selectWallet function
+          [[ "${dir_name}" != "[Esc] Cancel" ]] && waitForInput; continue
+        fi
+        getWalletType ${wallet_name}
+        case $? in
+          0) println "ERROR" "${FG_RED}ERROR${NC}: main pool owner can NOT be a hardware wallet!"
+             println "ERROR" "Use a CLI wallet as owner with enough funds to pay for pool deposit and registration transaction fee"
+             println "ERROR" "Add the hardware wallet as an additional multi-owner to the pool later in the pool registration wizard"
+             waitForInput && continue ;;
+          2) println "ERROR" "${FG_RED}ERROR${NC}: signing keys encrypted, please decrypt before use!" && waitForInput && continue ;;
+          3) println "ERROR" "${FG_RED}ERROR${NC}: payment and/or stake signing keys missing from wallet!" && waitForInput && continue ;;
+        esac
+      else
+        if ! selectWallet "delegate" "${WALLET_PAY_VK_FILENAME}" "${WALLET_STAKE_VK_FILENAME}"; then # ${wallet_name} populated by selectWallet function
+          [[ "${dir_name}" != "[Esc] Cancel" ]] && waitForInput; continue
+        fi
+        getWalletType ${wallet_name}
+      fi
+      if ! isWalletRegistered ${wallet_name}; then
+        if [[ ${op_mode} = "hybrid" ]]; then
+          println "ERROR" "\n${FG_RED}ERROR${NC}: wallet ${FG_GREEN}${wallet_name}${NC} not a registered wallet on chain and CNTools run in hybrid mode"
+          println "ERROR" "Please first register all wallets to use in pool registration using 'Wallet >> Register'"
+          waitForInput && continue
+        fi
+        getBaseAddress ${wallet_name}
+        getBalance ${base_addr}
+        if [[ ${lovelace} -eq 0 ]]; then
+          println "ERROR" "${FG_RED}ERROR${NC}: no funds available in base address for wallet ${FG_GREEN}${wallet_name}${NC}, needed to pay for registration fee"
+          waitForInput && continue
+        fi
+        if ! registerStakeWallet ${wallet_name}; then waitForInput && continue; fi
+      fi
+      owner_wallets+=( "${wallet_name}" )
+      println "DEBUG" "Owner #1 : ${FG_GREEN}${wallet_name}${NC} added!"
+      echo
+    fi
+    
+    if [[ ${reuse_wallets} = 'N' ]]; then
+      println "DEBUG" "Register a multi-owner pool?"
+      while true; do
+        select_opt "[n] No" "[y] Yes" "[Esc] Cancel"
+        case $? in
+          0) break ;;
+          1) if [[ ${op_mode} = "online" ]]; then
+               if selectWallet "delegate" "${WALLET_STAKE_VK_FILENAME}" "${owner_wallets[@]}"; then # ${wallet_name} populated by selectWallet function
+                 getWalletType ${wallet_name}
+                 case $? in
+                   0) hw_owner_wallets='Y' ;;
+                   2) [[ ! -f "${stake_sk_file}" ]] && println "ERROR" "${FG_RED}ERROR${NC}: stake signing key encrypted, please decrypt before use!" && waitForInput && println "DEBUG" "Add more owners?" && continue ;;
+                   3) if [[ -f "${WALLET_FOLDER}/${wallet_name}/${WALLET_HW_STAKE_SK_FILENAME}" ]]; then # hw stake signing key available but not payment, this is ok
+                        hw_owner_wallets='Y'
+                      elif [[ ! -f "${WALLET_FOLDER}/${1}/${WALLET_STAKE_SK_FILENAME}" ]]; then # hw or cli stake signing key not available, not good :(
+                        println "ERROR" "${FG_RED}ERROR${NC}: stake signing key missing from wallet!" && waitForInput && println "DEBUG" "Add more owners?" && continue
+                      fi ;;
+                 esac
+               else
+                 println "DEBUG" "Add more owners?" && continue
+               fi
+             else
+               if ! selectWallet "delegate" "${WALLET_STAKE_VK_FILENAME}" "${owner_wallets[@]}"; then println "DEBUG" "Add more owners?" && continue; fi
+             fi
+             owner_wallets+=( "${wallet_name}" )
+             println "DEBUG" "Owner #${#owner_wallets[@]} : ${FG_GREEN}${wallet_name}${NC} added!"
+             ;;
+          2) continue 2 ;;
+        esac
+        println "DEBUG" "Add more owners?"
+      done
+      echo
+    fi
+
+    if [[ ${reuse_wallets} = 'N' ]]; then
+      println "DEBUG" "Use a separate rewards wallet from main owner?"
+      select_opt "[n] No" "[y] Yes" "[Esc] Cancel"
+      case $? in
+        0) reward_wallet="${owner_wallets[0]}" ;;
+        1) if ! selectWallet "none" "${WALLET_STAKE_VK_FILENAME}" "${owner_wallets[@]}"; then # ${wallet_name} populated by selectWallet function
+             [[ "${dir_name}" != "[Esc] Cancel" ]] && waitForInput; continue
            fi
-         fi
-         ;;
-      2) continue ;;
-    esac
-    echo
+           reward_wallet="${wallet_name}"
+           if ! isWalletRegistered ${reward_wallet}; then
+             if [[ ${op_mode} = "hybrid" ]]; then
+               println "ERROR" "\nReward wallet ${FG_GREEN}${reward_wallet}${NC} not a registered wallet on chain and CNTools run in hybrid mode"
+               println "ERROR" "Please first register all wallets to use in pool registration using 'Wallet >> Register'"
+               waitForInput && continue
+             fi
+             getWalletType ${reward_wallet}
+             case $? in
+               0) hw_reward_wallet='Y' ;;
+               2) println "ERROR" "${FG_RED}ERROR${NC}: stake signing keys encrypted, please decrypt before use!" && waitForInput && continue ;;
+               3) println "ERROR" "${FG_RED}ERROR${NC}: stake signing keys missing from wallet!" && waitForInput && continue ;;
+             esac
+             getBaseAddress ${reward_wallet}
+             getBalance ${base_addr}
+             if [[ ${lovelace} -gt 0 ]]; then
+               println "DEBUG" "$(printf "%s\t${FG_CYAN}%s${NC} Ada" "Funds in reward wallet:"  "$(formatLovelace ${lovelace})")"
+               echo
+             else
+               println "ERROR" "${FG_RED}ERROR${NC}: no funds available in base address for wallet ${FG_GREEN}${reward_wallet}${NC}, needed to pay for registration fee"
+               waitForInput && continue
+             fi
+             if ! registerStakeWallet ${reward_wallet}; then
+               waitForInput && continue
+             fi
+           fi
+           ;;
+        2) continue ;;
+      esac
+      echo
+    fi
 
     multi_owner_output=""
-    multi_owner_skeys=()
-    multi_owner_vkeys=()
-    println "DEBUG" "Register a multi-owner pool?"
-    owner_count=1
-    while true; do
-      select_opt "[n] No" "[w] CNTools Wallet" "[f] Path to stake vkey/skey" "[Esc] Cancel"
-      case $? in
-        0) break ;;
-        1) if [[ ${op_mode} = "online" ]]; then
-             if selectWallet "delegate" "${WALLET_STAKE_VK_FILENAME}" "${pledge_wallets[@]}"; then # ${wallet_name} populated by selectWallet function
-               getWalletType ${wallet_name}
-               case $? in
-                 0) hw_wallet_used='Y' ;;
-                 2) println "ERROR" "${FG_RED}ERROR${NC}: payment and/or stake signing keys encrypted, please decrypt before use!" && waitForInput && continue ;;
-                 3) println "ERROR" "${FG_RED}ERROR${NC}: payment and/or stake signing keys missing from wallet!" && waitForInput && continue ;;
-               esac
-               multi_owner_output+="--pool-owner-stake-verification-key-file ${WALLET_FOLDER}/${wallet_name}/${WALLET_STAKE_VK_FILENAME} "
-               multi_owner_skeys+=( "${stake_sk_file}" )
-               pledge_wallets+=( "${wallet_name}" )
-               println "DEBUG" "Owner #$((++owner_count)) : ${FG_GREEN}${wallet_name}${NC}"
-             fi
-           else
-             if selectWallet "delegate" "${WALLET_STAKE_VK_FILENAME}"; then # ${wallet_name} populated by selectWallet function
-               multi_owner_output+="--pool-owner-stake-verification-key-file ${WALLET_FOLDER}/${wallet_name}/${WALLET_STAKE_VK_FILENAME} "
-               pledge_wallets+=( "${wallet_name}" )
-               println "DEBUG" "Owner #$((++owner_count)) : ${FG_GREEN}${wallet_name}${NC}"
-             fi
-           fi
-           ;;
-        2) println "DEBUG" "Enter path to ${FG_CYAN}${WALLET_STAKE_VK_FILENAME}${NC} & ${FG_CYAN}${WALLET_STAKE_SK_FILENAME}${NC}/${FG_CYAN}${WALLET_HW_STAKE_SK_FILENAME}${NC} files in this order!"
-           [[ ${ENABLE_DIALOG} = "true" ]] && waitForInput "Press any key to open the file explorer"
-           fileDialog 0 "Enter path to ${WALLET_STAKE_VK_FILENAME} file" "${WALLET_FOLDER}/"
-           println "DEBUG" "Owner #$((++owner_count)) : vkey = ${file}"
-           stake_vk_file_enter=${file}
-           if [[ ${op_mode} = "online" ]]; then
-             fileDialog 0 "Enter path to stake skey file" "${stake_vk_file_enter%/*}/${WALLET_STAKE_SK_FILENAME}"
-             println "DEBUG" "Owner #${owner_count} : skey = ${file}"
-             stake_sk_file_enter=${file}
-             if [[ ! -f "${stake_vk_file_enter}" || ! -f "${stake_sk_file_enter}" ]]; then
-               println "ERROR" "${FG_RED}ERROR${NC}: One or both files not found, please try again"
-               ((owner_count--))
-             else
-               [[ $(jq -r '.description' "${stake_sk_file_enter}") = *"Hardware"* ]] && hw_wallet_used='Y'
-               multi_owner_output+="--pool-owner-stake-verification-key-file ${stake_vk_file_enter} "
-               multi_owner_skeys+=( "${stake_sk_file_enter}" )
-               println "DEBUG" "[OPTIONAL]: Add wallet payment vkey to be able to check pledge balance?"
-               select_opt "[y] Yes" "[n] No"
-               case $? in
-                 0) fileDialog 0 "Enter path to ${WALLET_PAY_VK_FILENAME} file" "${stake_vk_file_enter%/*}/${WALLET_PAY_VK_FILENAME}"
-                    if [[ -f "${file}" ]]; then
-                      multi_owner_vkeys+=( "${file}" )
-                      multi_owner_vkeys+=( "${stake_vk_file_enter}" )
-                    else
-                      println "ERROR" "${FG_RED}ERROR${NC}: ${file} not found!"
-                      println "multi-owner wallet successfully added but wont be included in pledge balance verification (information only)"
-                    fi
-                    ;;
-                 1) : ;;
-               esac
-             fi
-           else
-             if [[ ! -f "${stake_vk_file_enter}" ]]; then
-               println "ERROR" "${FG_RED}ERROR${NC}: file not found, please try again"
-               ((owner_count--))
-             else
-               multi_owner_output+="--pool-owner-stake-verification-key-file ${stake_vk_file_enter} "
-             fi
-           fi
-           ;;
-        3) continue 2 ;;
-      esac
-      println "DEBUG" "Add more owners?"
+    for wallet_name in ${owner_wallets[@]}; do
+      [[ "${wallet_name}" = "${owner_wallets[0]}" ]] && continue # skip main owner
+      multi_owner_output+="--pool-owner-stake-verification-key-file ${WALLET_FOLDER}/${wallet_name}/${WALLET_STAKE_VK_FILENAME} "
     done
 
-    owner_stake_vk_file="${WALLET_FOLDER}/${owner_wallet}/${WALLET_STAKE_VK_FILENAME}"
-    owner_delegation_cert_file="${WALLET_FOLDER}/${owner_wallet}/${WALLET_DELEGCERT_FILENAME}"
+    owner_payment_sk_file="${WALLET_FOLDER}/${owner_wallets[0]}/${WALLET_PAY_SK_FILENAME}"
+    owner_payment_vk_file="${WALLET_FOLDER}/${owner_wallets[0]}/${WALLET_PAY_SK_FILENAME}"
+    owner_stake_vk_file="${WALLET_FOLDER}/${owner_wallets[0]}/${WALLET_STAKE_VK_FILENAME}"
+    owner_stake_sk_file="${WALLET_FOLDER}/${owner_wallets[0]}/${WALLET_STAKE_SK_FILENAME}"
+    owner_delegation_cert_file="${WALLET_FOLDER}/${owner_wallets[0]}/${WALLET_DELEGCERT_FILENAME}"
     reward_stake_vk_file="${WALLET_FOLDER}/${reward_wallet}/${WALLET_STAKE_VK_FILENAME}"
+    reward_stake_sk_file="${WALLET_FOLDER}/${reward_wallet}/${WALLET_STAKE_SK_FILENAME}"
     reward_delegation_cert_file="${WALLET_FOLDER}/${reward_wallet}/${WALLET_DELEGCERT_FILENAME}"
 
     pool_hotkey_vk_file="${POOL_FOLDER}/${pool_name}/${POOL_HOTKEY_VK_FILENAME}"
@@ -2042,12 +2130,14 @@ EOF
         println "ACTION" "${CCLI} node issue-op-cert --kes-verification-key-file \"${pool_hotkey_vk_file}\" --cold-signing-key-file \"${pool_coldkey_sk_file}\" --operational-certificate-issue-counter-file \"${pool_opcert_counter_file}\" --kes-period \"${current_kes_period}\" --out-file \"${pool_opcert_file}\""
         ${CCLI} node issue-op-cert --kes-verification-key-file "${pool_hotkey_vk_file}" --cold-signing-key-file "${pool_coldkey_sk_file}" --operational-certificate-issue-counter-file "${pool_opcert_counter_file}" --kes-period "${current_kes_period}" --out-file "${pool_opcert_file}"
       else
-        println "\n${FG_YELLOW}Pool operational certificate not generated in hybrid mode,\nplease use 'Pool >> Rotate' in offline mode to generate new hot keys, op cert and KES start period and transfer to online node!${NC}"
-        println "${FG_CYAN}${pool_hotkey_vk_file}${NC}"
-        println "${FG_CYAN}${pool_hotkey_sk_file}${NC}"
-        println "${FG_CYAN}${pool_opcert_file}${NC}"
-        println "${FG_CYAN}${pool_saved_kes_start}${NC}"
-        waitForInput "press any key to continue" && echo
+        println "DEBUG" "${FG_YELLOW}Pool operational certificate not generated in hybrid mode,"
+        println "DEBUG" "please use 'Pool >> Rotate' in offline mode to generate new hot keys, op cert and KES start period and transfer to online node!${NC}"
+        println "DEBUG" "Files generated when running 'Pool >> Rotate' to be transferred:"
+        println "DEBUG" "${FG_CYAN}${pool_hotkey_vk_file}${NC}"
+        println "DEBUG" "${FG_CYAN}${pool_hotkey_sk_file}${NC}"
+        println "DEBUG" "${FG_CYAN}${pool_opcert_file}${NC}"
+        println "DEBUG" "${FG_CYAN}${pool_saved_kes_start}${NC}"
+        waitForInput "press any key to continue"
       fi
     fi
 
@@ -2055,40 +2145,32 @@ EOF
     println "ACTION" "${CCLI} stake-pool registration-certificate --cold-verification-key-file ${pool_coldkey_vk_file} --vrf-verification-key-file ${pool_vrf_vk_file} --pool-pledge ${pledge_lovelace} --pool-cost ${cost_lovelace} --pool-margin ${margin_fraction} --pool-reward-account-verification-key-file ${reward_stake_vk_file} --pool-owner-stake-verification-key-file ${owner_stake_vk_file} ${multi_owner_output} --metadata-url ${meta_json_url} --metadata-hash \$\(${CCLI} stake-pool metadata-hash --pool-metadata-file ${pool_meta_file} \) ${relay_output} ${NETWORK_IDENTIFIER} --out-file ${pool_regcert_file}"
     ${CCLI} stake-pool registration-certificate --cold-verification-key-file "${pool_coldkey_vk_file}" --vrf-verification-key-file "${pool_vrf_vk_file}" --pool-pledge ${pledge_lovelace} --pool-cost ${cost_lovelace} --pool-margin ${margin_fraction} --pool-reward-account-verification-key-file "${reward_stake_vk_file}" --pool-owner-stake-verification-key-file "${owner_stake_vk_file}" ${multi_owner_output} --metadata-url "${meta_json_url}" --metadata-hash "$(${CCLI} stake-pool metadata-hash --pool-metadata-file ${pool_meta_file} )" ${relay_output} ${NETWORK_IDENTIFIER} --out-file "${pool_regcert_file}"
 
+    delegate_reward_wallet='N'
+    delegate_owner_wallet='N'
     if [[ ${SUBCOMMAND} = "register" ]]; then
-      delegate_reward_wallet='N'
-      delegate_owner_wallet='N'
-      if [[ ${hw_wallet_used} = 'Y' ]]; then
-        println "DEBUG" "${FG_BLUE}INFO${NC}: hardware wallet included, automatic owner/reward wallet delegation disabled"
+      if [[ ${hw_owner_wallets} = 'Y' || ${hw_reward_wallet} = 'Y' ]]; then
+        println "DEBUG" "${FG_BLUE}INFO${NC}: hardware wallet included as reward or multi-owner, automatic owner/reward wallet delegation disabled"
         println "DEBUG" "${FG_BLUE}INFO${NC}: ${FG_YELLOW}please manually delegate all wallets to the pool!!!${NC}"
         waitForInput "press any key to continue"
       else
-        println "LOG" "creating delegation certificate for owner wallet"
+        println "LOG" "creating delegation certificate for main owner wallet"
         println "ACTION" "${CCLI} stake-address delegation-certificate --stake-verification-key-file ${owner_stake_vk_file} --cold-verification-key-file ${pool_coldkey_vk_file} --out-file ${owner_delegation_cert_file}"
         ${CCLI} stake-address delegation-certificate --stake-verification-key-file "${owner_stake_vk_file}" --cold-verification-key-file "${pool_coldkey_vk_file}" --out-file "${owner_delegation_cert_file}"
         delegate_owner_wallet='Y'
-        if [[ ! "${owner_wallet}" = "${reward_wallet}" ]]; then
-          println "DEBUG" "\nRe-stake reward wallet to pool?"
-          select_opt "[y] Yes" "[n] No"
-          case $? in
-            0) delegate_reward_wallet='Y'
-               println "LOG" "creating delegation certificate for reward wallet"
-               println "ACTION" "${CCLI} stake-address delegation-certificate --stake-verification-key-file ${reward_stake_vk_file} --cold-verification-key-file ${pool_coldkey_vk_file} --out-file ${reward_delegation_cert_file}"
-               ${CCLI} stake-address delegation-certificate --stake-verification-key-file "${reward_stake_vk_file}" --cold-verification-key-file "${pool_coldkey_vk_file}" --out-file "${reward_delegation_cert_file}"
-               ;;
-            1) : ;;
-          esac
+        if [[ "${owner_wallets[0]}" != "${reward_wallet}" ]]; then
+          println "LOG" "creating delegation certificate for reward wallet"
+          println "ACTION" "${CCLI} stake-address delegation-certificate --stake-verification-key-file ${reward_stake_vk_file} --cold-verification-key-file ${pool_coldkey_vk_file} --out-file ${reward_delegation_cert_file}"
+          ${CCLI} stake-address delegation-certificate --stake-verification-key-file "${reward_stake_vk_file}" --cold-verification-key-file "${pool_coldkey_vk_file}" --out-file "${reward_delegation_cert_file}"
+          delegate_reward_wallet='Y'
         fi
       fi
     fi
     
-    echo
-    
     if [[ ${SUBCOMMAND} = "register" ]]; then
-      registerPool "${pool_name}" "${reward_wallet}" "${delegate_reward_wallet}" "${owner_wallet}" "${delegate_owner_wallet}" "${multi_owner_skeys[@]}"
+      registerPool
       rc=$?
     else
-      modifyPool "${pool_name}" "${reward_wallet}" "${owner_wallet}" "${multi_owner_skeys[@]}"
+      modifyPool
       rc=$?
     fi
     
@@ -2117,12 +2199,12 @@ EOF
     } | jq -c .)
     # Construct owner json array
     owner_array=()
-    for index in "${!pledge_wallets[@]}"; do
-      owner_array+=( "$((index+1))" "${pledge_wallets[${index}]}" )
+    for index in "${!owner_wallets[@]}"; do
+      owner_array+=( "$((index+1))" "${owner_wallets[${index}]}" )
     done
     owner_json=$({
       printf '['
-      printf '{"owner_id":%s,"wallet_name":"%s"},\n' "${owner_array[@]}" | sed '$s/,$//'
+      printf '{"id":%s,"wallet_name":"%s"},\n' "${owner_array[@]}" | sed '$s/,$//'
       printf ']'
     } | jq -c .)
     echo "{\"owners\":$owner_json,\"rewardWallet\":\"$reward_wallet\",\"pledgeADA\":$pledge_ada,\"margin\":$margin,\"costADA\":$cost_ada,\"json_url\":\"$meta_json_url\",\"relays\": $relay_json}" > "${pool_config}"
@@ -2132,8 +2214,7 @@ EOF
     [[ -f "${pool_deregcert_file}" ]] && rm -f ${pool_deregcert_file} # delete de-registration cert if available
 
     if [[ ${op_mode} = "online" ]]; then
-      echo
-      getBaseAddress ${owner_wallet}
+      getBaseAddress ${owner_wallets[0]}
       if ! verifyTx ${base_addr}; then waitForInput && continue; fi
       echo
       if [[ ${SUBCOMMAND} = "register" ]]; then
@@ -2144,51 +2225,39 @@ EOF
     else
       echo
       println "Pool ${FG_GREEN}${pool_name}${NC} built!"
-      println "${FG_YELLOW}Follow the steps above to witness, sign and submit transaction!${NC}"
-      echo
+      println "${FG_YELLOW}Follow the steps above to sign and submit transaction!${NC}"
     fi
     
-    pledge_cnt=0
-    for pledge_wallet in "${pledge_wallets[@]}"; do
-      println "Owner #$((++pledge_cnt))      : ${FG_GREEN}${pledge_wallet}${NC}"
+    for index in "${!owner_wallets[@]}"; do
+      println "Owner #$((index+1))      : ${FG_GREEN}${owner_wallets[${index}]}${NC}"
     done
-    multi_owner_key_cnt=$(( owner_count - ${#pledge_wallets[@]} ))
-    if [[ ${multi_owner_key_cnt} -eq 1 ]]; then
-      println "Owner #${owner_count}      : ${FG_CYAN}1${NC} additional owner using stake keys"
-    elif [[ ${multi_owner_key_cnt} -gt 1 ]]; then
-      println "Owner #$((${#pledge_wallets[@]}+1))-${owner_count}    : ${FG_CYAN}${multi_owner_key_cnt}${NC} additional owners using stake keys"
-    fi
     println "Reward Wallet : ${FG_GREEN}${reward_wallet}${NC}"
     println "Pledge        : $(formatAda ${pledge_ada}) Ada"
     println "Margin        : ${margin}%"
     println "Cost          : $(formatAda ${cost_ada}) Ada"
-    [[ ${SUBCOMMAND} = "register" ]] && println "DEBUG" "\nUncomment and set value for POOL_NAME in ${PARENT}/env with '${pool_name}'"
+    if [[ ${SUBCOMMAND} = "register" ]]; then
+      if [[ ${op_mode} = "hybrid" ]]; then
+        println "DEBUG" "\n${FG_YELLOW}After offline pool transaction is signed and submitted, uncomment and set value for POOL_NAME in ${PARENT}/env with${NC} '${FG_GREEN}${pool_name}${NC}'"
+      else
+        println "DEBUG" "\n${FG_YELLOW}Uncomment and set value for POOL_NAME in ${PARENT}/env with${NC} '${FG_GREEN}${pool_name}${NC}'"
+      fi
+    fi
+    echo
     if [[ ${op_mode} = "online" ]]; then
       total_pledge=0
-      for pledge_wallet in "${pledge_wallets[@]}"; do
-        getBaseAddress ${pledge_wallet}
+      for wallet_name in "${owner_wallets[@]}"; do
+        getBaseAddress ${wallet_name}
         getBalance ${base_addr}
         total_pledge=$(( total_pledge + lovelace ))
-        getRewards ${pledge_wallet}
+        getRewards ${wallet_name}
         [[ ${reward_lovelace} -gt 0 ]] && total_pledge=$(( total_pledge + reward_lovelace ))
       done
-      while [[ "${#multi_owner_vkeys[@]}" -gt 1 ]]; do
-        getBaseAddress "${multi_owner_vkeys[0]}" "${multi_owner_vkeys[1]}"
-        getBalance ${base_addr}
-        total_pledge=$(( total_pledge + lovelace ))
-        getRewardAddressFromKey "${multi_owner_vkeys[1]}"
-        getRewardsFromAddr ${reward_addr}
-        [[ ${reward_lovelace} -gt 0 ]] && total_pledge=$(( total_pledge + reward_lovelace ))
-        multi_owner_vkeys=( "${multi_owner_vkeys[@]:2}" ) # pop processed keys from array
-      done
-      echo
-      println "DEBUG" "${FG_BLUE}INFO${NC}: Total balance in ${FG_CYAN}${owner_count}${NC} owner/pledge wallet(s) are: $(formatLovelace ${total_pledge}) Ada"
+      println "DEBUG" "${FG_BLUE}INFO${NC}: Total balance in ${FG_CYAN}${#owner_wallets[@]}${NC} owner/pledge wallet(s) are: $(formatLovelace ${total_pledge}) Ada"
       if [[ ${total_pledge} -lt ${pledge_lovelace} ]]; then
         println "ERROR" "${FG_YELLOW}Not enough funds in owner/pledge wallet(s) to meet set pledge, please manually verify!!!${NC}"
       fi
     fi
-    if [[ ${owner_count} -gt 1 ]]; then
-      echo
+    if [[ ${#owner_wallets[@]} -gt 1 ]]; then
       println "DEBUG" "${FG_BLUE}INFO${NC}: please verify that all multi-owner wallets are delegated to the pool, if not do so!"
     fi
     
@@ -2202,6 +2271,9 @@ EOF
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     println " >> POOL >> RETIRE"
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    
+    [[ ! $(ls -A "${POOL_FOLDER}" 2>/dev/null) ]] && echo && println "${FG_YELLOW}No pools available!${NC}" && waitForInput && continue
+    [[ ! $(ls -A "${WALLET_FOLDER}" 2>/dev/null) ]] && echo && println "${FG_YELLOW}No wallets available to pay for pool de-registration!${NC}" && waitForInput && continue
 
     if [[ ${CNTOOLS_MODE} = "OFFLINE" ]]; then
       println "ERROR" "${FG_RED}ERROR${NC}: CNTools started in offline mode, option not available!"
@@ -2234,6 +2306,7 @@ EOF
 
     sleep 0.1 && read -r -p "Enter epoch in which to retire pool (blank for ${epoch_start}): " epoch_enter 2>&6 && println "LOG" "Enter epoch in which to retire pool (blank for ${epoch_start}): ${epoch_enter}"
     [[ -z "${epoch_enter}" ]] && epoch_enter=${epoch_start}
+    echo
 
     if [[ ${epoch_enter} -lt ${epoch_start} || ${epoch_enter} -gt ${epoch_end} ]]; then
       println "ERROR" "${FG_RED}ERROR${NC}: epoch invalid, valid range: ${epoch_start}-${epoch_end}"
@@ -2248,15 +2321,18 @@ EOF
       getWalletType ${wallet_name}
       case $? in
         0) println "ERROR" "${FG_RED}ERROR${NC}: please use a CLI wallet to pay for pool de-registration transaction fee!" && waitForInput && continue ;;
-        2) println "ERROR" "${FG_RED}ERROR${NC}: payment and/or stake signing keys encrypted, please decrypt before use!" && waitForInput && continue ;;
+        2) println "ERROR" "${FG_RED}ERROR${NC}: signing keys encrypted, please decrypt before use!" && waitForInput && continue ;;
         3) println "ERROR" "${FG_RED}ERROR${NC}: payment and/or stake signing keys missing from wallet!" && waitForInput && continue ;;
       esac
     else
       if ! selectWallet "balance" "${WALLET_PAY_VK_FILENAME}"; then # ${wallet_name} populated by selectWallet function
         [[ "${dir_name}" != "[Esc] Cancel" ]] && waitForInput; continue
       fi
+      getWalletType ${wallet_name}
+      case $? in
+        0) println "ERROR" "${FG_RED}ERROR${NC}: please use a CLI wallet to pay for pool de-registration transaction fee!" && waitForInput && continue ;;
+      esac
     fi
-    echo
 
     getBaseAddress ${wallet_name}
     getPayAddress ${wallet_name}
@@ -2267,7 +2343,7 @@ EOF
 
     if [[ ${pay_lovelace} -gt 0 && ${base_lovelace} -gt 0 ]]; then
       # Both payment and base address available with funds, let user choose what to use
-      println "DEBUG" "# Select wallet address to use"
+      println "DEBUG" "\n# Select wallet address to use"
       if [[ -n ${wallet_count} && ${wallet_count} -gt ${WALLET_SELECTION_FILTER_LIMIT} ]]; then
         println "DEBUG" "$(printf "%s\t\t${FG_CYAN}%s${NC} Ada" "Funds :"  "$(formatLovelace ${base_lovelace})")"
         println "DEBUG" "$(printf "%s\t${FG_CYAN}%s${NC} Ada" "Enterprise Funds :"  "$(formatLovelace ${pay_lovelace})")"
@@ -2281,15 +2357,15 @@ EOF
     elif [[ ${pay_lovelace} -gt 0 ]]; then
       addr="${pay_addr}"
       if [[ -n ${wallet_count} && ${wallet_count} -gt ${WALLET_SELECTION_FILTER_LIMIT} ]]; then
-        println "DEBUG" "$(printf "%s\t${FG_CYAN}%s${NC} Ada" "Enterprise Funds :"  "$(formatLovelace ${pay_lovelace})")"
+        println "DEBUG" "\n$(printf "%s\t${FG_CYAN}%s${NC} Ada" "Enterprise Funds :"  "$(formatLovelace ${pay_lovelace})")"
       fi
     elif [[ ${base_lovelace} -gt 0 ]]; then
       addr="${base_addr}"
       if [[ -n ${wallet_count} && ${wallet_count} -gt ${WALLET_SELECTION_FILTER_LIMIT} ]]; then
-        println "DEBUG" "$(printf "%s\t\t${FG_CYAN}%s${NC} Ada" "Funds :"  "$(formatLovelace ${base_lovelace})")"
+        println "DEBUG" "\n$(printf "%s\t\t${FG_CYAN}%s${NC} Ada" "Funds :"  "$(formatLovelace ${base_lovelace})")"
       fi
     else
-      println "ERROR" "${FG_RED}ERROR${NC}: no funds available for wallet ${FG_GREEN}${wallet_name}${NC}"
+      println "ERROR" "\n${FG_RED}ERROR${NC}: no funds available for wallet ${FG_GREEN}${wallet_name}${NC}"
       waitForInput && continue
     fi
 
@@ -2298,23 +2374,21 @@ EOF
     pool_deregcert_file="${POOL_FOLDER}/${pool_name}/${POOL_DEREGCERT_FILENAME}"
     pool_regcert_file="${POOL_FOLDER}/${pool_name}/${POOL_REGCERT_FILENAME}"
 
-    payment_sk_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_PAY_SK_FILENAME}"
-
     println "LOG" "creating de-registration cert"
     println "ACTION" "${CCLI} stake-pool deregistration-certificate --cold-verification-key-file ${pool_coldkey_vk_file} --epoch ${epoch_enter} --out-file ${pool_deregcert_file}"
     ${CCLI} stake-pool deregistration-certificate --cold-verification-key-file ${pool_coldkey_vk_file} --epoch ${epoch_enter} --out-file ${pool_deregcert_file}
 
-    if ! deRegisterPool "${pool_coldkey_sk_file}" "${pool_deregcert_file}" "${addr}" "${payment_sk_file}"; then
+    if ! deRegisterPool; then
       waitForInput && continue
     fi
     
     [[ -f "${pool_regcert_file}" ]] && rm -f ${pool_regcert_file} # delete registration cert
-
-    echo
+    
     if ! verifyTx ${addr}; then waitForInput && continue; fi
     
     echo
     println "Pool ${FG_GREEN}${pool_name}${NC} set to be retired in epoch ${FG_CYAN}${epoch_enter}${NC}"
+    println "Pool deposit will be returned to owner reward address after its retired"
 
     waitForInput && continue
 
@@ -2326,6 +2400,8 @@ EOF
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     println " >> POOL >> LIST"
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    
+    [[ ! $(ls -A "${POOL_FOLDER}" 2>/dev/null) ]] && echo && println "${FG_YELLOW}No pools available!${NC}" && waitForInput && continue
 
     while IFS= read -r -d '' pool; do
       echo
@@ -2368,6 +2444,8 @@ EOF
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     println " >> POOL >> SHOW"
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    
+    [[ ! $(ls -A "${POOL_FOLDER}" 2>/dev/null) ]] && echo && println "${FG_YELLOW}No pools available!${NC}" && waitForInput && continue
 
     if [[ ${CNTOOLS_MODE} = "OFFLINE" ]]; then
       println "DEBUG" "${FG_CYAN}OFFLINE MODE${NC}: CNTools started in offline mode, locally saved info shown!"
@@ -2586,12 +2664,14 @@ EOF
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     echo
     
+    [[ ! $(ls -A "${POOL_FOLDER}" 2>/dev/null) ]] && println "${FG_YELLOW}No pools available!${NC}" && waitForInput && continue
+    
     println "DEBUG" "# Select pool to rotate KES keys on"
     if ! selectPool "all" "${POOL_COLDKEY_SK_FILENAME}" "${POOL_HOTKEY_SK_FILENAME}" "${POOL_HOTKEY_VK_FILENAME}" "${POOL_OPCERT_COUNTER_FILENAME}"; then # ${pool_name} populated by selectPool function
       waitForInput && continue
     fi
 
-    if ! rotatePoolKeys "${pool_name}"; then
+    if ! rotatePoolKeys; then
       waitForInput && continue
     fi
 
@@ -2619,6 +2699,8 @@ EOF
     println " >> POOL >> DECRYPT"
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     echo
+    
+    [[ ! $(ls -A "${POOL_FOLDER}" 2>/dev/null) ]] && println "${FG_YELLOW}No pools available!${NC}" && waitForInput && continue
 
     println "DEBUG" "# Select pool to decrypt"
     if ! selectPool "all"; then # ${pool_name} populated by selectPool function
@@ -2673,6 +2755,8 @@ EOF
     println " >> POOL >> ENCRYPT"
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     echo
+    
+    [[ ! $(ls -A "${POOL_FOLDER}" 2>/dev/null) ]] && println "${FG_YELLOW}No pools available!${NC}" && waitForInput && continue
 
     println "DEBUG" "# Select pool to encrypt"
     if ! selectPool "all"; then # ${pool_name} populated by selectPool function
@@ -2737,88 +2821,18 @@ EOF
   println " >> TRANSACTION"
   println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
   println "OFF" " Handle Funds\n\n"\
-" ) Witness - Step 1. witness a tx with signing keys\n"\
-" ) Sign    - Step 2. sign tx with created witnesses or hw sign keys\n"\
-" ) Submit  - Step 3. submit signed tx to blockchain\n"\
+" ) Sign    - witness/sign offline tx with signing keys\n"\
+" ) Submit  - submit signed offline tx to blockchain\n"\
 "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
   println "DEBUG" " Select transaction operation\n"
-  select_opt "[w] Witness" "[s] Sign" "[t] Submit" "[h] Home"
+  select_opt "[s] Sign" "[t] Submit" "[h] Home"
   case $? in
-    0) SUBCOMMAND="witness" ;;
-    1) SUBCOMMAND="sign" ;;
-    2) SUBCOMMAND="submit" ;;
-    3) continue ;;
+    0) SUBCOMMAND="sign" ;;
+    1) SUBCOMMAND="submit" ;;
+    2) continue ;;
   esac
 
   case $SUBCOMMAND in
-    witness)
-    
-    clear
-    println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    println " >> TRANSACTION >> WITNESS"
-    println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-    echo
-    
-    [[ ${ENABLE_DIALOG} = "true" ]] && println "DEBUG" "Enter path for Tx file to witness" && waitForInput "Press any key to open the file explorer"
-    fileDialog 0 "Enter path for Tx file to witness"
-    println "DEBUG" "${FG_CYAN}${file}${NC}\n"
-    tx_raw=${file}
-    [[ -z "${tx_raw}" ]] && continue
-    if [[ ! -f "${tx_raw}" ]]; then
-      println "ERROR" "${FG_RED}ERROR${NC}: file not found: ${tx_raw}"
-      waitForInput && continue
-    fi
-    
-    println "DEBUG" "# Witness the transaction with all keys needed"
-    echo
-    witness_files=()
-    [[ ${ENABLE_DIALOG} = "true" ]] && println "DEBUG" "Enter path to signing key files" && waitForInput "Press any key to open the file explorer"
-    while true; do
-      fileDialog 0 "Enter path to signing key file" "${WALLET_FOLDER}/"
-      if [[ -z "${file}" ]]; then
-        println "${FG_YELLOW}EMPTY${NC}: no file selected, how do you want to proceed?"
-      elif [[ ! -f "${file}" ]]; then
-        println "ERROR" "${FG_RED}ERROR${NC}: file not found, please try again! [${file}]"
-      else
-        if witnessTx "${tx_raw}" "${file}"; then
-          println "Tx file successfully witnessed and available at: ${FG_CYAN}${tx_witness}${NC}"
-          witness_files+=( "${tx_witness}" )
-        fi
-      fi
-      println "DEBUG" "Add more keys?"
-      select_opt "[n] No" "[y] Yes" "[Esc] Cancel"
-      case $? in
-        0) echo && break ;;
-        1) : ;;
-        2) continue 2 ;;
-      esac
-    done
-
-    if [[ ${#witness_files[@]} -gt 0 ]]; then
-      println "DEBUG" "Automatically sign tx using created witness files?"
-      select_opt "[y] Yes" "[n] No" "[h] Home"
-      case $? in
-        0) tx_witness_files=( "${witness_files[@]}" )
-           if signTx "${tx_raw}"; then
-             echo
-             println "Tx file successfully signed and available at: ${FG_CYAN}${tx_signed}${NC}"
-             println "DEBUG" "Transfer file to online CNTools and use 'Submit' option to submit transaction to blockchain"
-           fi
-           ;;
-        1) echo
-           println "Tx file successfully witnessed with ${FG_CYAN}${witness_cnt}${NC} signing keys"
-           println "DEBUG" "Next step is to sign the tx with created witness files using 'Sign' option"
-           ;;
-        3) continue ;;
-      esac
-    else
-      println "${FG_RED}No witness files created!${NC}"
-    fi
-  
-    waitForInput && continue
-
-    ;; ###################################################################
-    
     sign)
     
     clear
@@ -2826,74 +2840,164 @@ EOF
     println " >> TRANSACTION >> SIGN"
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     echo
-    [[ ${ENABLE_DIALOG} = "true" ]] && println "DEBUG" "Enter path for Tx file to sign" && waitForInput "Press any key to open the file explorer"
-    fileDialog 0 "Enter path for Tx file to sign"
+    [[ ${ENABLE_DIALOG} = "true" ]] && println "DEBUG" "Enter path to offline tx file to sign" && waitForInput "Press any key to open the file explorer"
+    fileDialog 0 "Enter path to offline tx file to sign" "${TMP_FOLDER}/"
     println "DEBUG" "${FG_CYAN}${file}${NC}\n"
-    tx_raw=${file}
-    [[ -z "${tx_raw}" ]] && continue
-    if [[ ! -f "${tx_raw}" ]]; then
-      println "ERROR" "${FG_RED}ERROR${NC}: file not found: ${tx_raw}"
+    offline_tx=${file}
+    [[ -z "${offline_tx}" ]] && continue
+    if [[ ! -f "${offline_tx}" ]]; then
+      println "ERROR" "${FG_RED}ERROR${NC}: file not found: ${offline_tx}"
       waitForInput && continue
+    elif ! offlineJSON=$(jq -erc . "${offline_tx}"); then
+      println "ERROR" "${FG_RED}ERROR${NC}: invalid JSON file: ${offline_tx}"
+      waitForInput && continue
+    fi
+    
+    if ! otx_type="$(jq -er '.type' <<< ${offlineJSON})"; then println "ERROR" "${FG_RED}ERROR${NC}: field 'type' not found in: ${offline_tx}" && waitForInput && continue; fi
+    if ! otx_date_created="$(jq -er '."date-created"' <<< ${offlineJSON})"; then println "ERROR" "${FG_RED}ERROR${NC}: field 'date-created' not found in: ${offline_tx}" && waitForInput && continue; fi
+    if ! otx_date_expire="$(jq -er '."date-expire"' <<< ${offlineJSON})"; then println "ERROR" "${FG_RED}ERROR${NC}: field 'date-expire' not found in: ${offline_tx}" && waitForInput && continue; fi
+    if ! otx_txFee=$(jq -er '.txFee' <<< ${offlineJSON}); then println "ERROR" "${FG_RED}ERROR${NC}: field 'txFee' not found in: ${offline_tx}" && waitForInput && continue; fi
+    if ! otx_txBody=$(jq -er '.txBody' <<< ${offlineJSON}); then println "ERROR" "${FG_RED}ERROR${NC}: field 'txBody' not found in: ${offline_tx}" && waitForInput && continue; fi
+    echo -e "${otx_txBody}" > "${TMP_FOLDER}"/tx.raw
+    [[ $(jq -r '."signed-txBody" | length' <<< ${offlineJSON}) -gt 0 ]] && println "ERROR" "${FG_RED}ERROR${NC}: transaction already signed, please submit transaction to complete!" && waitForInput && continue
+    
+    println "DEBUG" "Transaction type : ${FG_CYAN}${otx_type}${NC}"
+    if wallet_name=$(jq -er '."wallet-name"' <<< ${offlineJSON}); then 
+      println "DEBUG" "Transaction fee  : ${FG_CYAN}$(formatLovelace ${otx_txFee})${NC} Ada, payed by ${FG_GREEN}${wallet_name}${NC}"
+      [[ $(cat "${WALLET_FOLDER}/${wallet_name}/${WALLET_PAY_ADDR_FILENAME}" 2>/dev/null) = "${addr}" ]] && wallet_source="enterprise" || wallet_source="base"
+    else
+      println "DEBUG" "Transaction fee  : ${FG_CYAN}$(formatLovelace ${otx_txFee})${NC} Ada"
+    fi
+    println "DEBUG" "Created          : ${FG_CYAN}$(date '+%F %T %Z' --date="${otx_date_created}")${NC}"
+    if [[ $(date '+%s' --date="${otx_date_expire}") -lt $(date '+%s') ]]; then
+      println "DEBUG" "Expire           : ${FG_RED}$(date '+%F %T %Z' --date="${otx_date_expire}")${NC}"
+      println "ERROR" "\n${FG_RED}ERROR${NC}: offline transaction expired!  please create a new one with long enough Time To Live (TTL)"
+      waitForInput && continue
+    else
+      println "DEBUG" "Expire           : ${FG_CYAN}$(date '+%F %T %Z' --date="${otx_date_expire}")${NC}"
     fi
     
     tx_witness_files=()
     tx_sign_files=()
     
-    println "DEBUG" "Sign transaction using a hardware wallet?"
-    select_opt "[n] No" "[y] Yes" "[Esc] Cancel"
-    case $? in
-      0) sign_type="witness" ;;
-      1) println "DEBUG" "Is the transaction a pool registration, modification or de-registration?"
-         select_opt "[n] No" "[y] Yes" "[Esc] Cancel"
-         case $? in
-           0) sign_type="sign" ;;
-           1) println "ERROR" "${FG_RED}ERROR${NC}: please witness the transaction using hardware wallet instead!"
-              waitForInput && continue
-              ;;
-           2) continue ;;
-         esac
-         ;;
-      2) continue ;;
+    case "${otx_type}" in
+      "Wallet Registration"|"Wallet De-Registration"|"Payment"|"Wallet Delegation"|"Wallet Rewards Withdrawal"|"Pool De-Registration"|"Metadata")
+        [[ ${otx_type} = "Wallet De-Registration" ]] && println "DEBUG" "\nAmount returned  : ${FG_CYAN}$(formatLovelace $(jq -r '."amount-returned"' <<< ${offlineJSON}))${NC} Ada"
+        [[ ${otx_type} = "Payment" ]] && println "DEBUG" "\nSource addr      : ${FG_CYAN}$(jq -r '."source-address"' <<< ${offlineJSON})${NC}"
+        [[ ${otx_type} = "Payment" ]] && println "DEBUG" "Amount           : ${FG_CYAN}$(formatLovelace $(jq -r '.amount' <<< ${offlineJSON}))${NC} Ada"
+        [[ ${otx_type} = "Payment" ]] && println "DEBUG" "Destination addr : ${FG_CYAN}$(jq -r '."destination-address"' <<< ${offlineJSON})${NC}"
+        [[ ${otx_type} = "Wallet Rewards Withdrawal" ]] && println "DEBUG" "\nRewards          : ${FG_CYAN}$(formatLovelace $(jq -r '.rewards' <<< ${offlineJSON}))${NC} Ada"
+        [[ ${otx_type} = "Pool De-Registration" ]] && println "DEBUG" "\nPool name        : ${FG_CYAN}$(jq -r '."pool-name"' <<< ${offlineJSON})${NC}"
+        [[ ${otx_type} = "Pool De-Registration" ]] && println "DEBUG" "Ticker           : ${FG_CYAN}$(jq -r '."pool-ticker"' <<< ${offlineJSON})${NC}"
+        [[ ${otx_type} = "Pool De-Registration" ]] && println "DEBUG" "To be retired    : epoch ${FG_CYAN}$(jq -r '."retire-epoch"' <<< ${offlineJSON})${NC}"
+        [[ ${otx_type} = "Metadata" ]] && println "DEBUG" "\nMetadata         :\n$(jq -r '.metadata' <<< ${offlineJSON})\n"
+        for otx_signing_file in $(jq -r '."signing-file"[] | @base64' <<< "${offlineJSON}"); do
+          _jq() { base64 -d <<< ${otx_signing_file} | jq -r "${1}"; }
+          otx_signing_name=$(_jq '.name')
+          println "DEBUG" "\n# Sign the transaction with: ${FG_CYAN}${otx_signing_name}${NC}"
+          [[ ${ENABLE_DIALOG} = "true" ]] && waitForInput "Press any key to open the file explorer"
+          [[ ${otx_signing_name} = "Wallet "* ]] && dialog_start_path="${WALLET_FOLDER}" || dialog_start_path="${POOL_FOLDER}"
+          fileDialog 0 "Enter path to ${otx_signing_name}" "${dialog_start_path}/"
+          [[ ! -f "${file}" ]] && println "ERROR" "${FG_RED}ERROR${NC}: file not found: ${file}" && waitForInput && continue 2
+          otx_vkey_cborHex="$(_jq '.vkey.cborHex')"
+          if [[ $(jq -r '.description' "${file}") = *"Hardware"* ]]; then
+            if ! grep -q "${otx_vkey_cborHex:4}" "${file}"; then # strip 5820 prefix
+              println "ERROR" "${FG_RED}ERROR${NC}: signing key provided doesn't match with verification key in offline transaction for: ${otx_signing_name}"
+              println "ERROR" "Provided hardware signing key's verification cborXPubKeyHex: $(jq -r .cborXPubKeyHex "${file}")"
+              println "ERROR" "Transaction verification cborHex: ${otx_vkey_cborHex:4}"
+              waitForInput && continue 2
+            fi
+          else
+            println "ACTION" "${CCLI} key verification-key --signing-key-file ${file} --verification-key-file ${TMP_FOLDER}/vkey.tmp"
+            if ! ${CCLI} key verification-key --signing-key-file "${file}" --verification-key-file "${TMP_FOLDER}"/vkey.tmp; then waitForInput && continue 2; fi
+            if [[ ${otx_vkey_cborHex} != $(jq -r .cborHex "${TMP_FOLDER}"/vkey.tmp) ]]; then
+              println "ERROR" "${FG_RED}ERROR${NC}: signing key provided doesn't match with verification key in offline transaction for: ${otx_signing_name}"
+              println "ERROR" "Provided signing key's verification cborHex: $(jq -r .cborHex "${TMP_FOLDER}"/vkey.tmp)"
+              println "ERROR" "Transaction verification cborHex: ${otx_vkey_cborHex}"
+              waitForInput && continue 2
+            fi
+          fi
+          println "DEBUG" "${FG_GREEN}Successfully added!${NC}"
+          tx_sign_files+=( "${file}" )
+        done
+        if [[ ${#tx_sign_files[@]} -gt 0 ]]; then
+          if ! signTx "${TMP_FOLDER}"/tx.raw "${tx_sign_files[@]}"; then waitForInput && continue; fi
+          echo
+          if jq ". += { \"signed-txBody\": $(jq -c . "${tx_signed}") }" <<< "${offlineJSON}" > "${offline_tx}"; then
+            println "Offline transaction successfully signed, please move ${offline_tx} back to online node and submit before ${FG_CYAN}$(date '+%F %T %Z' --date="${otx_date_expire}")${NC}!"
+          else
+            println "ERROR" "${FG_RED}ERROR${NC}: failed to write signed tx body to offline transaction file!"
+          fi
+        else
+          println "ERROR" "\n${FG_YELLOW}WARN${NC}: no signing keys added!"
+        fi
+        ;;
+      "Pool Registration"|"Pool Update")
+        echo
+        println "DEBUG" "Pool name        : ${FG_CYAN}$(jq -r '."pool-metadata".name' <<< ${offlineJSON})${NC}"
+        println "DEBUG" "Ticker           : ${FG_CYAN}$(jq -r '."pool-metadata".ticker' <<< ${offlineJSON})${NC}"
+        println "DEBUG" "Pledge           : ${FG_CYAN}$(formatAda $(jq -r '."pool-pledge"' <<< ${offlineJSON}))${NC} Ada"
+        println "DEBUG" "Margin           : ${FG_CYAN}$(jq -r '."pool-margin"' <<< ${offlineJSON})${NC} %"
+        println "DEBUG" "Cost             : ${FG_CYAN}$(formatAda $(jq -r '."pool-cost"' <<< ${offlineJSON}))${NC} Ada"
+        for otx_signing_file in $(jq -r '."signing-file"[] | @base64' <<< "${offlineJSON}"); do
+          _jq() { base64 -d <<< ${otx_signing_file} | jq -r "${1}"; }
+          otx_signing_name=$(_jq '.name')
+          for otx_witness in $(jq -r '.witness[] | @base64' <<< "${offlineJSON}"); do
+            __jq() { base64 -d <<< ${otx_witness} | jq -r "${1}"; }
+            [[ $(_jq '.name') = $(__jq '.name') ]] && continue 2 # offline transaction already witnessed by this signing key
+          done
+          println "DEBUG" "\nDo you want to sign ${otx_type} with: ${FG_CYAN}${otx_signing_name}${NC} ?"
+          select_opt "[y] Yes" "[n] No"
+          case $? in
+            0) [[ ${ENABLE_DIALOG} = "true" ]] && waitForInput "Press any key to open the file explorer"
+               [[ ${otx_signing_name} = "Wallet "* ]] && dialog_start_path="${WALLET_FOLDER}" || dialog_start_path="${POOL_FOLDER}"
+               fileDialog 0 "Enter path to ${otx_signing_name}" "${dialog_start_path}/"
+               [[ ! -f "${file}" ]] && println "ERROR" "${FG_RED}ERROR${NC}: file not found: ${file}" && waitForInput && continue 2
+               otx_vkey_cborHex="$(_jq '.vkey.cborHex')"
+               if [[ $(jq -r '.description' "${file}") = *"Hardware"* ]]; then
+                 if ! grep -e "${otx_vkey_cborHex:4}" "${file}"; then # strip 5820 prefix
+                   println "ERROR" "${FG_RED}ERROR${NC}: signing key provided doesn't match with verification key in offline transaction for: ${otx_signing_name}"
+                   println "ERROR" "Provided hardware signing key's verification cborXPubKeyHex: $(jq -r .cborXPubKeyHex "${file}")"
+                   println "ERROR" "Transaction verification cborHex: ${otx_vkey_cborHex:4}"
+                   waitForInput && continue 2
+                 fi
+               else
+                 println "ACTION" "${CCLI} key verification-key --signing-key-file ${file} --verification-key-file ${TMP_FOLDER}/vkey.tmp"
+                 if ! ${CCLI} key verification-key --signing-key-file "${file}" --verification-key-file "${TMP_FOLDER}"/vkey.tmp; then waitForInput && continue 2; fi
+                 if [[ ${otx_vkey_cborHex} != $(jq -r .cborHex "${TMP_FOLDER}"/vkey.tmp) ]]; then
+                   println "ERROR" "${FG_RED}ERROR${NC}: signing key provided doesn't match with verification key in offline transaction for: ${otx_signing_name}"
+                   println "ERROR" "Provided signing key's verification cborHex: $(jq -r .cborHex "${TMP_FOLDER}"/vkey.tmp)"
+                   println "ERROR" "Transaction verification cborHex: ${otx_vkey_cborHex}"
+                   waitForInput && continue 2
+                 fi
+               fi
+               if ! witnessTx "${TMP_FOLDER}/tx.raw" "${file}"; then waitForInput && continue 2; fi
+               if ! offlineJSON=$(jq ".witness += [{ name: \"${otx_signing_name}\", witnessBody: $(jq -c . "${tx_witness_files[0]}") }]" <<< ${offlineJSON}); then return 1; fi
+               ;;
+            1) continue ;;
+          esac
+        done
+        echo
+        if [[ $(jq -r '."signing-file" | length' <<< "${offlineJSON}") -eq $(jq -r '.witness | length' <<< "${offlineJSON}") ]]; then # witnessed by all signing keys
+          for otx_witness in $(jq -r '.witness[] | @base64' <<< "${offlineJSON}"); do
+            _jq() { base64 -d <<< ${otx_witness} | jq -r "${1}"; }
+            tx_witness="$(mktemp "${TMP_FOLDER}/tx.witness_XXXXXXXXXX")"
+            jq -r . <<< "$(_jq '.witnessBody')" > "${tx_witness}"
+            tx_witness_files+=( "${tx_witness}" )
+          done
+          if ! assembleTx "${TMP_FOLDER}/tx.raw"; then waitForInput && continue; fi
+          if jq ". += { \"signed-txBody\": $(jq -c . "${tx_signed}") }" <<< "${offlineJSON}" > "${offline_tx}"; then
+            println "Offline transaction successfully assembled and signed by all signing keys"
+            println "please move ${offline_tx} back to online node and submit before ${FG_CYAN}$(date '+%F %T %Z' --date="${otx_date_expire}")${NC}!"
+          else
+            println "ERROR" "${FG_RED}ERROR${NC}: failed to write signed tx body to offline transaction file!"
+          fi
+        else
+          println "Offline transaction need to be signed by ${FG_CYAN}$(jq -r '."signing-file" | length' <<< "${offlineJSON}")${NC} signing keys, only signed by ${FG_CYAN}$(jq -r '.witness | length' <<< "${offlineJSON}")${NC} so far!"
+        fi
+        ;;
+      *) println "ERROR" "${FG_RED}ERROR${NC}: unsupported offline tx type: ${otx_type}" && waitForInput && continue ;;
     esac
-    
-    println "DEBUG" "# Sign the transaction with all ${sign_type} files needed"
-    echo
-    [[ ${ENABLE_DIALOG} = "true" ]] && println "DEBUG" "Enter path to ${sign_type} files" && waitForInput "Press any key to open the file explorer"
-    while true; do
-      fileDialog 0 "Enter path to ${sign_type} file" "${WALLET_FOLDER}/"
-      if [[ -z "${file}" ]]; then
-        println "${FG_YELLOW}EMPTY${NC}: no file selected, how do you want to proceed?"
-      elif [[ ! -f "${file}" ]]; then
-        println "ERROR" "${FG_RED}ERROR${NC}: file not found, please try again! [${file}]"
-      else
-        [[ ${sign_type} = "witness" ]] && tx_witness_files+=( "${file}" )
-        [[ ${sign_type} = "sign" ]] && tx_sign_files+=( "${file}" )
-        println "${FG_GREEN}${file}${NC} added!"
-      fi
-      println "DEBUG" "Add more witness files?"
-      select_opt "[n] No" "[y] Yes" "[Esc] Cancel"
-      case $? in
-        0) echo && break ;;
-        1) : ;;
-        2) continue 2 ;;
-      esac
-    done
-
-    if [[ ${#tx_witness_files[@]} -gt 0 ]]; then
-      if signTx "${tx_raw}"; then
-        echo
-        println "Tx file successfully signed and available at: ${FG_CYAN}${tx_signed}${NC}"
-        println "DEBUG" "Transfer file to online CNTools and use 'Submit' option to submit transaction to blockchain"
-      fi
-    elif [[ ${#tx_sign_files[@]} -gt 0 ]]; then
-      if signTx "${tx_raw}" "${tx_sign_files[@]}"; then
-        echo
-        println "Tx file successfully signed and available at: ${FG_CYAN}${tx_signed}${NC}"
-        println "DEBUG" "Transfer file to online CNTools and use 'Submit' option to submit transaction to blockchain"
-      fi
-    else
-      println "ERROR" "${FG_RED}ERROR${NC}: no ${sign_type} files added!"
-    fi
     
     waitForInput && continue
 
@@ -2911,21 +3015,78 @@ EOF
       waitForInput && continue
     fi
     echo
-    [[ ${ENABLE_DIALOG} = "true" ]] && println "DEBUG" "Please enter signed Tx file to submit" && waitForInput "Press any key to open the file explorer"
-    fileDialog 0 "Please enter signed Tx file to submit"
-    println "DEBUG" "${FG_CYAN}${file}${NC}"
-    echo
-    [[ -z "${file}" ]] && continue
-    if [[ ! -f "${file}" ]]; then
-      println "ERROR" "${FG_RED}ERROR${NC}: file not found: ${file}"
+    [[ ${ENABLE_DIALOG} = "true" ]] && println "DEBUG" "Enter path to offline tx file to submit" && waitForInput "Press any key to open the file explorer"
+    fileDialog 0 "Enter path to offline tx file to submit" "${TMP_FOLDER}/"
+    println "DEBUG" "${FG_CYAN}${file}${NC}\n"
+    offline_tx=${file}
+    [[ -z "${offline_tx}" ]] && continue
+    if [[ ! -f "${offline_tx}" ]]; then
+      println "ERROR" "${FG_RED}ERROR${NC}: file not found: ${offline_tx}"
+      waitForInput && continue
+    elif ! offlineJSON=$(jq -erc . "${offline_tx}"); then
+      println "ERROR" "${FG_RED}ERROR${NC}: invalid JSON file: ${offline_tx}"
       waitForInput && continue
     fi
-    echo
-
-    if submitTx "${file}"; then
-      echo
-      println "${FG_CYAN}${file}${NC} successfully submitted!"
+    
+    if ! otx_type=$(jq -er '.type' <<< ${offlineJSON}); then println "ERROR" "${FG_RED}ERROR${NC}: field 'type' not found in: ${offline_tx}" && waitForInput && continue; fi
+    if ! otx_date_created=$(jq -er '."date-created"' <<< ${offlineJSON}); then println "ERROR" "${FG_RED}ERROR${NC}: field 'date-created' not found in: ${offline_tx}" && waitForInput && continue; fi
+    if ! otx_date_expire=$(jq -er '."date-expire"' <<< ${offlineJSON}); then println "ERROR" "${FG_RED}ERROR${NC}: field 'date-expire' not found in: ${offline_tx}" && waitForInput && continue; fi
+    if ! otx_txFee=$(jq -er '.txFee' <<< ${offlineJSON}); then println "ERROR" "${FG_RED}ERROR${NC}: field 'txFee' not found in: ${offline_tx}" && waitForInput && continue; fi
+    if ! otx_signed_txBody=$(jq -er '."signed-txBody"' <<< ${offlineJSON}); then println "ERROR" "${FG_RED}ERROR${NC}: field 'signed-txBody' not found in: ${offline_tx}" && waitForInput && continue; fi
+    [[ $(jq 'length' <<< ${otx_signed_txBody}) -eq 0 ]] && println "ERROR" "${FG_RED}ERROR${NC}: transaction not signed, please sign transaction first!" && waitForInput && continue
+    
+    println "DEBUG" "Transaction type : ${FG_CYAN}${otx_type}${NC}"
+    if jq -er '."wallet-name"' &>/dev/null <<< ${offlineJSON}; then 
+      println "DEBUG" "Transaction fee  : ${FG_CYAN}$(formatLovelace ${otx_txFee})${NC} Ada, payed by ${FG_GREEN}$(jq -r '."wallet-name"' <<< ${offlineJSON})${NC}"
+    else
+      println "DEBUG" "Transaction fee  : ${FG_CYAN}$(formatLovelace ${otx_txFee})${NC} Ada"
     fi
+    println "DEBUG" "Created          : ${FG_CYAN}$(date '+%F %T %Z' --date="${otx_date_created}")${NC}"
+    if [[ $(date '+%s' --date="${otx_date_expire}") -lt $(date '+%s') ]]; then
+      println "DEBUG" "Expire           : ${FG_RED}$(date '+%F %T %Z' --date="${otx_date_expire}")${NC}"
+      println "ERROR" "\n${FG_RED}ERROR${NC}: offline transaction expired!  please create a new one with long enough Time To Live (TTL)"
+      waitForInput && continue
+    else
+      println "DEBUG" "Expire           : ${FG_CYAN}$(date '+%F %T %Z' --date="${otx_date_expire}")${NC}"
+    fi
+    
+    case "${otx_type}" in
+      "Wallet Registration"|"Wallet De-Registration"|"Payment"|"Wallet Delegation"|"Wallet Rewards Withdrawal"|"Pool De-Registration"|"Metadata"|"Pool Registration"|"Pool Update")
+        [[ ${otx_type} = "Wallet De-Registration" ]] && println "DEBUG" "\nAmount returned  : ${FG_CYAN}$(formatLovelace $(jq -r '."amount-returned"' <<< ${offlineJSON}))${NC} Ada"
+        [[ ${otx_type} = "Payment" ]] && println "DEBUG" "\nSource addr      : ${FG_CYAN}$(jq -r '."source-address"' <<< ${offlineJSON})${NC}"
+        [[ ${otx_type} = "Payment" ]] && println "DEBUG" "Amount           : ${FG_CYAN}$(formatLovelace $(jq -r '.amount' <<< ${offlineJSON}))${NC} Ada"
+        [[ ${otx_type} = "Payment" ]] && println "DEBUG" "Destination addr : ${FG_CYAN}$(jq -r '."destination-address"' <<< ${offlineJSON})${NC}"
+        [[ ${otx_type} = "Wallet Rewards Withdrawal" ]] && println "DEBUG" "\nRewards          : ${FG_CYAN}$(formatLovelace $(jq -r '.rewards' <<< ${offlineJSON}))${NC} Ada"
+        [[ ${otx_type} = "Pool De-Registration" ]] && println "DEBUG" "\nPool name        : ${FG_CYAN}$(jq -r '."pool-name"' <<< ${offlineJSON})${NC}"
+        [[ ${otx_type} = "Pool De-Registration" ]] && println "DEBUG" "Ticker           : ${FG_CYAN}$(jq -r '."pool-ticker"' <<< ${offlineJSON})${NC}"
+        [[ ${otx_type} = "Pool De-Registration" ]] && println "DEBUG" "To be retired    : epoch ${FG_CYAN}$(jq -r '."retire-epoch"' <<< ${offlineJSON})${NC}"
+        [[ ${otx_type} = "Metadata" ]] && println "DEBUG" "\nMetadata         :\n$(jq -r '.metadata' <<< ${offlineJSON})\n"
+        [[ ${otx_type} = "Pool Registration" || ${otx_type} = "Pool Update" ]] && println "DEBUG" "\nPool name        : ${FG_CYAN}$(jq -r '."pool-metadata".name' <<< ${offlineJSON})${NC}"
+        [[ ${otx_type} = "Pool Registration" || ${otx_type} = "Pool Update" ]] && println "DEBUG" "Ticker           : ${FG_CYAN}$(jq -r '."pool-metadata".ticker' <<< ${offlineJSON})${NC}"
+        [[ ${otx_type} = "Pool Registration" || ${otx_type} = "Pool Update" ]] && println "DEBUG" "Pledge           : ${FG_CYAN}$(formatAda $(jq -r '."pool-pledge"' <<< ${offlineJSON}))${NC} Ada"
+        [[ ${otx_type} = "Pool Registration" || ${otx_type} = "Pool Update" ]] && println "DEBUG" "Margin           : ${FG_CYAN}$(jq -r '."pool-margin"' <<< ${offlineJSON})${NC} %"
+        [[ ${otx_type} = "Pool Registration" || ${otx_type} = "Pool Update" ]] && println "DEBUG" "Cost             : ${FG_CYAN}$(formatAda $(jq -r '."pool-cost"' <<< ${offlineJSON}))${NC} Ada"
+        tx_signed="${TMP_FOLDER}/tx.signed_$(date +%s)"
+        println "DEBUG" "\nProceed to submit transaction?"
+        select_opt "[y] Yes" "[n] No"
+        case $? in
+          0) : ;;
+          1) continue ;;
+        esac
+        echo -e "${otx_signed_txBody}" > "${tx_signed}"
+        if ! submitTx "${tx_signed}"; then waitForInput && continue; fi
+        echo
+        println "Offline transaction successfully submitted and set to be included in next block!"
+        echo 
+        println "DEBUG" "Delete submitted offline transaction file?"
+        select_opt "[y] Yes" "[n] No"
+        case $? in
+          0) rm -f "${offline_tx}" ;;
+          1) : ;;
+        esac
+        ;;
+      *) println "ERROR" "${FG_RED}ERROR${NC}: unsupported offline tx type: ${otx_type}" && waitForInput && continue ;;
+    esac
     
     waitForInput && continue
 
@@ -2941,6 +3102,8 @@ EOF
   println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
   println " >> FUNDS >> POST METADATA"
   println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+  
+  [[ ! $(ls -A "${WALLET_FOLDER}" 2>/dev/null) ]] && echo && println "${FG_YELLOW}No wallets available to pay for transaction fee!${NC}" && waitForInput && continue
 
   if [[ ${CNTOOLS_MODE} = "OFFLINE" ]]; then
     println "ERROR" "${FG_RED}ERROR${NC}: CNTools started in offline mode, option not available!"
@@ -3014,10 +3177,20 @@ EOF
     if ! selectWallet "balance" "${WALLET_PAY_SK_FILENAME}"; then # ${wallet_name} populated by selectWallet function
       [[ "${dir_name}" != "[Esc] Cancel" ]] && waitForInput; continue
     fi
+    getWalletType ${wallet_name}
+    case $? in
+      0) println "ERROR" "${FG_RED}ERROR${NC}: please use a CLI wallet to pay for metadata transaction fee!" && waitForInput && continue ;;
+      2) println "ERROR" "${FG_RED}ERROR${NC}: signing keys encrypted, please decrypt before use!" && waitForInput && continue ;;
+      3) println "ERROR" "${FG_RED}ERROR${NC}: payment and/or stake signing keys missing from wallet!" && waitForInput && continue ;;
+    esac
   else
     if ! selectWallet "balance"; then # ${wallet_name} populated by selectWallet function
       [[ "${dir_name}" != "[Esc] Cancel" ]] && waitForInput; continue
     fi
+    getWalletType ${wallet_name}
+    case $? in
+      0) println "ERROR" "${FG_RED}ERROR${NC}: please use a CLI wallet to pay for metadata transaction fee!" && waitForInput && continue ;;
+    esac
   fi
   echo
 
@@ -3057,9 +3230,7 @@ EOF
     waitForInput && continue
   fi
 
-  payment_sk_file="${WALLET_FOLDER}/${wallet_name}/${WALLET_PAY_SK_FILENAME}"
-
-  if ! sendMetadata "${addr}" "${payment_sk_file}" "${metafile}" "${metatype}"; then
+  if ! sendMetadata; then
     waitForInput && continue
   fi
 

--- a/scripts/cnode-helper-scripts/rotatePoolKeys.sh
+++ b/scripts/cnode-helper-scripts/rotatePoolKeys.sh
@@ -18,18 +18,18 @@ fi
 pool_name="${1}"
 
 if [[ ! -d "${POOL_FOLDER}/${pool_name}" ]]; then
-  say "${RED}ERROR${NC}: pool folder not found!"
-  say "${POOL_FOLDER}/${pool_name}"
+  echo -e "${RED}ERROR${NC}: pool folder not found!"
+  echo -e "${POOL_FOLDER}/${pool_name}"
   exit 1
 fi
 
-if ! rotatePoolKeys "${pool_name}"; then
-  say "" && exit 1
+if ! rotatePoolKeys; then
+  echo && exit 1
 fi
 
-say ""
-say "Pool KES Keys Updated: ${GREEN}${pool_name}${NC}"
-say "New KES start period: ${start_kes_period}"
-say "KES keys will expire on kes period ${kes_expiration_period}, ${expiration_date}"
-say "Restart your pool node for changes to take effect"
-say ""
+echo
+echo -e "Pool KES Keys Updated: ${GREEN}${pool_name}${NC}"
+echo -e "New KES start period: ${start_kes_period}"
+echo -e "KES keys will expire on kes period ${kes_expiration_period}, ${expiration_date}"
+echo -e "Restart your pool node for changes to take effect"
+echo

--- a/scripts/cnode-helper-scripts/sendADA.sh
+++ b/scripts/cnode-helper-scripts/sendADA.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC1090,SC2086,SC2206,SC2015,SC2154
+# shellcheck disable=SC1090,SC2086,SC2206,SC2015,SC2154,SC2034
 function usage() {
   printf "\n%s\n\n" "Usage: $(basename "$0") <Destination Address> <Amount> <Source Address> <Source Sign Key> [--include-fee]"
   printf "  %-20s\t%s\n" \

--- a/scripts/cnode-helper-scripts/sendADA.sh
+++ b/scripts/cnode-helper-scripts/sendADA.sh
@@ -16,18 +16,18 @@ if [[ $# -lt 4 ]]; then
   usage
 fi
 
-# source env
+# source files
 . "$(dirname $0)"/env
-. "$(dirname $0)"/cntools.library
 . "$(dirname $0)"/cntools.config
+. "$(dirname $0)"/cntools.library
 
 # create temporary directory if missing
 mkdir -p "${TMP_FOLDER}" # Create if missing
 if [[ ! -d "${TMP_FOLDER}" ]]; then
-  echo ""
-  say "${RED}ERROR${NC}: Failed to create directory for temporary files:"
-  say "${TMP_FOLDER}"
-  echo "" && exit 1
+  echo
+  echo -e "${RED}ERROR${NC}: Failed to create directory for temporary files:"
+  echo -e "${TMP_FOLDER}"
+  echo && exit 1
 fi
 
 # start with a clean slate
@@ -35,84 +35,84 @@ rm -f "${TMP_FOLDER}"/*
 
 # Get protocol parameters and save to ${TMP_FOLDER}/protparams.json
 ${CCLI} query protocol-parameters ${ERA_IDENTIFIER} ${PROTOCOL_IDENTIFIER} ${NETWORK_IDENTIFIER} --out-file ${TMP_FOLDER}/protparams.json || {
-  echo ""
-  say "${RED}ERROR${NC}: failed to query protocol parameters, node running and env parameters correct?"
+  echo
+  echo -e "${RED}ERROR${NC}: failed to query protocol parameters, node running and env parameters correct?"
   exit 1
 }
 
 # Handle script arguments
 if [[ ! -f "$1" ]]; then
-  D_ADDR="$1"
+  d_addr="$1"
 else
-  D_ADDR="$(cat $1)"
+  d_addr="$(cat $1)"
 fi
 
 if [[ ! -f "$3" ]]; then
-  S_ADDR="$3"
+  s_addr="$3"
 else
-  S_ADDR="$(cat $3)"
+  s_addr="$(cat $3)"
 fi
 
 if [[ -f "$4" ]]; then 
-  S_SKEY="$4" 
+  payment_sk_file="$4" 
 else
-  say "${RED}ERROR${NC}: Source Sign file(skey) not found!"
-  say "$4"
-  echo "" && exit 1
+  echo -e "${RED}ERROR${NC}: Source Sign file(skey) not found!"
+  echo -e "$4"
+  echo && exit 1
 fi
 
 if [[ $# -eq 5 ]]; then
-  [[ $5 = "--include-fee" ]] && INCL_FEE="yes" || usage
+  [[ $5 = "--include-fee" ]] && include_fee="yes" || usage
 else
-  INCL_FEE="no"
+  include_fee="no"
 fi
 
-getBalance ${S_ADDR}
+getBalance ${s_addr}
 if [[ ${lovelace} -gt 0 ]]; then
-  say "$(printf "\n%s\t${CYAN}%s${NC} ADA" "Funds in source wallet:"  "$(formatLovelace ${lovelace})")" "log"
+  echo -e "$(printf "\n%s\t${CYAN}%s${NC} ADA" "Funds in source wallet:"  "$(formatLovelace ${lovelace})")" "log"
 else
-  say "${RED}ERROR${NC}: no funds available in source address"
-  echo "" && exit 1
+  echo -e "${RED}ERROR${NC}: no funds available in source address"
+  echo && exit 1
 fi
 
-LOVELACE="$2"
-if [[ ${LOVELACE} != "all" ]]; then
-  if ! ADAtoLovelace "${LOVELACE}" >/dev/null; then
-    echo "" && exit 1
+amount_lovelace="$2"
+if [[ ${amount_lovelace} != "all" ]]; then
+  if ! ADAtoLovelace "${amount_lovelace}" >/dev/null; then
+    echo && exit 1
   fi
-  LOVELACE=$(ADAtoLovelace "${LOVELACE}")
-  if [[ ${LOVELACE} -gt ${lovelace} ]]; then
-    say "${RED}ERROR${NC}: not enough funds available in source address"
-    echo "" && exit 1
+  amount_lovelace=$(ADAtoLovelace "${amount_lovelace}")
+  if [[ ${amount_lovelace} -gt ${lovelace} ]]; then
+    echo -e "${RED}ERROR${NC}: not enough funds available in source address"
+    echo && exit 1
   fi
 else
-  LOVELACE=${lovelace}
-  say "$(printf "\n%s\t${CYAN}%s${NC} ADA" "ADA to send set to total supply:"  "$(formatLovelace ${lovelace})")" "log"
-  INCL_FEE="yes"
+  amount_lovelace=${lovelace}
+  echo -e "$(printf "\n%s\t${CYAN}%s${NC} ADA" "ADA to send set to total supply:"  "$(formatLovelace ${lovelace})")" "log"
+  include_fee="yes"
 fi
 
-if ! sendADA "${D_ADDR}" "${LOVELACE}" "${S_ADDR}" "${S_SKEY}" "${INCL_FEE}"; then
-  echo "" && exit 1
+if ! sendADA; then
+  echo && exit 1
 fi
 
 if ! waitNewBlockCreated; then
-  echo "" && exit 1
+  echo && exit 1
 fi
 
-getBalance ${S_ADDR}
+getBalance ${s_addr}
 
 while [[ ${lovelace} -ne ${newBalance} ]]; do
-  say ""
-  say "${ORANGE}WARN${NC}: Balance mismatch, transaction not included in latest block ($(formatLovelace ${lovelace}) != $(formatLovelace ${newBalance}))"
+  echo
+  echo -e "${ORANGE}WARN${NC}: Balance mismatch, transaction not included in latest block ($(formatLovelace ${lovelace}) != $(formatLovelace ${newBalance}))"
   if ! waitNewBlockCreated; then
     echo "" && exit 1
   fi
-  getBalance ${S_ADDR}
+  getBalance ${s_addr}
 done
 
-say "$(printf "\n%s\t\t${CYAN}%s${NC} ADA" "Funds in source wallet:"  "$(formatLovelace ${lovelace})")" "log"
+echo -e "$(printf "\n%s\t\t${CYAN}%s${NC} ADA" "Funds in source wallet:"  "$(formatLovelace ${lovelace})")" "log"
 
-getBalance ${D_ADDR}
-say "$(printf "%s\t${CYAN}%s${NC} ADA" "Funds in destination wallet:"  "$(formatLovelace ${lovelace})")" "log"
+getBalance ${d_addr}
+echo -e "$(printf "%s\t${CYAN}%s${NC} ADA" "Funds in destination wallet:"  "$(formatLovelace ${lovelace})")" "log"
 
-say "\n## Finished! ##\n"
+echo -e "\n## Finished! ##\n"


### PR DESCRIPTION
Changelog below include previous commits from #674
Commit also include a new env doc page that explains the purpose of the common env file as well as a general update of all the different script docs.
External scripts that rely on cntools.library updated.

-----------------------
## [7.0.0] - 2021-01-XX
Though mostly unchanged in the user interface, this is a mayor update with most of the code re-written/touched in the back-end.
Only the most noticeable changes added to changelog.

##### Added
- HW Wallet support through Vacuumlabs cardano-hw-cli (Ledger Nano X/S & Trezor T)
  - Vacuumlabs cardano-hw-cli added as build option to prereqs.sh, option '-w' incl Ledger udev rules. Software from Vacuumlabs and Ledger app still early in development and may contain limitations that require workarounds.
  - Because of HW wallet support, transaction signing has been re-designed. For CLI and HW wallet pool reg, raw tx is first witnessed by all signing keys separately and then assembled and signed instead of signing directly with all signing keys. But for all other HW wallet transactions, signing is done directly without first witnessing.
  - Requires updated Cardano app in Ledger/Trezor set to be released in January 2021 to use in pool registration/modification.
- Option added to disable Dialog for file/dir input in cntools.config

##### Changed
- Logging completely re-designed from the ground. Previous selective logging wasn't very useful. All output(almost) now outputted to both the screen and to a timestamped log file. One log file is created per CNTools session. Old log file archived in logs/archive subfolder and last 10 log files kept, rest is pruned on CNTools startup.
  - DEBUG    : Verbose output, most output printed on screen is logged as debug messages except explicitly disabled, like menu printing.
  - INFO     : Informational and the most important output.
  - ACTION   : e.g cardano-cli executions etc
  - ERROR    : error messages and stderr output
- Verbosity setting in cntools.config removed.
- Offline workflow now use a single JSON transaction file holding all data needed. This allows us to bake in additional data in the JSON file in addition to the tx body to make it much more clear what the offline transaction do. Like signing key verification, transaction data like fee, source wallet, pool name etc. It also lets the user know on offline computer what signing keys is needed to sign the transaction.
  - Sign Tx moved to Transaction >> Sign
  - Submit Tx moved to Transaction >> Submit