### PR TITLE
Add more checks for config

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -5,7 +5,7 @@
     * [Wallet](Build/wallet.md "Cardano Wallet")
     * [DBSync tool](Build/dbsync.md "Cardano DB Sync Tool")
     * [REST](Build/rest.md "Cardano Rest")
-  * [PostgREST](Build/pgrest.md "PostgREST")
+    * [PostgREST](Build/pgrest.md "PostgREST")
   * Scripts
     * [Common env](Scripts/env.md)
     * [CNTools](Scripts/cntools.md)

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -460,6 +460,12 @@ getCurrentKESperiod() {
   echo $(( tip_ref / SLOTS_PER_KES_PERIOD ))
 }
 
+# Description : Calculate expected interval between blocks
+slotInterval() {
+  if [[ -z ${DECENTRALISATION} || $(echo "${DECENTRALISATION} < 0.5" | bc) -eq 1 ]]; then d=0.5; else d=${DECENTRALISATION}; fi
+  echo "(${SLOT_LENGTH} / ${ACTIVE_SLOTS_COEFF} / ${d}) + 0.5" | bc -l | awk '{printf "%.0f\n", $1}'
+}
+
 # Description : Identify current era and set variables accordingly
 getEraIdentifier() {
     if ${CCLI} query protocol-parameters --byron-era ${NETWORK_IDENTIFIER} &>/dev/null; then ERA_IDENTIFIER="--byron-era" && ERA_WITNESS="TxWitness ByronEra"
@@ -477,11 +483,5 @@ if ! getEraIdentifier; then echo "Failed to query protocol-parameters from node,
 
 PROT_PARAMS="$(${CCLI} query protocol-parameters ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} 2>&1)"
 if [[ -n "${PROT_PARAMS}" ]] && ! DECENTRALISATION=$(jq -er .decentralisationParam <<< ${PROT_PARAMS} 2>/dev/null); then DECENTRALISATION=0.5; fi
-
-# Description : Calculate expected interval between blocks
-slotInterval() {
-  if [[ -z ${DECENTRALISATION} || $(echo "${DECENTRALISATION} < 0.5" | bc) -eq 1 ]]; then d=0.5; else d=${DECENTRALISATION}; fi
-  echo "(${SLOT_LENGTH} / ${ACTIVE_SLOTS_COEFF} / ${d}) + 0.5" | bc -l | awk '{printf "%.0f\n", $1}'
-}
 
 return 0

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -26,7 +26,7 @@ CNODE_PORT=6000                                         # Set node port
 #SHELLEY_TRANS_EPOCH=208                                # Override automatic detection of shelley epoch start, e.g 208 for mainnet
 #TG_BOT_TOKEN=""                                        # Uncomment and set to enable telegramSend function. To create your own BOT-token and Chat-Id follow guide at:
 #TG_CHAT_ID=""                                          # https://cardano-community.github.io/guild-operators/#/Scripts/sendalerts
-#USE_EKG="N"                                # Use EKG metrics from the node instead of Promethus. Promethus metrics(default) should yield slightly better performance
+#USE_EKG="N"                                            # Use EKG metrics from the node instead of Promethus. Promethus metrics(default) should yield slightly better performance
 
 #WALLET_FOLDER="${CNODE_HOME}/priv/wallet"              # Root folder for Wallets
 #POOL_FOLDER="${CNODE_HOME}/priv/pool"                  # Root folder for Pools
@@ -144,6 +144,12 @@ fi
 if ! jq -r . "${CONFIG}" >/dev/null 2>&1; then
   echo "Could not parse ${CONFIG} file in JSON format, please double-check the syntax of your config, or simply download it from guild-operators repository!"
   return 1
+elif [[ "$(jq -r .TraceChainDb ${CONFIG})" != "true" ]]; then
+  echo "The ${CONFIG} file suggests that you have set TraceChainDb parameter to false. Please change it to true, as it is required to extract statistics from node."
+  return 1
+elif [[ "$(jq .options.mapBackends.cardano.node.BlockFetchDecision.peers /opt/cardano/cnode/files/config.json 2>&1)" != "null" ]]; then
+  echo "It seems your ${CONFIG} file was not upgraded from version before cardano-node 1.25.0. Please download it from guild-operators repository!"
+  return 1
 fi
 
 [[ -z ${EKG_TIMEOUT} ]] && EKG_TIMEOUT=3
@@ -158,6 +164,7 @@ else
   echo "Not a valid IP format set for EKG host, please check env file!"
   return 1
 fi
+
 if [[ -z ${EKG_PORT} ]]; then
   if ! EKG_PORT=$(jq -er '.hasEKG' "${CONFIG}" 2>/dev/null); then
     if [[ ${OFFLINE_MODE} = "N" ]]; then
@@ -171,6 +178,7 @@ elif [[ ! ${EKG_PORT} =~ ^[0-9]+$ ]]; then
 fi
 
 if [[ -z ${PROM_HOST} ]]; then PROM_HOST=$(jq -er '.hasPrometheus[0]' "${CONFIG}" 2>/dev/null) || PROM_HOST=127.0.0.1; fi
+
 if [[ ${PROM_HOST} =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
   IFS='.' read -ra PROM_OCTETS <<< ${PROM_HOST}
   if ! [[ ${PROM_OCTETS[0]} -le 255 && ${PROM_OCTETS[1]} -le 255 && ${PROM_OCTETS[2]} -le 255 && ${PROM_OCTETS[3]} -le 255 ]]; then
@@ -198,11 +206,11 @@ if ! GENESIS_JSON=$(jq -er '.ShelleyGenesisFile' "${CONFIG}" 2>/dev/null); then
     if [[ -f "${CNODE_HOME}/files/genesis.json" ]]; then
       GENESIS_JSON="${CNODE_HOME}/files/genesis.json"
     else
-      echo "Could not find shelley genesis file in default location or 'ShelleyGenesisFile' from the node configuration file"
+      echo "Could not find shelley genesis file in default location or 'ShelleyGenesisFile' in ${CONFIG}"
       return 1
     fi
   else
-    echo "Could not get 'ShelleyGenesisFile' from the node configuration file"
+    echo "Could not get 'ShelleyGenesisFile' in ${CONFIG}"
     return 1
   fi
 else
@@ -234,7 +242,17 @@ BLOCKLOG_DB="${BLOCKLOG_DIR}/blocklog.db"
 [[ -z ${BLOCKLOG_TZ} ]] && BLOCKLOG_TZ="UTC"
 [[ -z ${CNODE_PORT} ]] && CNODE_PORT=6000
 
-CNODE_PID=$(pgrep -fn "[c]ardano-node*.*--port ${CNODE_PORT}")
+CNODE_PID=$(pgrep -fn "[c]ardano-node.*.${CONFIG}.*.--port ${CNODE_PORT}")
+
+if [[ -n "${CNODE_PID}" ]]; then
+  if [[ "${USE_EKG}" == "N" ]] && [[ "$(ss -lnpt | grep "${CNODE_PID}," | awk '{print $4}' | cut -d: -f2)" != **"${PROM_PORT}"** ]]; then
+    echo "ERROR: You specified ${PROM_PORT} as your Prometheus port, but it looks like the cardano-node (PID: ${CNODE_PORT} ) is not listening on this port. Please update the config or kill the conflicting process first."
+    exit 1
+  elif [[ "$(ss -lnpt | grep "${CNODE_PID}," | awk '{print $4}' | cut -d: -f2)" != **"${EKG_PORT}"** ]]; then
+    echo "ERROR: You specified ${EKG_PORT} as your EKG port, but it looks like the cardano-node (PID: ${CNODE_PID} ) is not listening on this port. Please update the config or kill the conflicting process first."
+    exit 1
+  fi
+fi
 
 PROTOCOL=$(jq -r .Protocol "${CONFIG}")
 NETWORKID=$(jq -r .networkId ${GENESIS_JSON})

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -147,7 +147,7 @@ if ! jq -r . "${CONFIG}" >/dev/null 2>&1; then
 elif [[ "$(jq -r .TraceChainDb ${CONFIG})" != "true" ]]; then
   echo "The ${CONFIG} file suggests that you have set TraceChainDb parameter to false. Please change it to true, as it is required to extract statistics from node."
   return 1
-elif [[ "$(jq .options.mapBackends.cardano.node.BlockFetchDecision.peers /opt/cardano/cnode/files/config.json 2>&1)" != "null" ]]; then
+elif jq -e .options.mapBackends.\"cardano.node.BlockFetchDecision.peers\" "${CONFIG}" &>/dev/null; then
   echo "It seems your ${CONFIG} file was not upgraded from version before cardano-node 1.25.0. Please download it from guild-operators repository!"
   return 1
 fi

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034,SC2086,SC2230,SC2009,SC2206
+# shellcheck disable=SC2034,SC2086,SC2230,SC2009,SC2206,SC2062
 
 ######################################
 # User Variables - Change as desired #
@@ -141,6 +141,20 @@ if [[ -z "${CONFIG}" ]]; then
   fi
 fi
 
+if command -v "ss" &>/dev/null; then
+  use_lsof='N'
+elif command -v "lsof" &>/dev/null; then
+  use_lsof='Y'
+else
+  echo -e "'ss' and fallback 'lsof' commands are missing, please install using latest prereqs.sh script or with your packet manager of choice.\nhttps://command-not-found.com/ss can be used to check package name to install.\n"
+  return 1
+fi
+
+if ! command -v "jq" &>/dev/null; then
+  echo -e "'jq' command is missing, please install using latest prereqs.sh script of with your packet manager of choice.\nhttps://command-not-found.com/ss can be used to check package name to install.\n"
+  return 1
+fi
+
 if ! jq -r . "${CONFIG}" >/dev/null 2>&1; then
   echo "Could not parse ${CONFIG} file in JSON format, please double-check the syntax of your config, or simply download it from guild-operators repository!"
   return 1
@@ -245,12 +259,16 @@ BLOCKLOG_DB="${BLOCKLOG_DIR}/blocklog.db"
 CNODE_PID=$(pgrep -fn "[c]ardano-node.*.${CONFIG}.*.--port ${CNODE_PORT}")
 
 if [[ -n "${CNODE_PID}" ]]; then
-  if [[ "${USE_EKG}" == "N" ]] && [[ "$(ss -lnpt | grep "${CNODE_PID}," | awk '{print $4}' | cut -d: -f2)" != **"${PROM_PORT}"** ]]; then
-    echo "ERROR: You specified ${PROM_PORT} as your Prometheus port, but it looks like the cardano-node (PID: ${CNODE_PORT} ) is not listening on this port. Please update the config or kill the conflicting process first."
-    exit 1
-  elif [[ "$(ss -lnpt | grep "${CNODE_PID}," | awk '{print $4}' | cut -d: -f2)" != **"${EKG_PORT}"** ]]; then
-    echo "ERROR: You specified ${EKG_PORT} as your EKG port, but it looks like the cardano-node (PID: ${CNODE_PID} ) is not listening on this port. Please update the config or kill the conflicting process first."
-    exit 1
+  if [[ "${USE_EKG}" == "N" ]]; then
+    if { [[ "${use_lsof}" != 'Y' ]] && [[ "$(ss -lnpt | grep "${CNODE_PID}," | awk '{print $4}' | cut -d: -f2)" != **"${PROM_PORT}"** ]]; } || { [[ "${use_lsof}" == 'Y' ]] && [[ "$(lsof -Pnl -i4 +M | grep ${CNODE_PID}.*.LISTEN)" == **"${PROM_PORT}"** ]]; }; then
+      echo "ERROR: You specified ${PROM_PORT} as your Prometheus port, but it looks like the cardano-node (PID: ${CNODE_PID} ) is not listening on this port. Please update the config or kill the conflicting process first."
+      exit 1
+    fi
+  else
+    if { [[ "${use_lsof}" != 'Y' ]] && [[ "$(ss -lnpt | grep "${CNODE_PID}," | awk '{print $4}' | cut -d: -f2)" != **"${EKG_PORT}"** ]]; } || { [[ "${use_lsof}" == 'Y' ]] && [[ "$(lsof -Pnl -i4 +M | grep ${CNODE_PID}.*.LISTEN)" == **"${EKG_PORT}"** ]]; }; then
+      echo "ERROR: You specified ${EKG_PORT} as your EKG port, but it looks like the cardano-node (PID: ${CNODE_PID} ) is not listening on this port. Please update the config or kill the conflicting process first."
+      exit 1
+    fi
   fi
 fi
 

--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -105,14 +105,6 @@ myExit() {
   cleanup "$1"
 }
 
-if command -v "ss" &>/dev/null; then 
-  use_lsof='N'
-elif command -v "lsof" &>/dev/null; then 
-  use_lsof='Y'
-else
-  myExit 1 "'ss' and fallback 'lsof' commands missing, please install using latest prereqs.sh script or with your packet manager of choice.\nhttps://command-not-found.com/ss can be used to check package name to install."
-fi
-
 if ! command -v "tcptraceroute" &>/dev/null; then
   myExit 1 "'tcptraceroute' command missing, please install using latest prereqs.sh script or with your packet manager of choice.\nhttps://command-not-found.com/tcptraceroute can be used to check package name to install."
 fi


### PR DESCRIPTION
- Tracer check for ChainDb
- Ensure old mapping backends have been deleted (prompting for upgrade)
- Add CONFIG to pgrep to grab PID
- If EKG or Prom are specified in config, but they're already in use by another node - we'd often get quite a confusing behaviour depending on network the other node is coming from. Add a check to ensure Prometheus port (if USE_EKG = 'N') is also being listened by CNODE_PID. Same for EKG_PORT if USE_EKG='Y'
- Move ss/lsof/jq check to env instead of gLiveView