### PR TITLE
Consolidate tmp storage between scripts

### DIFF
--- a/scripts/cnode-helper-scripts/balance.sh
+++ b/scripts/cnode-helper-scripts/balance.sh
@@ -16,23 +16,23 @@ else
 fi
 
 function cleanup() {
-  rm -rf "/${TMP_DIR}/fullUtxo.out"
-  rm -rf "/${TMP_DIR}/balance.txt"
+  rm -rf "${TMP_DIR}/fullUtxo.out"
+  rm -rf "${TMP_DIR}/balance.txt"
 }
 
 # start with a clean slate
 cleanup
 
-${CCLI} query utxo ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} --address "${WALLET_ADDR}" > "/${TMP_DIR}/fullUtxo.out"
-tail -n +3 "/${TMP_DIR}/fullUtxo.out" | sort -k3 -nr > "/${TMP_DIR}/balance.txt"
+${CCLI} query utxo ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} --address "${WALLET_ADDR}" > "${TMP_DIR}/fullUtxo.out"
+tail -n +3 "${TMP_DIR}/fullUtxo.out" | sort -k3 -nr > "${TMP_DIR}/balance.txt"
 
 TOTALBALANCE=0
 UTx0_COUNT=0
 
-if [ -s "/${TMP_DIR}/balance.txt" ]; then
+if [ -s "${TMP_DIR}/balance.txt" ]; then
   echo ""
-  head -n 2 "/${TMP_DIR}/fullUtxo.out"
-  head -n 10 "/${TMP_DIR}/balance.txt"
+  head -n 2 "${TMP_DIR}/fullUtxo.out"
+  head -n 10 "${TMP_DIR}/balance.txt"
 fi
 
 while read -r UTxO; do
@@ -43,7 +43,7 @@ while read -r UTxO; do
   UTx0_COUNT=$(( UTx0_COUNT + 1 ))
   TX_IN="${TX_IN} --tx-in ${INADDR}#${IDX}"
   TOTALBALANCE=$(( TOTALBALANCE + BALANCE ))
-done <"/${TMP_DIR}/balance.txt"
+done <"${TMP_DIR}/balance.txt"
 
 [[ ${UTx0_COUNT} -gt 10 ]] && echo "... (top 10 UTx0 with most lovelace)"
 

--- a/scripts/cnode-helper-scripts/balance.sh
+++ b/scripts/cnode-helper-scripts/balance.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC1090,SC2086
-# Only source env if not done already, this script is sourced from other scripts
-[ "$0" = "${BASH_SOURCE[*]}" ] && . "$(dirname "$0")"/env
+
+. "$(dirname $0)"/env
 
 usage() { echo "Usage: $(basename "$0") <address or path to address file>" 1>&2; exit 1; }
 
@@ -16,23 +16,23 @@ else
 fi
 
 function cleanup() {
-  rm -rf /tmp/fullUtxo.out
-  rm -rf /tmp/balance.txt
+  rm -rf "/${TMP_DIR}/fullUtxo.out"
+  rm -rf "/${TMP_DIR}/balance.txt"
 }
 
 # start with a clean slate
 cleanup
 
-${CCLI} query utxo ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} --address "${WALLET_ADDR}" > /tmp/fullUtxo.out
-tail -n +3 /tmp/fullUtxo.out | sort -k3 -nr > /tmp/balance.txt
+${CCLI} query utxo ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} --address "${WALLET_ADDR}" > "/${TMP_DIR}/fullUtxo.out"
+tail -n +3 "/${TMP_DIR}/fullUtxo.out" | sort -k3 -nr > "/${TMP_DIR}/balance.txt"
 
 TOTALBALANCE=0
 UTx0_COUNT=0
 
-if [ -s /tmp/balance.txt ]; then
+if [ -s "/${TMP_DIR}/balance.txt" ]; then
   echo ""
-  head -n 2 /tmp/fullUtxo.out
-  head -n 10 /tmp/balance.txt
+  head -n 2 "/${TMP_DIR}/fullUtxo.out"
+  head -n 10 "/${TMP_DIR}/balance.txt"
 fi
 
 while read -r UTxO; do
@@ -43,7 +43,7 @@ while read -r UTxO; do
   UTx0_COUNT=$(( UTx0_COUNT + 1 ))
   TX_IN="${TX_IN} --tx-in ${INADDR}#${IDX}"
   TOTALBALANCE=$(( TOTALBALANCE + BALANCE ))
-done </tmp/balance.txt
+done <"/${TMP_DIR}/balance.txt"
 
 [[ ${UTx0_COUNT} -gt 10 ]] && echo "... (top 10 UTx0 with most lovelace)"
 

--- a/scripts/cnode-helper-scripts/cncli.sh
+++ b/scripts/cnode-helper-scripts/cncli.sh
@@ -101,9 +101,9 @@ getPoolVrfVkeyCborHex() {
 }
 
 dumpLedgerState() { # getNodeMetrics expected to have been already run
-  ledger_state_file="/${TMP_DIR}/ledger-state_${NWMAGIC}_${epochnum}.json"
+  ledger_state_file="${TMP_DIR}/ledger-state_${NWMAGIC}_${epochnum}.json"
   [[ -n $(find "${ledger_state_file}" -mmin -60 2>/dev/null) ]] && return 0 # no need to continue, we have a fresh(<1h) ledger-state already
-  rm -f "/${TMP_DIR}/ledger-state_"* # remove old ledger dumps before creating a new
+  rm -f "${TMP_DIR}/ledger-state_"* # remove old ledger dumps before creating a new
   if ! timeout -k 5 "${TIMEOUT_LEDGER_STATE}" ${CCLI} query ledger-state ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} --out-file "${ledger_state_file}"; then
     echo "ERROR: ledger dump failed/timed out, increase timeout value"
     [[ -f "${ledger_state_file}" ]] && rm -f "${ledger_state_file}"
@@ -187,7 +187,7 @@ cncliInit() {
     sleep 10
   done
   
-  TMP_DIR="/${TMP_DIR}/cncli"
+  TMP_DIR="${TMP_DIR}/cncli"
   if ! mkdir -p "${TMP_DIR}" 2>/dev/null; then echo "ERROR: Failed to create directory for temporary files: ${TMP_DIR}"; exit 1; fi
   
   [[ ! -f "${CNCLI}" ]] && echo -e "\nERROR: failed to locate cncli executable, please install with 'prereqs.sh'\n" && exit 1
@@ -555,7 +555,7 @@ cncliPTsendtip() {
     echo "ERROR: cardano-node not in PATH, please manually set CCLI in env file"
     exit 1
   fi
-  pt_config="/${TMP_DIR}/$(basename ${CNODE_HOME})-pooltool.json"
+  pt_config="${TMP_DIR}/$(basename ${CNODE_HOME})-pooltool.json"
   bash -c "cat <<-'EOF' > ${pt_config}
 		{
 		  \"api_key\": \"${PT_API_KEY}\",
@@ -577,7 +577,7 @@ cncliPTsendtip() {
 cncliPTsendslots() {
   [[ -z ${POOL_ID} || -z ${POOL_TICKER} || -z ${PT_API_KEY} ]] && echo "'POOL_ID' and/or 'POOL_TICKER' and/or 'PT_API_KEY' not set in $(basename "$0"), exiting!" && exit 1
   # Generate a temporary pooltool config
-  pt_config="/${TMP_DIR}/$(basename ${CNODE_HOME})-pooltool.json"
+  pt_config="${TMP_DIR}/$(basename ${CNODE_HOME})-pooltool.json"
   bash -c "cat <<-'EOF' > ${pt_config}
 		{
 		  \"api_key\": \"${PT_API_KEY}\",

--- a/scripts/cnode-helper-scripts/cncli.sh
+++ b/scripts/cnode-helper-scripts/cncli.sh
@@ -20,7 +20,6 @@
 #SLEEP_RATE=60                            # CNCLI leaderlog/validate: time to wait until next check (in seconds)
 #CONFIRM_SLOT_CNT=600                     # CNCLI validate: require at least these many slots to have passed before validating
 #CONFIRM_BLOCK_CNT=15                     # CNCLI validate: require at least these many blocks on top of minted before validating
-#TIMEOUT_LEDGER_STATE=300                 # CNCLI leaderlog: timeout in seconds for ledger-state query
 #BATCH_AUTO_UPDATE=N                      # Set to Y to automatically update the script if a new version is available without user interaction
 #LEDGER_API=true                          # Use API from api.crypto2099.io in cncli call instead of local ledger-state dump to vastly reduce system resources. ONLY for MainNet network (true|false)
 
@@ -61,7 +60,7 @@ else usage; fi
 ######################################
 
 createBlocklogDB() {
-  if ! mkdir -p "${BLOCKLOG_DIR}"; then echo "ERROR: failed to create directory to store blocklog: ${BLOCKLOG_DIR}" && return 1; fi
+  if ! mkdir -p "${BLOCKLOG_DIR}" 2>/dev/null; then echo "ERROR: failed to create directory to store blocklog: ${BLOCKLOG_DIR}" && return 1; fi
   if [[ ! -f ${BLOCKLOG_DB} ]]; then # create a fresh DB with latest schema
     sqlite3 ${BLOCKLOG_DB} <<-EOF
 			CREATE TABLE blocklog (id INTEGER PRIMARY KEY AUTOINCREMENT, slot INTEGER NOT NULL UNIQUE, at TEXT NOT NULL UNIQUE, epoch INTEGER NOT NULL, block INTEGER NOT NULL DEFAULT 0, slot_in_epoch INTEGER NOT NULL DEFAULT 0, hash TEXT NOT NULL DEFAULT '', size INTEGER NOT NULL DEFAULT 0, status TEXT NOT NULL);
@@ -104,7 +103,7 @@ getPoolVrfVkeyCborHex() {
 dumpLedgerState() { # getNodeMetrics expected to have been already run
   ledger_state_file="/${TMP_DIR}/ledger-state_${NWMAGIC}_${epochnum}.json"
   [[ -n $(find "${ledger_state_file}" -mmin -60 2>/dev/null) ]] && return 0 # no need to continue, we have a fresh(<1h) ledger-state already
-  rm -f /tmp/ledger-state_* # remove old ledger dumps before creating a new
+  rm -f "/${TMP_DIR}/ledger-state_"* # remove old ledger dumps before creating a new
   if ! timeout -k 5 "${TIMEOUT_LEDGER_STATE}" ${CCLI} query ledger-state ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} --out-file "${ledger_state_file}"; then
     echo "ERROR: ledger dump failed/timed out, increase timeout value"
     [[ -f "${ledger_state_file}" ]] && rm -f "${ledger_state_file}"
@@ -188,19 +187,21 @@ cncliInit() {
     sleep 10
   done
   
+  TMP_DIR="/${TMP_DIR}/cncli"
+  if ! mkdir -p "${TMP_DIR}" 2>/dev/null; then echo "ERROR: Failed to create directory for temporary files: ${TMP_DIR}"; exit 1; fi
+  
   [[ ! -f "${CNCLI}" ]] && echo -e "\nERROR: failed to locate cncli executable, please install with 'prereqs.sh'\n" && exit 1
   CNCLI_VERSION="v$(cncli -V | cut -d' ' -f2)"
   if ! versionCheck "1.0.0" "${CNCLI_VERSION}"; then echo "ERROR: cncli ${CNCLI_VERSION} installed, please upgrade to latest version!"; exit 1; fi
   if ! versionCheck "1.4.0" "${CNCLI_VERSION}"; then echo "WARN: cncli ${CNCLI_VERSION} installed, disabling LEDGER_API !! please upgrade to v1.4.0 or newer to enable"; exit 1; fi
   
   [[ -z "${CNCLI_DIR}" ]] && CNCLI_DIR="${CNODE_HOME}/guild-db/cncli"
-  mkdir -p "${CNCLI_DIR}"
+  if ! mkdir -p "${CNCLI_DIR}" 2>/dev/null; then echo "ERROR: Failed to create CNCLI DB directory: ${CNCLI_DIR}"; exit 1; fi
   CNCLI_DB="${CNCLI_DIR}/cncli.db"
   [[ -z "${LEDGER_API}" ]] && LEDGER_API="true"
   [[ -z "${SLEEP_RATE}" ]] && SLEEP_RATE=60
   [[ -z "${CONFIRM_SLOT_CNT}" ]] && CONFIRM_SLOT_CNT=600
   [[ -z "${CONFIRM_BLOCK_CNT}" ]] && CONFIRM_BLOCK_CNT=15
-  [[ -z "${TIMEOUT_LEDGER_STATE}" ]] && TIMEOUT_LEDGER_STATE=300
   [[ -z "${PT_HOST}" ]] && PT_HOST="127.0.0.1"
   [[ -z "${PT_PORT}" ]] && PT_PORT="${CNODE_PORT}"
   if [[ -d "${POOL_DIR}" ]]; then

--- a/scripts/cnode-helper-scripts/cntools.config
+++ b/scripts/cnode-helper-scripts/cntools.config
@@ -1,9 +1,8 @@
 ## CNTOOLS CONFIG ##
-TMP_FOLDER=/tmp/cntools
 TIMEOUT_NO_OF_SLOTS=600 # used when waiting for a new block to be created
-TIMEOUT_LEDGER_STATE=300 # used for querying ledger-state
 
 # log cntools activities (comment or set empty to disable)
+# LOG_DIR set in env file
 CNTOOLS_LOG="${LOG_DIR}/cntools-history.log"
 
 # kes rotation warning (in seconds)

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -18,9 +18,9 @@ CNTOOLS_VERSION="${CNTOOLS_MAJOR_VERSION}.${CNTOOLS_MINOR_VERSION}.${CNTOOLS_PAT
 # Default config values                                    #
 # overriden by values set in cntools.config                #
 ############################################################
-[[ -z ${TMP_FOLDER} ]] && TMP_FOLDER=/tmp/cntools
+TMP_DIR="/${TMP_DIR}/cntools"
+if ! mkdir -p "${TMP_DIR}" 2>/dev/null; then myExit 1 "${FG_RED}ERROR${NC}: Failed to create directory for temporary files: ${TMP_DIR}"; fi
 [[ -z ${TIMEOUT_NO_OF_SLOTS} ]] && TIMEOUT_NO_OF_SLOTS=600
-[[ -z ${TIMEOUT_LEDGER_STATE} ]] && TIMEOUT_LEDGER_STATE=300
 [[ ${SHELLEY_TRANS_FILENAME} =~ ^${CNODE_HOME}/db/ ]] && mkdir -p "${CNODE_HOME}/guild-db" && SHELLEY_TRANS_FILENAME="${CNODE_HOME}/guild-db/shelley_trans_epoch"
 [[ -z ${WALLET_SELECTION_FILTER_LIMIT} ]] && WALLET_SELECTION_FILTER_LIMIT=10
 [[ -z ${KES_ALERT_PERIOD} ]] && KES_ALERT_PERIOD=172800 # default 2 days
@@ -134,10 +134,10 @@ protectionPreRequisites() {
   if ! need_cmd "chattr" &>/dev/null; then
     [[ ${ENABLE_CHATTR} = true ]] && println "ERROR" "chattr command not available but enabled in config, please install or disable in cntools.config and re-run CNTools" && return 1
   elif [[ ${ENABLE_CHATTR} = true ]]; then # chattr available and enabled, make sure sudo access to chattr is enabled
-    touch "${TMP_FOLDER}"/test
+    touch "${TMP_DIR}"/test
     println "DEBUG" "Testing chattr access permission, enter user password if requested..."
-    if ! sudo chattr -i "${TMP_FOLDER}"/test; then
-      rm -f "${TMP_FOLDER}"/test
+    if ! sudo chattr -i "${TMP_DIR}"/test; then
+      rm -f "${TMP_DIR}"/test
       echo
       println "ERROR" "${FG_YELLOW}WARN${NC}: Elevated privileges needed for chattr command used to write protect wallet and pool keys"
       println "ERROR" "Add required sudo permissions or run the following command to add passwordless sudo access to chattr command for '$(whoami)' user"
@@ -145,7 +145,7 @@ protectionPreRequisites() {
       println "ERROR" "echo \"$(whoami) ALL=NOPASSWD: $(command -v chattr)\" | sudo tee /etc/sudoers.d/cntools"
       return 1
     fi
-    rm -f "${TMP_FOLDER}"/test
+    rm -f "${TMP_DIR}"/test
   fi
 }
 
@@ -169,8 +169,8 @@ safeDel() {
 # Command     : dialogSetup
 # Description : set config parameters for dialog formatting
 dialogSetup() {
-  export DIALOGRC="${TMP_FOLDER}"/.dialogrc
-  [[ ! -f ${DIALOGRC} ]] && cat <<-EOF > "${TMP_FOLDER}"/.dialogrc
+  export DIALOGRC="${TMP_DIR}"/.dialogrc
+  [[ ! -f ${DIALOGRC} ]] && cat <<-EOF > "${TMP_DIR}"/.dialogrc
 		# Types of values:
 		#
 		# Number     -  <number>
@@ -230,7 +230,7 @@ dialogSetup() {
 # Description : open a file dialog
 # Parameters  : show help  >  [0=no|1=yes] print dialog help text
 #             : title      >  The dialog title text
-#             : verbosity  >  [optional] Start path when dialog is opened, either dir or file (default: /tmp/)
+#             : verbosity  >  [optional] Start path when dialog is opened, either dir or file (default: ${TMP_DIR}/)
 fileDialog() {
   exec >&6 # normal stdout
   if [[ ${ENABLE_DIALOG} = "false" ]]; then
@@ -238,7 +238,7 @@ fileDialog() {
     return
   fi
   dialogSetup
-  [[ -n $2 ]] && start_path="$2" || start_path="/tmp/"
+  [[ -n $2 ]] && start_path="$2" || start_path="${TMP_DIR}/"
   file=$(dialog --stdout --clear --keep-tite --title "$1" --fselect "${start_path}" $(($(tput lines)-14)) $(($(tput cols)-10)))
   exec >&8 # custom stdout
 }
@@ -246,7 +246,7 @@ fileDialog() {
 # Description : open a directory dialog
 # Parameters  : show help  >  [0=no|1=yes] print dialog help text
 #             : title      >  The dialog title text
-#             : verbosity  >  [optional] Start path when dialog is opened, either dir or file (default: /tmp/)
+#             : verbosity  >  [optional] Start path when dialog is opened, either dir or file (default: ${TMP_DIR}/)
 dirDialog() {
   exec >&6 # normal stdout
   if [[ ${ENABLE_DIALOG} = "false" ]]; then
@@ -254,7 +254,7 @@ dirDialog() {
     return
   fi
   dialogSetup
-  [[ -n $2 ]] && start_path="$2" || start_path="/tmp/"
+  [[ -n $2 ]] && start_path="$2" || start_path="${TMP_DIR}/"
   dir=$(dialog --stdout --clear --keep-tite --title "$1" --dselect "${start_path}" $(($(tput lines)-14)) $(($(tput cols)-10)))
   exec >&8 # custom stdout
 }
@@ -1064,10 +1064,10 @@ getAssetsTxOut() {
 
 # Command     : getMinUTxObalance
 # Description : calculate minimum balance needed in source wallet UTxOs for transaction to be valid
-#               getBalance assumed to be run before and protocol params file available at "${TMP_FOLDER}"/protparams.json
+#               getBalance assumed to be run before and protocol params file available at "${TMP_DIR}"/protparams.json
 # Return      : populates ${min_utxo_balance}
 getMinUTxObalance() {
-  [[ -z ${minUTxOValue} ]] && minUTxOValue=$(jq -r '.minUTxOValue //1000000' "${TMP_FOLDER}"/protparams.json)
+  [[ -z ${minUTxOValue} ]] && minUTxOValue=$(jq -r '.minUTxOValue //1000000' "${TMP_DIR}"/protparams.json)
   min_utxo_balance=$(( minUTxOValue + ($((${#assets[@]}-1))*minUTxOValue) ))	# TODO: improve when better calculations are provided in cardano-cli
 }
 
@@ -1189,22 +1189,22 @@ registerStakeWallet() {
   if ! ${CCLI} stake-address registration-certificate --stake-verification-key-file "${stake_vk_file}" --out-file "${stake_cert_file}"; then return 1; fi
 
   if ! getTTL; then return 1; fi
-  keyDeposit=$(jq -r '.keyDeposit' "${TMP_FOLDER}"/protparams.json)
+  keyDeposit=$(jq -r '.keyDeposit' "${TMP_DIR}"/protparams.json)
   println "LOG" "Key Deposit is ${keyDeposit}"
 
   getAssetsTxOut
 
-  println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out \"${base_addr}+0${assets_tx_out}\" --invalid-hereafter ${ttl} --fee 0 --certificate-file ${stake_cert_file} ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp"
-  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out "${base_addr}+0${assets_tx_out}" --invalid-hereafter ${ttl} --fee 0 --certificate-file ${stake_cert_file} ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
+  println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out \"${base_addr}+0${assets_tx_out}\" --invalid-hereafter ${ttl} --fee 0 --certificate-file ${stake_cert_file} ${ERA_IDENTIFIER} --out-file ${TMP_DIR}/tx0.tmp"
+  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out "${base_addr}+0${assets_tx_out}" --invalid-hereafter ${ttl} --fee 0 --certificate-file ${stake_cert_file} ${ERA_IDENTIFIER} --out-file "${TMP_DIR}"/tx0.tmp; then return 1; fi
   min_fee_args=(
     transaction calculate-min-fee
-    --tx-body-file "${TMP_FOLDER}"/tx0.tmp
+    --tx-body-file "${TMP_DIR}"/tx0.tmp
     --tx-in-count ${utxo_cnt}
     --tx-out-count 1
     ${NETWORK_IDENTIFIER}
     --witness-count 2
     --byron-witness-count 0
-    --protocol-params-file "${TMP_FOLDER}"/protparams.json
+    --protocol-params-file "${TMP_DIR}"/protparams.json
   )
   println "ACTION" "${CCLI} ${min_fee_args[*]}"
   min_fee=$([[ "$(${CCLI} ${min_fee_args[*]})" =~ ([0-9]+) ]] && echo ${BASH_REMATCH[1]})
@@ -1225,7 +1225,7 @@ registerStakeWallet() {
     --invalid-hereafter ${ttl}
     --fee ${min_fee}
     --certificate-file ${stake_cert_file}
-    --out-file "${TMP_FOLDER}"/tx.raw
+    --out-file "${TMP_DIR}"/tx.raw
   )
   if ! buildTx; then return 1; fi
   
@@ -1233,12 +1233,12 @@ registerStakeWallet() {
     if ! buildOfflineJSON "Wallet Registration"; then return 1; fi
     if ! offlineJSON=$(jq ". += { \"wallet-name\": \"${wallet_name}\" }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { txFee: \"$(( min_fee + keyDeposit ))\" }" <<< ${offlineJSON}); then return 1; fi
-    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_FOLDER}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_DIR}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"signing-file\": [] }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Wallet '${wallet_name}' payment signing key\", vkey: $(jq -c . "${payment_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Wallet '${wallet_name}' stake signing key\", vkey: $(jq -c . "${stake_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"signed-txBody\": {} }" <<< ${offlineJSON}); then return 1; fi
-    offline_tx="${TMP_FOLDER}/offline_tx_$(jq -r .id <<< ${offlineJSON}).json"
+    offline_tx="${TMP_DIR}/offline_tx_$(jq -r .id <<< ${offlineJSON}).json"
     jq -r . <<< "${offlineJSON}" > "${offline_tx}"
     echo
     println "Offline transaction successfully built and saved to: ${FG_LGRAY}${offline_tx}${NC}" 
@@ -1248,7 +1248,7 @@ registerStakeWallet() {
     return 2 # return as failed to stop main processing and return to home menu
   fi
   
-  if ! signTx "${TMP_FOLDER}/tx.raw" "${stake_sk_file}" "${payment_sk_file}"; then return 1; fi
+  if ! signTx "${TMP_DIR}/tx.raw" "${stake_sk_file}" "${payment_sk_file}"; then return 1; fi
   if ! submitTx "${tx_signed}"; then return 1; fi
   echo
   if ! verifyTx ${base_addr}; then return 1; fi
@@ -1269,22 +1269,22 @@ deregisterStakeWallet() {
 
   if ! getTTL; then return 1; fi
   
-  keyDeposit=$(jq -r '.keyDeposit' "${TMP_FOLDER}"/protparams.json)
+  keyDeposit=$(jq -r '.keyDeposit' "${TMP_DIR}"/protparams.json)
   println "LOG" "Key Deposit is ${keyDeposit}"
 
   getAssetsTxOut
 
-  println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out \"${base_addr}+0${assets_tx_out}\" --invalid-hereafter ${ttl} --fee 0 --certificate-file ${stake_dereg_file} ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp"
-  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out "${base_addr}+0${assets_tx_out}" --invalid-hereafter ${ttl} --fee 0 --certificate-file ${stake_dereg_file} ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
+  println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out \"${base_addr}+0${assets_tx_out}\" --invalid-hereafter ${ttl} --fee 0 --certificate-file ${stake_dereg_file} ${ERA_IDENTIFIER} --out-file ${TMP_DIR}/tx0.tmp"
+  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out "${base_addr}+0${assets_tx_out}" --invalid-hereafter ${ttl} --fee 0 --certificate-file ${stake_dereg_file} ${ERA_IDENTIFIER} --out-file "${TMP_DIR}"/tx0.tmp; then return 1; fi
   min_fee_args=(
     transaction calculate-min-fee
-    --tx-body-file "${TMP_FOLDER}"/tx0.tmp
+    --tx-body-file "${TMP_DIR}"/tx0.tmp
     --tx-in-count ${utxo_cnt}
     --tx-out-count 1
     ${NETWORK_IDENTIFIER}
     --witness-count 2
     --byron-witness-count 0
-    --protocol-params-file "${TMP_FOLDER}"/protparams.json
+    --protocol-params-file "${TMP_DIR}"/protparams.json
   )
   println "ACTION" "${CCLI} ${min_fee_args[*]}"
   min_fee=$([[ "$(${CCLI} ${min_fee_args[*]})" =~ ([0-9]+) ]] && echo ${BASH_REMATCH[1]})
@@ -1305,7 +1305,7 @@ deregisterStakeWallet() {
     --invalid-hereafter ${ttl}
     --fee ${min_fee}
     --certificate-file ${stake_dereg_file}
-    --out-file "${TMP_FOLDER}"/tx.raw
+    --out-file "${TMP_DIR}"/tx.raw
   )
   if ! buildTx; then return 1; fi
   
@@ -1314,12 +1314,12 @@ deregisterStakeWallet() {
     if ! offlineJSON=$(jq ". += { \"wallet-name\": \"${wallet_name}\" }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"amount-returned\": \"${keyDeposit}\" }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { txFee: \"${min_fee}\" }" <<< ${offlineJSON}); then return 1; fi
-    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_FOLDER}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_DIR}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"signing-file\": [] }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Wallet '${wallet_name}' payment signing key\", vkey: $(jq -c . "${payment_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Wallet '${wallet_name}' stake signing key\", vkey: $(jq -c . "${stake_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"signed-txBody\": {} }" <<< ${offlineJSON}); then return 1; fi
-    offline_tx="${TMP_FOLDER}/offline_tx_$(jq -r .id <<< ${offlineJSON}).json"
+    offline_tx="${TMP_DIR}/offline_tx_$(jq -r .id <<< ${offlineJSON}).json"
     jq -r . <<< "${offlineJSON}" > "${offline_tx}"
     echo
     println "Offline transaction successfully built and saved to: ${FG_LGRAY}${offline_tx}${NC}" 
@@ -1329,7 +1329,7 @@ deregisterStakeWallet() {
     return 2 # return as failed to stop main processing and return to home menu
   fi
   
-  if ! signTx "${TMP_FOLDER}/tx.raw" "${stake_sk_file}" "${payment_sk_file}"; then return 1; fi
+  if ! signTx "${TMP_DIR}/tx.raw" "${stake_sk_file}" "${payment_sk_file}"; then return 1; fi
   if ! submitTx "${tx_signed}"; then return 1; fi
 }
 
@@ -1363,7 +1363,7 @@ sendAssets() {
     --invalid-hereafter ${ttl}
     --fee 0
     ${ERA_IDENTIFIER}
-    --out-file "${TMP_FOLDER}"/tx0.tmp
+    --out-file "${TMP_DIR}"/tx0.tmp
   )
   if [[ ${outCount} -eq 1 ]]; then
     dummy_build_args+=( --tx-out "${d_addr}+0${assets_tx_out_d}" )
@@ -1375,13 +1375,13 @@ sendAssets() {
   
   min_fee_args=(
     transaction calculate-min-fee
-    --tx-body-file "${TMP_FOLDER}"/tx0.tmp
+    --tx-body-file "${TMP_DIR}"/tx0.tmp
     --tx-in-count ${utxo_cnt}
     --tx-out-count ${outCount}
     ${NETWORK_IDENTIFIER}
     --witness-count 1
     --byron-witness-count 0
-    --protocol-params-file "${TMP_FOLDER}"/protparams.json
+    --protocol-params-file "${TMP_DIR}"/protparams.json
   )
   println "ACTION" "${CCLI} ${min_fee_args[*]}"
   min_fee=$([[ "$(${CCLI} ${min_fee_args[*]})" =~ ([0-9]+) ]] && echo ${BASH_REMATCH[1]})
@@ -1391,10 +1391,10 @@ sendAssets() {
     ${tx_in}
     --invalid-hereafter ${ttl}
     --fee ${min_fee}
-    --out-file "${TMP_FOLDER}"/tx.raw
+    --out-file "${TMP_DIR}"/tx.raw
   )
   
-  [[ -z ${minUTxOValue} ]] && minUTxOValue=$(jq -r '.minUTxOValue //1000000' "${TMP_FOLDER}"/protparams.json)
+  [[ -z ${minUTxOValue} ]] && minUTxOValue=$(jq -r '.minUTxOValue //1000000' "${TMP_DIR}"/protparams.json)
   
   if [[ ${outCount} -eq 1 ]]; then # all assets to destination, nothing to return
     newBalance=0
@@ -1439,11 +1439,11 @@ sendAssets() {
       [[ ${assets_to_send[${idx}]} -gt 0 ]] && if ! offlineJSON=$(jq "."assets" += [{ asset: \"${idx}\", amount: \"${assets_to_send[${idx}]}\" }]" <<< ${offlineJSON}); then return 1; fi
     done
     if ! offlineJSON=$(jq ". += { txFee: \"${min_fee}\" }" <<< ${offlineJSON}); then return 1; fi
-    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_FOLDER}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_DIR}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"signing-file\": [] }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Wallet '${s_wallet}' payment signing key\", vkey: $(jq -c . "${s_payment_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"signed-txBody\": {} }" <<< ${offlineJSON}); then return 1; fi
-    offline_tx="${TMP_FOLDER}/offline_tx_$(jq -r .id <<< ${offlineJSON}).json"
+    offline_tx="${TMP_DIR}/offline_tx_$(jq -r .id <<< ${offlineJSON}).json"
     jq -r . <<< "${offlineJSON}" > "${offline_tx}"
     echo
     println "Offline transaction successfully built and saved to: ${FG_LGRAY}${offline_tx}${NC}" 
@@ -1452,7 +1452,7 @@ sendAssets() {
     return 2 # return as failed to stop main processing and return to home menu
   fi
   
-  if ! signTx "${TMP_FOLDER}/tx.raw" "${s_payment_sk_file}"; then return 1; fi
+  if ! signTx "${TMP_DIR}/tx.raw" "${s_payment_sk_file}"; then return 1; fi
   if ! submitTx "${tx_signed}"; then return 1; fi
 }
 
@@ -1466,17 +1466,17 @@ delegate() {
   
   getAssetsTxOut
 
-  println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out \"${base_addr}+0${assets_tx_out}\" --invalid-hereafter ${ttl} --fee 0 --certificate-file ${pool_delegcert_file} ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp"
-  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out "${base_addr}+0${assets_tx_out}" --invalid-hereafter ${ttl} --fee 0 --certificate-file ${pool_delegcert_file} ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
+  println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out \"${base_addr}+0${assets_tx_out}\" --invalid-hereafter ${ttl} --fee 0 --certificate-file ${pool_delegcert_file} ${ERA_IDENTIFIER} --out-file ${TMP_DIR}/tx0.tmp"
+  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out "${base_addr}+0${assets_tx_out}" --invalid-hereafter ${ttl} --fee 0 --certificate-file ${pool_delegcert_file} ${ERA_IDENTIFIER} --out-file "${TMP_DIR}"/tx0.tmp; then return 1; fi
   min_fee_args=(
     transaction calculate-min-fee
-    --tx-body-file "${TMP_FOLDER}"/tx0.tmp
+    --tx-body-file "${TMP_DIR}"/tx0.tmp
     --tx-in-count ${utxo_cnt}
     --tx-out-count 1
     ${NETWORK_IDENTIFIER}
     --witness-count 2
     --byron-witness-count 0
-    --protocol-params-file "${TMP_FOLDER}"/protparams.json
+    --protocol-params-file "${TMP_DIR}"/protparams.json
   )
   println "ACTION" "${CCLI} ${min_fee_args[*]}"
   min_fee=$([[ "$(${CCLI} ${min_fee_args[*]})" =~ ([0-9]+) ]] && echo ${BASH_REMATCH[1]})
@@ -1497,7 +1497,7 @@ delegate() {
     --invalid-hereafter ${ttl}
     --fee ${min_fee}
     --certificate-file ${pool_delegcert_file}
-    --out-file "${TMP_FOLDER}"/tx.raw
+    --out-file "${TMP_DIR}"/tx.raw
   )
   if ! buildTx; then return 1; fi
 
@@ -1505,12 +1505,12 @@ delegate() {
     if ! buildOfflineJSON "Wallet Delegation"; then return 1; fi
     if ! offlineJSON=$(jq ". += { \"wallet-name\": \"${wallet_name}\" }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { txFee: \"${min_fee}\" }" <<< ${offlineJSON}); then return 1; fi
-    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_FOLDER}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_DIR}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"signing-file\": [] }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Wallet '${wallet_name}' payment signing key\", vkey: $(jq -c . "${payment_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Wallet '${wallet_name}' stake signing key\", vkey: $(jq -c . "${stake_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"signed-txBody\": {} }" <<< ${offlineJSON}); then return 1; fi
-    offline_tx="${TMP_FOLDER}/offline_tx_$(jq -r .id <<< ${offlineJSON}).json"
+    offline_tx="${TMP_DIR}/offline_tx_$(jq -r .id <<< ${offlineJSON}).json"
     jq -r . <<< "${offlineJSON}" > "${offline_tx}"
     echo
     println "Offline transaction successfully built and saved to: ${FG_LGRAY}${offline_tx}${NC}" 
@@ -1520,7 +1520,7 @@ delegate() {
     return 2 # return as failed to stop main processing and return to home menu
   fi
   
-  if ! signTx "${TMP_FOLDER}/tx.raw" "${stake_sk_file}" "${payment_sk_file}"; then return 1; fi
+  if ! signTx "${TMP_DIR}/tx.raw" "${stake_sk_file}" "${payment_sk_file}"; then return 1; fi
   if ! submitTx "${tx_signed}"; then return 1; fi
 }
 
@@ -1534,17 +1534,17 @@ withdrawRewards() {
   
   getAssetsTxOut
 
-  println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out \"${base_addr}+0${assets_tx_out}\" --invalid-hereafter ${ttl} --fee 0 ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp"
-  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out "${base_addr}+0${assets_tx_out}" --invalid-hereafter ${ttl} --fee 0 ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
+  println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out \"${base_addr}+0${assets_tx_out}\" --invalid-hereafter ${ttl} --fee 0 ${ERA_IDENTIFIER} --out-file ${TMP_DIR}/tx0.tmp"
+  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out "${base_addr}+0${assets_tx_out}" --invalid-hereafter ${ttl} --fee 0 ${ERA_IDENTIFIER} --out-file "${TMP_DIR}"/tx0.tmp; then return 1; fi
   min_fee_args=(
     transaction calculate-min-fee
-    --tx-body-file "${TMP_FOLDER}"/tx0.tmp
+    --tx-body-file "${TMP_DIR}"/tx0.tmp
     --tx-in-count ${utxo_cnt}
     --tx-out-count 1
     ${NETWORK_IDENTIFIER}
     --witness-count 2
     --byron-witness-count 0
-    --protocol-params-file "${TMP_FOLDER}"/protparams.json
+    --protocol-params-file "${TMP_DIR}"/protparams.json
   )
   println "ACTION" "${CCLI} ${min_fee_args[*]}"
   min_fee=$([[ "$(${CCLI} ${min_fee_args[*]})" =~ ([0-9]+) ]] && echo ${BASH_REMATCH[1]})
@@ -1565,7 +1565,7 @@ withdrawRewards() {
     --withdrawal ${reward_addr}+${reward_lovelace}
     --invalid-hereafter ${ttl}
     --fee ${min_fee}
-    --out-file "${TMP_FOLDER}"/tx.raw
+    --out-file "${TMP_DIR}"/tx.raw
   )
   if ! buildTx; then return 1; fi
 
@@ -1574,12 +1574,12 @@ withdrawRewards() {
     if ! offlineJSON=$(jq ". += { \"wallet-name\": \"${wallet_name}\" }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { rewards: \"${reward_lovelace}\" }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { txFee: \"${min_fee}\" }" <<< ${offlineJSON}); then return 1; fi
-    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_FOLDER}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_DIR}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"signing-file\": [] }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Wallet '${wallet_name}' payment signing key\", vkey: $(jq -c . "${payment_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Wallet '${wallet_name}' stake signing key\", vkey: $(jq -c . "${stake_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"signed-txBody\": {} }" <<< ${offlineJSON}); then return 1; fi
-    offline_tx="${TMP_FOLDER}/offline_tx_$(jq -r .id <<< ${offlineJSON}).json"
+    offline_tx="${TMP_DIR}/offline_tx_$(jq -r .id <<< ${offlineJSON}).json"
     jq -r . <<< "${offlineJSON}" > "${offline_tx}"
     echo
     println "Offline transaction successfully built and saved to: ${FG_LGRAY}${offline_tx}${NC}" 
@@ -1589,7 +1589,7 @@ withdrawRewards() {
     return 2 # return as failed to stop main processing and return to home menu
   fi
   
-  if ! signTx "${TMP_FOLDER}/tx.raw" "${stake_sk_file}" "${payment_sk_file}"; then return 1; fi
+  if ! signTx "${TMP_DIR}/tx.raw" "${stake_sk_file}" "${payment_sk_file}"; then return 1; fi
   if ! submitTx "${tx_signed}"; then return 1; fi
 }
 
@@ -1602,7 +1602,7 @@ registerPool() {
   
   if ! getTTL; then return 1; fi
   
-  poolDeposit=$(jq -r '.poolDeposit' "${TMP_FOLDER}"/protparams.json)
+  poolDeposit=$(jq -r '.poolDeposit' "${TMP_DIR}"/protparams.json)
   println "LOG" "Pool Deposit is ${poolDeposit}"
   
   owner_delegation_cert=""
@@ -1630,17 +1630,17 @@ registerPool() {
   
   getAssetsTxOut
 
-  println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out \"${base_addr}+0${assets_tx_out}\" --invalid-hereafter ${ttl} --certificate-file ${pool_regcert_file} ${owner_delegation_cert} ${reward_delegation_cert} --fee 0 ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp"
-  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out "${base_addr}+0${assets_tx_out}" --invalid-hereafter ${ttl} --certificate-file ${pool_regcert_file} ${owner_delegation_cert} ${reward_delegation_cert} --fee 0 ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
+  println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out \"${base_addr}+0${assets_tx_out}\" --invalid-hereafter ${ttl} --certificate-file ${pool_regcert_file} ${owner_delegation_cert} ${reward_delegation_cert} --fee 0 ${ERA_IDENTIFIER} --out-file ${TMP_DIR}/tx0.tmp"
+  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out "${base_addr}+0${assets_tx_out}" --invalid-hereafter ${ttl} --certificate-file ${pool_regcert_file} ${owner_delegation_cert} ${reward_delegation_cert} --fee 0 ${ERA_IDENTIFIER} --out-file "${TMP_DIR}"/tx0.tmp; then return 1; fi
   min_fee_args=(
     transaction calculate-min-fee
-    --tx-body-file "${TMP_FOLDER}"/tx0.tmp
+    --tx-body-file "${TMP_DIR}"/tx0.tmp
     --tx-in-count ${utxo_cnt}
     --tx-out-count 1
     ${NETWORK_IDENTIFIER}
     --witness-count ${witness_count}
     --byron-witness-count 0
-    --protocol-params-file "${TMP_FOLDER}"/protparams.json
+    --protocol-params-file "${TMP_DIR}"/protparams.json
   )
   println "ACTION" "${CCLI} ${min_fee_args[*]}"
   min_fee=$([[ "$(${CCLI} ${min_fee_args[*]})" =~ ([0-9]+) ]] && echo ${BASH_REMATCH[1]})
@@ -1663,7 +1663,7 @@ registerPool() {
     --certificate-file ${pool_regcert_file}
     ${owner_delegation_cert}
     ${reward_delegation_cert}
-    --out-file "${TMP_FOLDER}"/tx.raw
+    --out-file "${TMP_DIR}"/tx.raw
   )
   if ! buildTx; then return 1; fi
   
@@ -1676,7 +1676,7 @@ registerPool() {
     if ! offlineJSON=$(jq ". += { \"pool-cost\": \"${cost_ada}\" }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"pool-reg-cert\": $(jq -c . "${pool_regcert_file}") }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { txFee: \"$(( min_fee + poolDeposit ))\" }" <<< ${offlineJSON}); then return 1; fi
-    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_FOLDER}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_DIR}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"signing-file\": [] }" <<< ${offlineJSON}); then return 1; fi
     for index in "${!owner_wallets[@]}"; do
       if [[ ${index} -eq 0 ]]; then
@@ -1689,7 +1689,7 @@ registerPool() {
     if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Pool '${pool_name}' cold signing key\", vkey: $(jq -c . "${pool_coldkey_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { witness: [] }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"signed-txBody\": {} }" <<< ${offlineJSON}); then return 1; fi
-    offline_tx="${TMP_FOLDER}/offline_tx_$(jq -r .id <<< ${offlineJSON}).json"
+    offline_tx="${TMP_DIR}/offline_tx_$(jq -r .id <<< ${offlineJSON}).json"
     jq -r . <<< "${offlineJSON}" > "${offline_tx}"
     echo
     println "Offline transaction successfully built and saved to: ${FG_LGRAY}${offline_tx}${NC}" 
@@ -1712,8 +1712,8 @@ registerPool() {
     multi_owner_keys+=( "${stake_sk_file}" )
   done
   
-  if ! witnessTx "${TMP_FOLDER}/tx.raw" "${owner_payment_sk_file}" "${pool_coldkey_sk_file}" "${owner_stake_sk_file}" "${reward_stake_sk_file}" "${multi_owner_keys[@]}"; then return 1; fi
-  if ! assembleTx "${TMP_FOLDER}/tx.raw"; then return 1; fi
+  if ! witnessTx "${TMP_DIR}/tx.raw" "${owner_payment_sk_file}" "${pool_coldkey_sk_file}" "${owner_stake_sk_file}" "${reward_stake_sk_file}" "${multi_owner_keys[@]}"; then return 1; fi
+  if ! assembleTx "${TMP_DIR}/tx.raw"; then return 1; fi
   if ! submitTx "${tx_signed}"; then return 1; fi
 }
 
@@ -1731,17 +1731,17 @@ modifyPool() {
   
   getAssetsTxOut
 
-  println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out \"${base_addr}+0${assets_tx_out}\" --invalid-hereafter ${ttl} --certificate-file ${pool_regcert_file} --fee 0 ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp"
-  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out "${base_addr}+0${assets_tx_out}" --invalid-hereafter ${ttl} --certificate-file ${pool_regcert_file} --fee 0 ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
+  println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out \"${base_addr}+0${assets_tx_out}\" --invalid-hereafter ${ttl} --certificate-file ${pool_regcert_file} --fee 0 ${ERA_IDENTIFIER} --out-file ${TMP_DIR}/tx0.tmp"
+  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out "${base_addr}+0${assets_tx_out}" --invalid-hereafter ${ttl} --certificate-file ${pool_regcert_file} --fee 0 ${ERA_IDENTIFIER} --out-file "${TMP_DIR}"/tx0.tmp; then return 1; fi
   min_fee_args=(
     transaction calculate-min-fee
-    --tx-body-file "${TMP_FOLDER}"/tx0.tmp
+    --tx-body-file "${TMP_DIR}"/tx0.tmp
     --tx-in-count ${utxo_cnt}
     --tx-out-count 1
     ${NETWORK_IDENTIFIER}
     --witness-count ${witness_count}
     --byron-witness-count 0
-    --protocol-params-file "${TMP_FOLDER}"/protparams.json
+    --protocol-params-file "${TMP_DIR}"/protparams.json
   )
   println "ACTION" "${CCLI} ${min_fee_args[*]}"
   min_fee=$([[ "$(${CCLI} ${min_fee_args[*]})" =~ ([0-9]+) ]] && echo ${BASH_REMATCH[1]})
@@ -1762,7 +1762,7 @@ modifyPool() {
     --invalid-hereafter ${ttl}
     --fee ${min_fee}
     --certificate-file ${pool_regcert_file}
-    --out-file "${TMP_FOLDER}"/tx.raw
+    --out-file "${TMP_DIR}"/tx.raw
   )
   if ! buildTx; then return 1; fi
   
@@ -1775,7 +1775,7 @@ modifyPool() {
     if ! offlineJSON=$(jq ". += { \"pool-cost\": \"${cost_ada}\" }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"pool-reg-cert\": $(jq -c . "${pool_regcert_file}") }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { txFee: \"${min_fee}\" }" <<< ${offlineJSON}); then return 1; fi
-    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_FOLDER}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_DIR}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"signing-file\": [] }" <<< ${offlineJSON}); then return 1; fi
     for index in "${!owner_wallets[@]}"; do
       if [[ ${index} -eq 0 ]]; then
@@ -1787,7 +1787,7 @@ modifyPool() {
     if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Pool '${pool_name}' cold signing key\", vkey: $(jq -c . "${pool_coldkey_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { witness: [] }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"signed-txBody\": {} }" <<< ${offlineJSON}); then return 1; fi
-    offline_tx="${TMP_FOLDER}/offline_tx_$(jq -r .id <<< ${offlineJSON}).json"
+    offline_tx="${TMP_DIR}/offline_tx_$(jq -r .id <<< ${offlineJSON}).json"
     jq -r . <<< "${offlineJSON}" > "${offline_tx}"
     echo
     println "Offline transaction successfully built and saved to: ${FG_LGRAY}${offline_tx}${NC}" 
@@ -1808,8 +1808,8 @@ modifyPool() {
     multi_owner_keys+=( "${stake_sk_file}" )
   done
   
-  if ! witnessTx "${TMP_FOLDER}/tx.raw" "${owner_payment_sk_file}" "${pool_coldkey_sk_file}" "${owner_stake_sk_file}" "${multi_owner_keys[@]}"; then return 1; fi
-  if ! assembleTx "${TMP_FOLDER}/tx.raw"; then return 1; fi
+  if ! witnessTx "${TMP_DIR}/tx.raw" "${owner_payment_sk_file}" "${pool_coldkey_sk_file}" "${owner_stake_sk_file}" "${multi_owner_keys[@]}"; then return 1; fi
+  if ! assembleTx "${TMP_DIR}/tx.raw"; then return 1; fi
   if ! submitTx "${tx_signed}"; then return 1; fi
 }
 
@@ -1824,17 +1824,17 @@ deRegisterPool() {
   
   getAssetsTxOut
 
-  println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out \"${addr}+0${assets_tx_out}\" --invalid-hereafter ${ttl} --fee 0 --certificate-file ${pool_deregcert_file} ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp"
-  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out "${addr}+0${assets_tx_out}" --invalid-hereafter ${ttl} --fee 0 --certificate-file ${pool_deregcert_file} ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
+  println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out \"${addr}+0${assets_tx_out}\" --invalid-hereafter ${ttl} --fee 0 --certificate-file ${pool_deregcert_file} ${ERA_IDENTIFIER} --out-file ${TMP_DIR}/tx0.tmp"
+  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out "${addr}+0${assets_tx_out}" --invalid-hereafter ${ttl} --fee 0 --certificate-file ${pool_deregcert_file} ${ERA_IDENTIFIER} --out-file "${TMP_DIR}"/tx0.tmp; then return 1; fi
   min_fee_args=(
     transaction calculate-min-fee
-    --tx-body-file "${TMP_FOLDER}"/tx0.tmp
+    --tx-body-file "${TMP_DIR}"/tx0.tmp
     --tx-in-count ${utxo_cnt}
     --tx-out-count 1
     ${NETWORK_IDENTIFIER}
     --witness-count 2
     --byron-witness-count 0
-    --protocol-params-file "${TMP_FOLDER}"/protparams.json
+    --protocol-params-file "${TMP_DIR}"/protparams.json
   )
   println "ACTION" "${CCLI} ${min_fee_args[*]}"
   min_fee=$([[ "$(${CCLI} ${min_fee_args[*]})" =~ ([0-9]+) ]] && echo ${BASH_REMATCH[1]})
@@ -1855,7 +1855,7 @@ deRegisterPool() {
     --invalid-hereafter ${ttl}
     --fee ${min_fee}
     --certificate-file ${pool_deregcert_file}
-    --out-file "${TMP_FOLDER}"/tx.raw
+    --out-file "${TMP_DIR}"/tx.raw
   )
   if ! buildTx; then return 1; fi
   
@@ -1871,12 +1871,12 @@ deRegisterPool() {
     fi
     if ! offlineJSON=$(jq ". += { \"retire-epoch\": \"${epoch_enter}\" }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { txFee: \"${min_fee}\" }" <<< ${offlineJSON}); then return 1; fi
-    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_FOLDER}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_DIR}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"signing-file\": [] }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Wallet '${wallet_name}' payment signing key\", vkey: $(jq -c . "${payment_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Pool '${pool_name}' stake signing key\", vkey: $(jq -c . "${pool_coldkey_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"signed-txBody\": {} }" <<< ${offlineJSON}); then return 1; fi
-    offline_tx="${TMP_FOLDER}/offline_tx_$(jq -r .id <<< ${offlineJSON}).json"
+    offline_tx="${TMP_DIR}/offline_tx_$(jq -r .id <<< ${offlineJSON}).json"
     jq -r . <<< "${offlineJSON}" > "${offline_tx}"
     echo
     println "Offline transaction successfully built and saved to: ${FG_LGRAY}${offline_tx}${NC}" 
@@ -1886,7 +1886,7 @@ deRegisterPool() {
     return 2 # return as failed to stop main processing and return to home menu
   fi
   
-  if ! signTx "${TMP_FOLDER}/tx.raw" "${payment_sk_file}" "${pool_coldkey_sk_file}"; then return 1; fi
+  if ! signTx "${TMP_DIR}/tx.raw" "${payment_sk_file}" "${pool_coldkey_sk_file}"; then return 1; fi
   if ! submitTx "${tx_signed}"; then return 1; fi
 }
 
@@ -1938,17 +1938,17 @@ sendMetadata() {
   
   getAssetsTxOut
 
-  println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out \"${addr}+0${assets_tx_out}\" --invalid-hereafter ${ttl} --fee 0 ${metafile_param} ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp"
-  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out "${addr}+0${assets_tx_out}" --invalid-hereafter ${ttl} --fee 0 ${metafile_param} ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
+  println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out \"${addr}+0${assets_tx_out}\" --invalid-hereafter ${ttl} --fee 0 ${metafile_param} ${ERA_IDENTIFIER} --out-file ${TMP_DIR}/tx0.tmp"
+  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out "${addr}+0${assets_tx_out}" --invalid-hereafter ${ttl} --fee 0 ${metafile_param} ${ERA_IDENTIFIER} --out-file "${TMP_DIR}"/tx0.tmp; then return 1; fi
   min_fee_args=(
     transaction calculate-min-fee
-    --tx-body-file "${TMP_FOLDER}"/tx0.tmp
+    --tx-body-file "${TMP_DIR}"/tx0.tmp
     --tx-in-count ${utxo_cnt}
     --tx-out-count 1
     ${NETWORK_IDENTIFIER}
     --witness-count 1
     --byron-witness-count 0
-    --protocol-params-file "${TMP_FOLDER}"/protparams.json
+    --protocol-params-file "${TMP_DIR}"/protparams.json
   )
   println "ACTION" "${CCLI} ${min_fee_args[*]}"
   min_fee=$([[ "$(${CCLI} ${min_fee_args[*]})" =~ ([0-9]+) ]] && echo ${BASH_REMATCH[1]})
@@ -1969,7 +1969,7 @@ sendMetadata() {
     ${metafile_param}
     --invalid-hereafter ${ttl}
     --fee ${min_fee}
-    --out-file "${TMP_FOLDER}"/tx.raw
+    --out-file "${TMP_DIR}"/tx.raw
   )
   if ! buildTx; then return 1; fi
   
@@ -1978,11 +1978,11 @@ sendMetadata() {
     if ! offlineJSON=$(jq ". += { \"wallet-name\": \"${wallet_name}\" }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { metadata: $(jq -c . "${metafile}") }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { txFee: \"${min_fee}\" }" <<< ${offlineJSON}); then return 1; fi
-    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_FOLDER}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_DIR}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"signing-file\": [] }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Wallet '${wallet_name}' payment signing key\", vkey: $(jq -c . "${payment_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"signed-txBody\": {} }" <<< ${offlineJSON}); then return 1; fi
-    offline_tx="${TMP_FOLDER}/offline_tx_$(jq -r .id <<< ${offlineJSON}).json"
+    offline_tx="${TMP_DIR}/offline_tx_$(jq -r .id <<< ${offlineJSON}).json"
     jq -r . <<< "${offlineJSON}" > "${offline_tx}"
     echo
     println "Offline transaction successfully built and saved to: ${FG_LGRAY}${offline_tx}${NC}" 
@@ -1991,7 +1991,7 @@ sendMetadata() {
     return 2 # return as failed to stop main processing and return to home menu
   fi
   
-  if ! signTx "${TMP_FOLDER}/tx.raw" "${payment_sk_file}"; then return 1; fi
+  if ! signTx "${TMP_DIR}/tx.raw" "${payment_sk_file}"; then return 1; fi
   if ! submitTx "${tx_signed}"; then return 1; fi
 }
 
@@ -2014,17 +2014,17 @@ mintAsset() {
   [[ -z ${asset_name} ]] && asset_name_out="" || asset_name_out=".${asset_name}"
   getAssetsTxOut "${policy_id}${asset_name_out}" "${asset_amount}"
   
-  println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out \"${addr}+0${assets_tx_out}\" --mint \"${asset_amount} ${policy_id}${asset_name_out}\" ${metafile_param} --invalid-hereafter ${ttl} --fee 0 ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp"
-  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out "${addr}+0${assets_tx_out}" --mint "${asset_amount} ${policy_id}${asset_name_out}" ${metafile_param} --invalid-hereafter ${ttl} --fee 0 ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
+  println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out \"${addr}+0${assets_tx_out}\" --mint \"${asset_amount} ${policy_id}${asset_name_out}\" ${metafile_param} --invalid-hereafter ${ttl} --fee 0 ${ERA_IDENTIFIER} --out-file ${TMP_DIR}/tx0.tmp"
+  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out "${addr}+0${assets_tx_out}" --mint "${asset_amount} ${policy_id}${asset_name_out}" ${metafile_param} --invalid-hereafter ${ttl} --fee 0 ${ERA_IDENTIFIER} --out-file "${TMP_DIR}"/tx0.tmp; then return 1; fi
   min_fee_args=(
     transaction calculate-min-fee
-    --tx-body-file "${TMP_FOLDER}"/tx0.tmp
+    --tx-body-file "${TMP_DIR}"/tx0.tmp
     --tx-in-count ${utxo_cnt}
     --tx-out-count 1
     ${NETWORK_IDENTIFIER}
     --witness-count 2
     --byron-witness-count 0
-    --protocol-params-file "${TMP_FOLDER}"/protparams.json
+    --protocol-params-file "${TMP_DIR}"/protparams.json
   )
   println "ACTION" "${CCLI} ${min_fee_args[*]}"
   min_fee=$([[ "$(${CCLI} ${min_fee_args[*]})" =~ ([0-9]+) ]] && echo ${BASH_REMATCH[1]})
@@ -2046,7 +2046,7 @@ mintAsset() {
     ${metafile_param}
     --invalid-hereafter ${ttl}
     --fee ${min_fee}
-    --out-file "${TMP_FOLDER}"/tx.raw
+    --out-file "${TMP_DIR}"/tx.raw
   )
   if ! buildTx; then return 1; fi
   
@@ -2062,11 +2062,11 @@ mintAsset() {
       if ! offlineJSON=$(jq ". += { metadata: $(jq -c . "${metafile}") }" <<< ${offlineJSON}); then return 1; fi
     fi
     if ! offlineJSON=$(jq ". += { txFee: \"${min_fee}\" }" <<< ${offlineJSON}); then return 1; fi
-    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_FOLDER}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_DIR}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"signing-file\": [] }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Wallet '${wallet_name}' payment signing key\", vkey: $(jq -c . "${payment_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"signed-txBody\": {} }" <<< ${offlineJSON}); then return 1; fi
-    offline_tx="${TMP_FOLDER}/offline_tx_$(jq -r .id <<< ${offlineJSON}).json"
+    offline_tx="${TMP_DIR}/offline_tx_$(jq -r .id <<< ${offlineJSON}).json"
     jq -r . <<< "${offlineJSON}" > "${offline_tx}"
     echo
     println "Offline transaction successfully built and saved to: ${FG_LGRAY}${offline_tx}${NC}" 
@@ -2077,7 +2077,7 @@ mintAsset() {
     return 2 # return as failed to stop main processing and return to home menu
   fi
   
-  if ! signTx "${TMP_FOLDER}/tx.raw" "${payment_sk_file}" "${policy_sk_file}" "${policy_script_file}"; then return 1; fi
+  if ! signTx "${TMP_DIR}/tx.raw" "${payment_sk_file}" "${policy_sk_file}" "${policy_script_file}"; then return 1; fi
   if ! submitTx "${tx_signed}"; then return 1; fi
 }
 
@@ -2098,17 +2098,17 @@ burnAsset() {
   [[ -z ${asset_name} ]] && asset_name_out="" || asset_name_out=".${asset_name}"
   getAssetsTxOut "${policy_id}${asset_name_out}" "-${assets_to_burn}"
 
-  println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out \"${addr}+0${assets_tx_out}\" --mint \"-${assets_to_burn} ${policy_id}${asset_name_out}\" ${metafile_param} --invalid-hereafter ${ttl} --fee 0 ${ERA_IDENTIFIER} --out-file ${TMP_FOLDER}/tx0.tmp"
-  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out "${addr}+0${assets_tx_out}" --mint "-${assets_to_burn} ${policy_id}${asset_name_out}" ${metafile_param} --invalid-hereafter ${ttl} --fee 0 ${ERA_IDENTIFIER} --out-file "${TMP_FOLDER}"/tx0.tmp; then return 1; fi
+  println "ACTION" "${CCLI} transaction build-raw ${tx_in} --tx-out \"${addr}+0${assets_tx_out}\" --mint \"-${assets_to_burn} ${policy_id}${asset_name_out}\" ${metafile_param} --invalid-hereafter ${ttl} --fee 0 ${ERA_IDENTIFIER} --out-file ${TMP_DIR}/tx0.tmp"
+  if ! ${CCLI} transaction build-raw ${tx_in} --tx-out "${addr}+0${assets_tx_out}" --mint "-${assets_to_burn} ${policy_id}${asset_name_out}" ${metafile_param} --invalid-hereafter ${ttl} --fee 0 ${ERA_IDENTIFIER} --out-file "${TMP_DIR}"/tx0.tmp; then return 1; fi
   min_fee_args=(
     transaction calculate-min-fee
-    --tx-body-file "${TMP_FOLDER}"/tx0.tmp
+    --tx-body-file "${TMP_DIR}"/tx0.tmp
     --tx-in-count ${utxo_cnt}
     --tx-out-count 1
     ${NETWORK_IDENTIFIER}
     --witness-count 2
     --byron-witness-count 0
-    --protocol-params-file "${TMP_FOLDER}"/protparams.json
+    --protocol-params-file "${TMP_DIR}"/protparams.json
   )
   println "ACTION" "${CCLI} ${min_fee_args[*]}"
   min_fee=$([[ "$(${CCLI} ${min_fee_args[*]})" =~ ([0-9]+) ]] && echo ${BASH_REMATCH[1]})
@@ -2130,7 +2130,7 @@ burnAsset() {
     ${metafile_param}
     --invalid-hereafter ${ttl}
     --fee ${min_fee}
-    --out-file "${TMP_FOLDER}"/tx.raw
+    --out-file "${TMP_DIR}"/tx.raw
   )
   if ! buildTx; then return 1; fi
   
@@ -2146,11 +2146,11 @@ burnAsset() {
       if ! offlineJSON=$(jq ". += { metadata: $(jq -c . "${metafile}") }" <<< ${offlineJSON}); then return 1; fi
     fi
     if ! offlineJSON=$(jq ". += { txFee: \"${min_fee}\" }" <<< ${offlineJSON}); then return 1; fi
-    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_FOLDER}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_DIR}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"signing-file\": [] }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Wallet '${wallet_name}' payment signing key\", vkey: $(jq -c . "${payment_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"signed-txBody\": {} }" <<< ${offlineJSON}); then return 1; fi
-    offline_tx="${TMP_FOLDER}/offline_tx_$(jq -r .id <<< ${offlineJSON}).json"
+    offline_tx="${TMP_DIR}/offline_tx_$(jq -r .id <<< ${offlineJSON}).json"
     jq -r . <<< "${offlineJSON}" > "${offline_tx}"
     echo
     println "Offline transaction successfully built and saved to: ${FG_LGRAY}${offline_tx}${NC}" 
@@ -2161,7 +2161,7 @@ burnAsset() {
     return 2 # return as failed to stop main processing and return to home menu
   fi
   
-  if ! signTx "${TMP_FOLDER}/tx.raw" "${payment_sk_file}" "${policy_sk_file}" "${policy_script_file}"; then return 1; fi
+  if ! signTx "${TMP_DIR}/tx.raw" "${payment_sk_file}" "${policy_sk_file}" "${policy_script_file}"; then return 1; fi
   if ! submitTx "${tx_signed}"; then return 1; fi
 }
 
@@ -2190,7 +2190,7 @@ witnessTx() {
       return 1
     elif [[ $(jq -r '.description' "${skey}") = *"Hardware"* ]]; then # HW signing key
       if ! unlockHWDevice "witness the transaction"; then return 1; fi
-      tx_witness="$(mktemp "${TMP_FOLDER}/tx.witness_XXXXXXXXXX")"
+      tx_witness="$(mktemp "${TMP_DIR}/tx.witness_XXXXXXXXXX")"
       witness_command=(
         cardano-hw-cli transaction witness
         --tx-body-file "${tx_raw}"
@@ -2201,7 +2201,7 @@ witnessTx() {
       println "ACTION" "${witness_command[@]}"
       if ! ${witness_command[@]}; then println "ERROR" "\n${FG_RED}ERROR${NC}: during hardware wallet signing !!" && return 1; fi
     else
-      tx_witness="$(mktemp "${TMP_FOLDER}/tx.witness_XXXXXXXXXX")"
+      tx_witness="$(mktemp "${TMP_DIR}/tx.witness_XXXXXXXXXX")"
       witness_command=(
         ${CCLI} transaction witness
         --tx-body-file "${tx_raw}"
@@ -2220,7 +2220,7 @@ witnessTx() {
 # Description : Helper function to witnessTx for assembling a signed tx using witnesses from tx_witness_files[] array
 assembleTx() {
   tx_raw="$1"
-  tx_signed="${TMP_FOLDER}/tx.signed_$(date +%s)"
+  tx_signed="${TMP_DIR}/tx.signed_$(date +%s)"
   if [[ ${#tx_witness_files[@]} -gt 0 ]]; then # assemble witness files and sign
     tx_witness_out=()
     for witness in "${tx_witness_files[@]}"; do
@@ -2253,7 +2253,7 @@ assembleTx() {
 signTx() {
   tx_raw="$1"
   shift
-  tx_signed="${TMP_FOLDER}/tx.signed_$(date +%s)"
+  tx_signed="${TMP_DIR}/tx.signed_$(date +%s)"
   if [[ $# -gt 0 ]]; then
     tx_sign_out=()
     hw_wallet='N'

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -18,7 +18,7 @@ CNTOOLS_VERSION="${CNTOOLS_MAJOR_VERSION}.${CNTOOLS_MINOR_VERSION}.${CNTOOLS_PAT
 # Default config values                                    #
 # overriden by values set in cntools.config                #
 ############################################################
-TMP_DIR="/${TMP_DIR}/cntools"
+TMP_DIR="${TMP_DIR}/cntools"
 if ! mkdir -p "${TMP_DIR}" 2>/dev/null; then myExit 1 "${FG_RED}ERROR${NC}: Failed to create directory for temporary files: ${TMP_DIR}"; fi
 [[ -z ${TIMEOUT_NO_OF_SLOTS} ]] && TIMEOUT_NO_OF_SLOTS=600
 [[ ${SHELLEY_TRANS_FILENAME} =~ ^${CNODE_HOME}/db/ ]] && mkdir -p "${CNODE_HOME}/guild-db" && SHELLEY_TRANS_FILENAME="${CNODE_HOME}/guild-db/shelley_trans_epoch"

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -102,12 +102,6 @@ fi
 # get helper functions from library file
 . "${PARENT}"/cntools.library
 
-# create temporary directory if missing & remove lockfile if it exist
-mkdir -p "${TMP_FOLDER}" # Create if missing
-if [[ ! -d "${TMP_FOLDER}" ]]; then
-  myExit 1 "${FG_RED}ERROR${NC}: Failed to create directory for temporary files:\n${TMP_FOLDER}"
-fi
-
 archiveLog # archive current log and cleanup log archive folder
 
 exec 6>&1 # Link file descriptor #6 with normal stdout.
@@ -144,10 +138,10 @@ if [[ ${CNTOOLS_MODE} = "CONNECTED" ]]; then
   # check to see if there are any updates available
   clear
   println "DEBUG" "CNTools version check...\n"
-  if curl -s -f -m ${CURL_TIMEOUT} -o "${TMP_FOLDER}"/cntools.library "${URL}/cntools.library" && [[ -f "${TMP_FOLDER}"/cntools.library ]]; then
-    GIT_MAJOR_VERSION=$(grep -r ^CNTOOLS_MAJOR_VERSION= "${TMP_FOLDER}"/cntools.library |sed -e "s#.*=##")
-    GIT_MINOR_VERSION=$(grep -r ^CNTOOLS_MINOR_VERSION= "${TMP_FOLDER}"/cntools.library |sed -e "s#.*=##")
-    GIT_PATCH_VERSION=$(grep -r ^CNTOOLS_PATCH_VERSION= "${TMP_FOLDER}"/cntools.library |sed -e "s#.*=##")
+  if curl -s -f -m ${CURL_TIMEOUT} -o "${TMP_DIR}"/cntools.library "${URL}/cntools.library" && [[ -f "${TMP_DIR}"/cntools.library ]]; then
+    GIT_MAJOR_VERSION=$(grep -r ^CNTOOLS_MAJOR_VERSION= "${TMP_DIR}"/cntools.library |sed -e "s#.*=##")
+    GIT_MINOR_VERSION=$(grep -r ^CNTOOLS_MINOR_VERSION= "${TMP_DIR}"/cntools.library |sed -e "s#.*=##")
+    GIT_PATCH_VERSION=$(grep -r ^CNTOOLS_PATCH_VERSION= "${TMP_DIR}"/cntools.library |sed -e "s#.*=##")
     if [[ "$GIT_PATCH_VERSION" -eq 999  ]]; then
       ((GIT_MAJOR_VERSION++))
       GIT_MINOR_VERSION=0
@@ -163,22 +157,22 @@ if [[ ${CNTOOLS_MODE} = "CONNECTED" ]]; then
       waitForInput "press any key to proceed"
     else
       # check if CNTools was recently updated, if so show whats new
-      if curl -s -f -m ${CURL_TIMEOUT} -o "${TMP_FOLDER}"/cntools-changelog.md "${URL_DOCS}/cntools-changelog.md"; then
-        if ! cmp -s "${TMP_FOLDER}"/cntools-changelog.md "${PARENT}/cntools-changelog.md"; then
+      if curl -s -f -m ${CURL_TIMEOUT} -o "${TMP_DIR}"/cntools-changelog.md "${URL_DOCS}/cntools-changelog.md"; then
+        if ! cmp -s "${TMP_DIR}"/cntools-changelog.md "${PARENT}/cntools-changelog.md"; then
           # Latest changes not shown, show whats new and copy changelog
           clear 
           exec >&6 # normal stdout
           sleep 0.1
           if [[ ! -f "${PARENT}/cntools-changelog.md" ]]; then 
             # special case for first installation or 5.0.0 upgrade, print release notes until previous major version
-            println "OFF" "~ CNTools - What's New ~\n\n" "$(sed -n "/\[${CNTOOLS_MAJOR_VERSION}\.${CNTOOLS_MINOR_VERSION}\.${CNTOOLS_PATCH_VERSION}\]/,/\[$((CNTOOLS_MAJOR_VERSION-1))\.[0-9]\.[0-9]\]/p" "${TMP_FOLDER}"/cntools-changelog.md | head -n -2)" | less -X
+            println "OFF" "~ CNTools - What's New ~\n\n" "$(sed -n "/\[${CNTOOLS_MAJOR_VERSION}\.${CNTOOLS_MINOR_VERSION}\.${CNTOOLS_PATCH_VERSION}\]/,/\[$((CNTOOLS_MAJOR_VERSION-1))\.[0-9]\.[0-9]\]/p" "${TMP_DIR}"/cntools-changelog.md | head -n -2)" | less -X
           else
             # print release notes from current until previously installed version
             [[ $(cat "${PARENT}/cntools-changelog.md") =~ \[([[:digit:]])\.([[:digit:]])\.([[:digit:]])\] ]]
-            cat <(println "OFF" "~ CNTools - What's New ~\n") <(awk "1;/\[${BASH_REMATCH[1]}\.${BASH_REMATCH[2]}\.${BASH_REMATCH[3]}\]/{exit}" "${TMP_FOLDER}"/cntools-changelog.md | head -n -2 | tail -n +7) <(echo -e "\n [Press 'q' to quit and proceed to CNTools main menu]\n") | less -X
+            cat <(println "OFF" "~ CNTools - What's New ~\n") <(awk "1;/\[${BASH_REMATCH[1]}\.${BASH_REMATCH[2]}\.${BASH_REMATCH[3]}\]/{exit}" "${TMP_DIR}"/cntools-changelog.md | head -n -2 | tail -n +7) <(echo -e "\n [Press 'q' to quit and proceed to CNTools main menu]\n") | less -X
           fi
           exec >&8 # custom stdout
-          cp "${TMP_FOLDER}"/cntools-changelog.md "${PARENT}/cntools-changelog.md"
+          cp "${TMP_DIR}"/cntools-changelog.md "${PARENT}/cntools-changelog.md"
         fi
       else
         println "ERROR" "\n${FG_RED}ERROR${NC}: failed to download changelog from GitHub!"
@@ -196,7 +190,7 @@ if [[ ${CNTOOLS_MODE} = "CONNECTED" ]]; then
   elif [[ -z "${PROT_PARAMS}" ]] || ! jq -er . <<< "${PROT_PARAMS}" &>/dev/null; then
     myExit 1 "${FG_YELLOW}WARN${NC}: failed to query protocol parameters, ensure your node is running with correct genesis (the node needs to be in sync to 1 epoch after the hardfork)\n\nError message: ${PROT_PARAMS}\n\n${FG_BLUE}INFO${NC}: re-run CNTools in offline mode with -o parameter if you want to access CNTools with limited functionality"
   fi
-  echo "${PROT_PARAMS}" > "${TMP_FOLDER}"/protparams.json
+  echo "${PROT_PARAMS}" > "${TMP_DIR}"/protparams.json
 fi
 
 # check if there are pools in need of KES key rotation
@@ -235,7 +229,7 @@ fi
 function main {
   while true; do # Main loop
     # Start with a clean slate after each completed or canceled command excluding .dialogrc from purge
-    find "${TMP_FOLDER:?}" -type f -not \( -name 'protparams.json' -o -name '.dialogrc' -o -name "offline_tx*" -o -name "*_cntools_backup*" -o -name "metadata_*" \) -delete
+    find "${TMP_DIR:?}" -type f -not \( -name 'protparams.json' -o -name '.dialogrc' -o -name "offline_tx*" -o -name "*_cntools_backup*" -o -name "metadata_*" \) -delete
     clear
     println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
     if [[ ${CNTOOLS_MODE} = "CONNECTED" ]]; then
@@ -453,20 +447,20 @@ function main {
 									    "cborHex": "5880${ses_key}"
 									}
 									EOF
-                println "ACTION" "${CCLI} key verification-key --signing-key-file ${payment_sk_file} --verification-key-file ${TMP_FOLDER}/payment.evkey"
-                if ! ${CCLI} key verification-key --signing-key-file "${payment_sk_file}" --verification-key-file "${TMP_FOLDER}/payment.evkey"; then
+                println "ACTION" "${CCLI} key verification-key --signing-key-file ${payment_sk_file} --verification-key-file ${TMP_DIR}/payment.evkey"
+                if ! ${CCLI} key verification-key --signing-key-file "${payment_sk_file}" --verification-key-file "${TMP_DIR}/payment.evkey"; then
                   println "ERROR" "\n${FG_RED}ERROR${NC}: failure during payment signing key extraction!"; safeDel "${WALLET_FOLDER}/${wallet_name}"; waitForInput && continue
                 fi
-                println "ACTION" "${CCLI} key verification-key --signing-key-file ${stake_sk_file} --verification-key-file ${TMP_FOLDER}/stake.evkey"
-                if ! ${CCLI} key verification-key --signing-key-file "${stake_sk_file}" --verification-key-file "${TMP_FOLDER}/stake.evkey"; then
+                println "ACTION" "${CCLI} key verification-key --signing-key-file ${stake_sk_file} --verification-key-file ${TMP_DIR}/stake.evkey"
+                if ! ${CCLI} key verification-key --signing-key-file "${stake_sk_file}" --verification-key-file "${TMP_DIR}/stake.evkey"; then
                   println "ERROR" "\n${FG_RED}ERROR${NC}: failure during stake signing key extraction!"; safeDel "${WALLET_FOLDER}/${wallet_name}"; waitForInput && continue
                 fi
-                println "ACTION" "${CCLI} key non-extended-key --extended-verification-key-file ${TMP_FOLDER}/payment.evkey --verification-key-file ${payment_vk_file}"
-                if ! ${CCLI} key non-extended-key --extended-verification-key-file "${TMP_FOLDER}/payment.evkey" --verification-key-file "${payment_vk_file}"; then
+                println "ACTION" "${CCLI} key non-extended-key --extended-verification-key-file ${TMP_DIR}/payment.evkey --verification-key-file ${payment_vk_file}"
+                if ! ${CCLI} key non-extended-key --extended-verification-key-file "${TMP_DIR}/payment.evkey" --verification-key-file "${payment_vk_file}"; then
                   println "ERROR" "\n${FG_RED}ERROR${NC}: failure during payment verification key extraction!"; safeDel "${WALLET_FOLDER}/${wallet_name}"; waitForInput && continue
                 fi
-                println "ACTION" "${CCLI} key non-extended-key --extended-verification-key-file ${TMP_FOLDER}/stake.evkey --verification-key-file ${stake_vk_file}"
-                if ! ${CCLI} key non-extended-key --extended-verification-key-file "${TMP_FOLDER}/stake.evkey" --verification-key-file "${stake_vk_file}"; then
+                println "ACTION" "${CCLI} key non-extended-key --extended-verification-key-file ${TMP_DIR}/stake.evkey --verification-key-file ${stake_vk_file}"
+                if ! ${CCLI} key non-extended-key --extended-verification-key-file "${TMP_DIR}/stake.evkey" --verification-key-file "${stake_vk_file}"; then
                   println "ERROR" "\n${FG_RED}ERROR${NC}: failure during stake verification key extraction!"; safeDel "${WALLET_FOLDER}/${wallet_name}"; waitForInput && continue
                 fi
                 chmod 600 "${WALLET_FOLDER}/${wallet_name}/"*
@@ -550,13 +544,13 @@ function main {
                 if ! cardano-hw-cli address key-gen --path 1852H/1815H/0H/0/0 --verification-key-file "${payment_vk_file}" --hw-signing-file "${payment_sk_file}"; then
                   println "ERROR" "\n${FG_RED}ERROR${NC}: failure during payment key extraction!"; safeDel "${WALLET_FOLDER}/${wallet_name}"; waitForInput && continue
                 fi
-                jq '.description = "Payment Hardware Verification Key"' "${payment_vk_file}" > "${TMP_FOLDER}/$(basename "${payment_vk_file}").tmp" && mv -f "${TMP_FOLDER}/$(basename "${payment_vk_file}").tmp" "${payment_vk_file}"
+                jq '.description = "Payment Hardware Verification Key"' "${payment_vk_file}" > "${TMP_DIR}/$(basename "${payment_vk_file}").tmp" && mv -f "${TMP_DIR}/$(basename "${payment_vk_file}").tmp" "${payment_vk_file}"
                 println "DEBUG" "${FG_BLUE}INFO${NC}: repeat and follow instructions on hardware device to extract the ${FG_LGRAY}stake keys${NC}"
                 println "ACTION" "cardano-hw-cli address key-gen --path 1852H/1815H/0H/2/0 --verification-key-file ${stake_vk_file} --hw-signing-file ${stake_sk_file}"
                 if ! cardano-hw-cli address key-gen --path 1852H/1815H/0H/2/0 --verification-key-file "${stake_vk_file}" --hw-signing-file "${stake_sk_file}"; then
                   println "ERROR" "\n${FG_RED}ERROR${NC}: failure during stake key extraction!"; safeDel "${WALLET_FOLDER}/${wallet_name}"; waitForInput && continue
                 fi
-                jq '.description = "Stake Hardware Verification Key"' "${stake_vk_file}" > "${TMP_FOLDER}/$(basename "${stake_vk_file}").tmp" && mv -f "${TMP_FOLDER}/$(basename "${stake_vk_file}").tmp" "${stake_vk_file}"
+                jq '.description = "Stake Hardware Verification Key"' "${stake_vk_file}" > "${TMP_DIR}/$(basename "${stake_vk_file}").tmp" && mv -f "${TMP_DIR}/$(basename "${stake_vk_file}").tmp" "${stake_vk_file}"
                 getBaseAddress ${wallet_name}
                 getPayAddress ${wallet_name}
                 getRewardAddress ${wallet_name}
@@ -621,7 +615,7 @@ function main {
               fi
             else
               println "ERROR" "\n${FG_RED}ERROR${NC}: no funds available in base address for wallet ${FG_GREEN}${wallet_name}${NC}"
-              keyDeposit=$(jq -r '.keyDeposit' "${TMP_FOLDER}"/protparams.json)
+              keyDeposit=$(jq -r '.keyDeposit' "${TMP_DIR}"/protparams.json)
               println "DEBUG" "Funds for key deposit($(formatLovelace ${keyDeposit}) Ada) + transaction fee needed to register the wallet"
               waitForInput && continue
             fi
@@ -1133,7 +1127,7 @@ function main {
             for asset in "${!assets[@]}"; do
               assets_left[${asset}]=${assets[${asset}]}
             done
-            minUTxOValue=$(jq -r '.minUTxOValue //1000000' "${TMP_FOLDER}"/protparams.json)
+            minUTxOValue=$(jq -r '.minUTxOValue //1000000' "${TMP_DIR}"/protparams.json)
             # Amount
             println "DEBUG" "# Amount to Send (in Ada)"
             println "DEBUG" " Valid entry:"
@@ -1355,7 +1349,7 @@ function main {
               1) sleep 0.1 && read -r -p "vkey cbor-hex(blank to cancel): " vkey_cbor 2>&6 && println "LOG" "vkey cbor-hex(blank to cancel): ${vkey_cbor}"
                  [[ -z "${vkey_cbor}" ]] && continue
                  pool_name="${vkey_cbor}"
-                 pool_coldkey_vk_file="${TMP_FOLDER}"/pool_delegation.vkey
+                 pool_coldkey_vk_file="${TMP_DIR}"/pool_delegation.vkey
                  printf "{\"type\":\"StakePoolVerificationKey_ed25519\",\"description\":\"Stake Pool Operator Verification Key\",\"cborHex\":\"%s\"}" ${vkey_cbor} > "${pool_coldkey_vk_file}"
                  ;;
               2) continue ;;
@@ -1577,7 +1571,7 @@ function main {
             else
               margin_fraction=$(pctToFraction "${margin}")
             fi
-            minPoolCost=$(( $(jq -r '.minPoolCost //0' "${TMP_FOLDER}"/protparams.json) / 1000000 )) # convert to Ada
+            minPoolCost=$(( $(jq -r '.minPoolCost //0' "${TMP_DIR}"/protparams.json) / 1000000 )) # convert to Ada
             [[ -f ${pool_config} ]] && cost_ada=$(jq -r '.costADA //0' "${pool_config}") || cost_ada=${minPoolCost} # default cost
             [[ ${cost_ada} -lt ${minPoolCost} ]] && cost_ada=${minPoolCost} # raise old value to new minimum cost
             sleep 0.1 && read -r -p "Cost (in Ada, minimum: ${minPoolCost}, default: $(formatAsset ${cost_ada})): " cost_enter 2>&6 && println "LOG" "Cost (in Ada, minimum: ${minPoolCost}, default: $(formatAsset ${cost_ada})): ${cost_enter}"
@@ -1605,7 +1599,7 @@ function main {
               waitForInput && continue
             fi
             metadata_done=false
-            meta_tmp="${TMP_FOLDER}/url_poolmeta.json"
+            meta_tmp="${TMP_DIR}/url_poolmeta.json"
             if curl -sL -f -m ${CURL_TIMEOUT} -o "${meta_tmp}" ${meta_json_url} && jq -er . "${meta_tmp}" &>/dev/null; then
               [[ $(wc -c <"${meta_tmp}") -gt 512 ]] && println "ERROR" "${FG_RED}ERROR${NC}: file at specified URL contain more than allowed 512b of data!" && waitForInput && continue
               echo && jq -r . "${meta_tmp}" >&3 && echo
@@ -2159,7 +2153,7 @@ function main {
             fi
             echo
             epoch=$(getEpoch)
-            eMax=$(jq -r '.eMax' "${TMP_FOLDER}"/protparams.json)
+            eMax=$(jq -r '.eMax' "${TMP_DIR}"/protparams.json)
             println "DEBUG" "Current epoch: ${FG_LBLUE}${epoch}${NC}"
             epoch_start=$((epoch + 1))
             epoch_end=$((epoch + eMax))
@@ -2297,8 +2291,8 @@ function main {
             tput rc && tput ed
             if [[ ${CNTOOLS_MODE} = "CONNECTED" ]]; then
               tput sc && println "DEBUG" "Dumping ledger-state from node, can take a while on larger networks...\n"
-              println "ACTION" "timeout -k 5 $TIMEOUT_LEDGER_STATE ${CCLI} query ledger-state ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} --out-file ${TMP_FOLDER}/ledger-state.json"
-              if ! timeout -k 5 $TIMEOUT_LEDGER_STATE ${CCLI} query ledger-state ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} --out-file "${TMP_FOLDER}"/ledger-state.json; then
+              println "ACTION" "timeout -k 5 $TIMEOUT_LEDGER_STATE ${CCLI} query ledger-state ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} --out-file ${TMP_DIR}/ledger-state.json"
+              if ! timeout -k 5 $TIMEOUT_LEDGER_STATE ${CCLI} query ledger-state ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} --out-file "${TMP_DIR}"/ledger-state.json; then
                 tput rc && tput ed
                 println "ERROR" "${FG_RED}ERROR${NC}: ledger dump failed/timed out"
                 println "ERROR" "increase timeout value in cntools.config"
@@ -2312,7 +2306,7 @@ function main {
               [[ -f "${POOL_FOLDER}/${pool_name}/${POOL_DEREGCERT_FILENAME}" ]] && ledger_retiring="?" || ledger_retiring=""
             else
               tput sc && println "Parsing ledger-state, can take a while on larger networks...\n"
-              ledger_pstate=$(jq -r '.nesEs.esLState._delegationState._pstate' "${TMP_FOLDER}"/ledger-state.json)
+              ledger_pstate=$(jq -r '.nesEs.esLState._delegationState._pstate' "${TMP_DIR}"/ledger-state.json)
               ledger_pParams=$(jq -r '._pParams."'"${pool_id}"'" // empty' <<< ${ledger_pstate})
               ledger_fPParams=$(jq -r '._fPParams."'"${pool_id}"'" // empty' <<< ${ledger_pstate})
               ledger_retiring=$(jq -r '._retiring."'"${pool_id}"'" // empty' <<< ${ledger_pstate})
@@ -2349,15 +2343,15 @@ function main {
               else
                 meta_json_url=$(jq -r '.metadata.url //empty' <<< "${ledger_fPParams}")
               fi
-              if [[ -n ${meta_json_url} ]] && curl -sL -f -m ${CURL_TIMEOUT} -o "${TMP_FOLDER}/url_poolmeta.json" ${meta_json_url}; then
+              if [[ -n ${meta_json_url} ]] && curl -sL -f -m ${CURL_TIMEOUT} -o "${TMP_DIR}/url_poolmeta.json" ${meta_json_url}; then
                 println "Metadata"
-                println "$(printf "  %-19s : ${FG_LGRAY}%s${NC}" "Name" "$(jq -r .name "$TMP_FOLDER/url_poolmeta.json")")"
-                println "$(printf "  %-19s : ${FG_LGRAY}%s${NC}" "Ticker" "$(jq -r .ticker "$TMP_FOLDER/url_poolmeta.json")")"
-                println "$(printf "  %-19s : ${FG_LGRAY}%s${NC}" "Homepage" "$(jq -r .homepage "$TMP_FOLDER/url_poolmeta.json")")"
-                println "$(printf "  %-19s : ${FG_LGRAY}%s${NC}" "Description" "$(jq -r .description "$TMP_FOLDER/url_poolmeta.json")")"
+                println "$(printf "  %-19s : ${FG_LGRAY}%s${NC}" "Name" "$(jq -r .name "$TMP_DIR/url_poolmeta.json")")"
+                println "$(printf "  %-19s : ${FG_LGRAY}%s${NC}" "Ticker" "$(jq -r .ticker "$TMP_DIR/url_poolmeta.json")")"
+                println "$(printf "  %-19s : ${FG_LGRAY}%s${NC}" "Homepage" "$(jq -r .homepage "$TMP_DIR/url_poolmeta.json")")"
+                println "$(printf "  %-19s : ${FG_LGRAY}%s${NC}" "Description" "$(jq -r .description "$TMP_DIR/url_poolmeta.json")")"
                 println "$(printf "  %-19s : ${FG_LGRAY}%s${NC}" "URL" "${meta_json_url}")"
-                println "ACTION" "${CCLI} stake-pool metadata-hash --pool-metadata-file ${TMP_FOLDER}/url_poolmeta.json"
-                meta_hash_url="$( ${CCLI} stake-pool metadata-hash --pool-metadata-file "${TMP_FOLDER}/url_poolmeta.json" )"
+                println "ACTION" "${CCLI} stake-pool metadata-hash --pool-metadata-file ${TMP_DIR}/url_poolmeta.json"
+                meta_hash_url="$( ${CCLI} stake-pool metadata-hash --pool-metadata-file "${TMP_DIR}/url_poolmeta.json" )"
                 meta_hash_pParams=$(jq -r '.metadata.hash //empty' <<< "${ledger_pParams}")
                 meta_hash_fPParams=$(jq -r '.metadata.hash //empty' <<< "${ledger_fPParams}")
                 println "$(printf "  %-19s : ${FG_LGRAY}%s${NC}" "Hash URL" "${meta_hash_url}")"
@@ -2645,7 +2639,7 @@ function main {
             println "DEBUG" "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
             echo
             [[ ${ENABLE_DIALOG} = "true" ]] && println "DEBUG" "Enter path to offline tx file to sign" && waitForInput "Press any key to open the file explorer"
-            fileDialog "Enter path to offline tx file to sign" "${TMP_FOLDER}/"
+            fileDialog "Enter path to offline tx file to sign" "${TMP_DIR}/"
             println "DEBUG" "${FG_LGRAY}${file}${NC}\n"
             offline_tx=${file}
             [[ -z "${offline_tx}" ]] && continue
@@ -2661,7 +2655,7 @@ function main {
             if ! otx_date_expire="$(jq -er '."date-expire"' <<< ${offlineJSON})"; then println "ERROR" "${FG_RED}ERROR${NC}: field 'date-expire' not found in: ${offline_tx}" && waitForInput && continue; fi
             if ! otx_txFee=$(jq -er '.txFee' <<< ${offlineJSON}); then println "ERROR" "${FG_RED}ERROR${NC}: field 'txFee' not found in: ${offline_tx}" && waitForInput && continue; fi
             if ! otx_txBody=$(jq -er '.txBody' <<< ${offlineJSON}); then println "ERROR" "${FG_RED}ERROR${NC}: field 'txBody' not found in: ${offline_tx}" && waitForInput && continue; fi
-            echo -e "${otx_txBody}" > "${TMP_FOLDER}"/tx.raw
+            echo -e "${otx_txBody}" > "${TMP_DIR}"/tx.raw
             [[ $(jq -r '."signed-txBody" | length' <<< ${offlineJSON}) -gt 0 ]] && println "ERROR" "${FG_RED}ERROR${NC}: transaction already signed, please submit transaction to complete!" && waitForInput && continue
             println "DEBUG" "Transaction type : ${FG_GREEN}${otx_type}${NC}"
             if wallet_name=$(jq -er '."wallet-name"' <<< ${offlineJSON}); then 
@@ -2723,16 +2717,16 @@ function main {
                       waitForInput && continue 2
                     fi
                   else
-                    println "ACTION" "${CCLI} key verification-key --signing-key-file ${file} --verification-key-file ${TMP_FOLDER}/tmp.vkey"
-                    if ! ${CCLI} key verification-key --signing-key-file "${file}" --verification-key-file "${TMP_FOLDER}"/tmp.vkey; then waitForInput && continue 2; fi
+                    println "ACTION" "${CCLI} key verification-key --signing-key-file ${file} --verification-key-file ${TMP_DIR}/tmp.vkey"
+                    if ! ${CCLI} key verification-key --signing-key-file "${file}" --verification-key-file "${TMP_DIR}"/tmp.vkey; then waitForInput && continue 2; fi
                     if [[ $(jq -r '.type' "${file}") = *"Extended"* ]]; then
-                      println "ACTION" "${CCLI} key non-extended-key --extended-verification-key-file ${TMP_FOLDER}/tmp.vkey --verification-key-file ${TMP_FOLDER}/tmp2.vkey"
-                      if ! ${CCLI} key non-extended-key --extended-verification-key-file "${TMP_FOLDER}/tmp.vkey" --verification-key-file "${TMP_FOLDER}/tmp2.vkey"; then waitForInput && continue 2; fi
-                      mv -f "${TMP_FOLDER}/tmp2.vkey" "${TMP_FOLDER}/tmp.vkey"
+                      println "ACTION" "${CCLI} key non-extended-key --extended-verification-key-file ${TMP_DIR}/tmp.vkey --verification-key-file ${TMP_DIR}/tmp2.vkey"
+                      if ! ${CCLI} key non-extended-key --extended-verification-key-file "${TMP_DIR}/tmp.vkey" --verification-key-file "${TMP_DIR}/tmp2.vkey"; then waitForInput && continue 2; fi
+                      mv -f "${TMP_DIR}/tmp2.vkey" "${TMP_DIR}/tmp.vkey"
                     fi
-                    if [[ ${otx_vkey_cborHex} != $(jq -r .cborHex "${TMP_FOLDER}"/tmp.vkey) ]]; then
+                    if [[ ${otx_vkey_cborHex} != $(jq -r .cborHex "${TMP_DIR}"/tmp.vkey) ]]; then
                       println "ERROR" "${FG_RED}ERROR${NC}: signing key provided doesn't match with verification key in offline transaction for: ${otx_signing_name}"
-                      println "ERROR" "Provided signing key's verification cborHex: $(jq -r .cborHex "${TMP_FOLDER}"/tmp.vkey)"
+                      println "ERROR" "Provided signing key's verification cborHex: $(jq -r .cborHex "${TMP_DIR}"/tmp.vkey)"
                       println "ERROR" "Transaction verification cborHex: ${otx_vkey_cborHex}"
                       waitForInput && continue 2
                     fi
@@ -2741,7 +2735,7 @@ function main {
                   tx_sign_files+=( "${file}" )
                 done
                 if [[ ${#tx_sign_files[@]} -gt 0 ]]; then
-                  if ! signTx "${TMP_FOLDER}"/tx.raw "${tx_sign_files[@]}"; then waitForInput && continue; fi
+                  if ! signTx "${TMP_DIR}"/tx.raw "${tx_sign_files[@]}"; then waitForInput && continue; fi
                   echo
                   if jq ". += { \"signed-txBody\": $(jq -c . "${tx_signed}") }" <<< "${offlineJSON}" > "${offline_tx}"; then
                     println "Offline transaction successfully signed, please move ${offline_tx} back to online node and submit before ${FG_LGRAY}$(date '+%F %T %Z' --date="${otx_date_expire}")${NC}!"
@@ -2781,21 +2775,21 @@ function main {
                            waitForInput && continue 2
                          fi
                        else
-                         println "ACTION" "${CCLI} key verification-key --signing-key-file ${file} --verification-key-file ${TMP_FOLDER}/tmp.vkey"
-                         if ! ${CCLI} key verification-key --signing-key-file "${file}" --verification-key-file "${TMP_FOLDER}"/tmp.vkey; then waitForInput && continue 2; fi
+                         println "ACTION" "${CCLI} key verification-key --signing-key-file ${file} --verification-key-file ${TMP_DIR}/tmp.vkey"
+                         if ! ${CCLI} key verification-key --signing-key-file "${file}" --verification-key-file "${TMP_DIR}"/tmp.vkey; then waitForInput && continue 2; fi
                          if [[ $(jq -r '.type' "${file}") = *"Extended"* ]]; then
-                           println "ACTION" "${CCLI} key non-extended-key --extended-verification-key-file ${TMP_FOLDER}/tmp.vkey --verification-key-file ${TMP_FOLDER}/tmp2.vkey"
-                           if ! ${CCLI} key non-extended-key --extended-verification-key-file "${TMP_FOLDER}/tmp.vkey" --verification-key-file "${TMP_FOLDER}/tmp2.vkey"; then waitForInput && continue 2; fi
-                           mv -f "${TMP_FOLDER}/tmp2.vkey" "${TMP_FOLDER}/tmp.vkey"
+                           println "ACTION" "${CCLI} key non-extended-key --extended-verification-key-file ${TMP_DIR}/tmp.vkey --verification-key-file ${TMP_DIR}/tmp2.vkey"
+                           if ! ${CCLI} key non-extended-key --extended-verification-key-file "${TMP_DIR}/tmp.vkey" --verification-key-file "${TMP_DIR}/tmp2.vkey"; then waitForInput && continue 2; fi
+                           mv -f "${TMP_DIR}/tmp2.vkey" "${TMP_DIR}/tmp.vkey"
                          fi
-                         if [[ ${otx_vkey_cborHex} != $(jq -r .cborHex "${TMP_FOLDER}"/tmp.vkey) ]]; then
+                         if [[ ${otx_vkey_cborHex} != $(jq -r .cborHex "${TMP_DIR}"/tmp.vkey) ]]; then
                            println "ERROR" "${FG_RED}ERROR${NC}: signing key provided doesn't match with verification key in offline transaction for: ${otx_signing_name}"
-                           println "ERROR" "Provided signing key's verification cborHex: $(jq -r .cborHex "${TMP_FOLDER}"/tmp.vkey)"
+                           println "ERROR" "Provided signing key's verification cborHex: $(jq -r .cborHex "${TMP_DIR}"/tmp.vkey)"
                            println "ERROR" "Transaction verification cborHex: ${otx_vkey_cborHex}"
                            waitForInput && continue 2
                          fi
                        fi
-                       if ! witnessTx "${TMP_FOLDER}/tx.raw" "${file}"; then waitForInput && continue 2; fi
+                       if ! witnessTx "${TMP_DIR}/tx.raw" "${file}"; then waitForInput && continue 2; fi
                        if ! offlineJSON=$(jq ".witness += [{ name: \"${otx_signing_name}\", witnessBody: $(jq -c . "${tx_witness_files[0]}") }]" <<< ${offlineJSON}); then return 1; fi
                        jq -r . <<< "${offlineJSON}" > "${offline_tx}" # save this witness to disk
                        ;;
@@ -2806,11 +2800,11 @@ function main {
                 if [[ $(jq -r '."signing-file" | length' <<< "${offlineJSON}") -eq $(jq -r '.witness | length' <<< "${offlineJSON}") ]]; then # witnessed by all signing keys
                   for otx_witness in $(jq -r '.witness[] | @base64' <<< "${offlineJSON}"); do
                     _jq() { base64 -d <<< ${otx_witness} | jq -r "${1}"; }
-                    tx_witness="$(mktemp "${TMP_FOLDER}/tx.witness_XXXXXXXXXX")"
+                    tx_witness="$(mktemp "${TMP_DIR}/tx.witness_XXXXXXXXXX")"
                     jq -r . <<< "$(_jq '.witnessBody')" > "${tx_witness}"
                     tx_witness_files+=( "${tx_witness}" )
                   done
-                  if ! assembleTx "${TMP_FOLDER}/tx.raw"; then waitForInput && continue; fi
+                  if ! assembleTx "${TMP_DIR}/tx.raw"; then waitForInput && continue; fi
                   if jq ". += { \"signed-txBody\": $(jq -c . "${tx_signed}") }" <<< "${offlineJSON}" > "${offline_tx}"; then
                     println "Offline transaction successfully assembled and signed by all signing keys"
                     println "please move ${offline_tx} back to online node and submit before ${FG_LGRAY}$(date '+%F %T %Z' --date="${otx_date_expire}")${NC}!"
@@ -2836,7 +2830,7 @@ function main {
             fi
             echo
             [[ ${ENABLE_DIALOG} = "true" ]] && println "DEBUG" "Enter path to offline tx file to submit" && waitForInput "Press any key to open the file explorer"
-            fileDialog "Enter path to offline tx file to submit" "${TMP_FOLDER}/"
+            fileDialog "Enter path to offline tx file to submit" "${TMP_DIR}/"
             println "DEBUG" "${FG_LGRAY}${file}${NC}\n"
             offline_tx=${file}
             [[ -z "${offline_tx}" ]] && continue
@@ -2899,7 +2893,7 @@ function main {
                 [[ ${otx_type} = "Asset Burning" ]] && println "DEBUG" "Assets To Burn   : ${FG_LBLUE}$(formatAsset "$(jq -r '."asset-amount"' <<< ${offlineJSON})")${NC}"
                 [[ ${otx_type} = "Asset Burning" ]] && println "DEBUG" "Assets Left      : ${FG_LBLUE}$(formatAsset "$(jq -r '."asset-minted"' <<< ${offlineJSON})")${NC}"
                 if [[ ${otx_type} = "Asset Minting" || ${otx_type} = "Asset Burning" ]] && otx_metadata=$(jq -er '.metadata' <<< ${offlineJSON}); then println "DEBUG" "Metadata         : \n${otx_metadata}\n"; fi
-                tx_signed="${TMP_FOLDER}/tx.signed_$(date +%s)"
+                tx_signed="${TMP_DIR}/tx.signed_$(date +%s)"
                 println "DEBUG" "\nProceed to submit transaction?"
                 select_opt "[y] Yes" "[n] No"
                 case $? in
@@ -3145,10 +3139,10 @@ function main {
         echo
         println "DEBUG" "Full changelog available at:\nhttps://cardano-community.github.io/guild-operators/#/Scripts/cntools-changelog"
         echo
-        if curl -s -f -m ${CURL_TIMEOUT} -o "${TMP_FOLDER}"/cntools.library "${URL}/cntools.library"; then
-          GIT_MAJOR_VERSION=$(grep -r ^CNTOOLS_MAJOR_VERSION= "${TMP_FOLDER}"/cntools.library |sed -e "s#.*=##")
-          GIT_MINOR_VERSION=$(grep -r ^CNTOOLS_MINOR_VERSION= "${TMP_FOLDER}"/cntools.library |sed -e "s#.*=##")
-          GIT_PATCH_VERSION=$(grep -r ^CNTOOLS_PATCH_VERSION= "${TMP_FOLDER}"/cntools.library |sed -e "s#.*=##")
+        if curl -s -f -m ${CURL_TIMEOUT} -o "${TMP_DIR}"/cntools.library "${URL}/cntools.library"; then
+          GIT_MAJOR_VERSION=$(grep -r ^CNTOOLS_MAJOR_VERSION= "${TMP_DIR}"/cntools.library |sed -e "s#.*=##")
+          GIT_MINOR_VERSION=$(grep -r ^CNTOOLS_MINOR_VERSION= "${TMP_DIR}"/cntools.library |sed -e "s#.*=##")
+          GIT_PATCH_VERSION=$(grep -r ^CNTOOLS_PATCH_VERSION= "${TMP_DIR}"/cntools.library |sed -e "s#.*=##")
           GIT_VERSION="${GIT_MAJOR_VERSION}.${GIT_MINOR_VERSION}.${GIT_PATCH_VERSION}"
           if [[ ${CNTOOLS_MAJOR_VERSION} -lt ${GIT_MAJOR_VERSION} ]]; then
             println "DEBUG" "New major version available: ${FG_GREEN}${GIT_VERSION}${NC} (Current: ${CNTOOLS_VERSION})\n"
@@ -3312,12 +3306,12 @@ function main {
               waitForInput && continue
             fi
             println "DEBUG" "${FG_GREEN}${backup_file}${NC}\n"
-            if ! restore_path="$(mktemp -d "${TMP_FOLDER}/restore_XXXXXXXXXX")"; then println "ERROR" "${FG_RED}ERROR${NC}: failed to create restore directory:\n${restore_path}" && waitForInput && continue; fi
+            if ! restore_path="$(mktemp -d "${TMP_DIR}/restore_XXXXXXXXXX")"; then println "ERROR" "${FG_RED}ERROR${NC}: failed to create restore directory:\n${restore_path}" && waitForInput && continue; fi
             tmp_bkp_file=""
             if [ "${backup_file##*.}" = "gpg" ]; then
               println "DEBUG" "Backup GPG encrypted, enter password to decrypt"
               if getPassword; then # $password variable populated by getPassword function
-                tmp_bkp_file=$(mktemp "${TMP_FOLDER}/bkp_file_XXXXXXXXXX.tar.gz.gpg")
+                tmp_bkp_file=$(mktemp "${TMP_DIR}/bkp_file_XXXXXXXXXX.tar.gz.gpg")
                 cp -f "${backup_file}" "${tmp_bkp_file}"
                 decryptFile "${backup_file}" "${password}"
                 backup_file="${backup_file%.*}"
@@ -3450,7 +3444,7 @@ function main {
               metafile="${file}"
               println "DEBUG" "${FG_LGRAY}${metafile}${NC}\n"
             else
-              metafile="${TMP_FOLDER}/metadata_$(date '+%Y%m%d%H%M%S').json"
+              metafile="${TMP_DIR}/metadata_$(date '+%Y%m%d%H%M%S').json"
               println "DEBUG" "\nDo you want to select a metadata file, enter URL to metadata file, or enter/paste metadata content?"
               select_opt "[f] File" "[u] URL" "[e] Enter"
               case $? in
@@ -3847,7 +3841,7 @@ function main {
                 case $? in
                   0) : ;; # do nothing
                   1) [[ ${ENABLE_DIALOG} = "true" ]] && println "DEBUG" "Enter path to metadata JSON file" && waitForInput "Press any key to open the file explorer"
-                     fileDialog "Enter path to metadata JSON file" "${TMP_FOLDER}/"
+                     fileDialog "Enter path to metadata JSON file" "${TMP_DIR}/"
                      println "DEBUG" "${FG_LGRAY}${file}${NC}\n"
                      metafile=${file}
                      [[ -z "${metafile}" ]] && println "ERROR" "${FG_RED}ERROR${NC}: Metadata file path empty!" && waitForInput && continue
@@ -4025,7 +4019,7 @@ function main {
                 case $? in
                   0) : ;; # do nothing
                   1) [[ ${ENABLE_DIALOG} = "true" ]] && println "DEBUG" "Enter path to metadata JSON file" && waitForInput "Press any key to open the file explorer"
-                     fileDialog "Enter path to metadata JSON file" "${TMP_FOLDER}/"
+                     fileDialog "Enter path to metadata JSON file" "${TMP_DIR}/"
                      println "DEBUG" "${FG_LGRAY}${file}${NC}\n"
                      metafile=${file}
                      [[ -z "${metafile}" ]] && println "ERROR" "${FG_RED}ERROR${NC}: Metadata file path empty!" && waitForInput && continue

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -15,7 +15,7 @@ CNODE_PORT=6000                                         # Set node port
 #TOPOLOGY="${CNODE_HOME}/files/topology.json"           # Override default topology.json path
 #LOG_DIR="${CNODE_HOME}/logs"                           # Folder where your logs will be sent to (must pre-exist)
 #DB_DIR="${CNODE_HOME}/db"                              # Folder to store the cardano-node blockchain db
-#TMP_DIR="/tmp"                                         # Folder to hold temporary files in the various scripts, each script might create additional subfolders
+#TMP_DIR="/tmp/cnode"                                   # Folder to hold temporary files in the various scripts, each script might create additional subfolders
 #EKG_HOST=127.0.0.1                                     # Set node EKG host IP
 #EKG_PORT=12788                                         # Override automatic detection of node EKG port
 #PROM_HOST=127.0.0.1                                    # Set node Prometheus host IP
@@ -28,6 +28,7 @@ CNODE_PORT=6000                                         # Set node port
 #TG_BOT_TOKEN=""                                        # Uncomment and set to enable telegramSend function. To create your own BOT-token and Chat-Id follow guide at:
 #TG_CHAT_ID=""                                          # https://cardano-community.github.io/guild-operators/#/Scripts/sendalerts
 #USE_EKG="N"                                            # Use EKG metrics from the node instead of Promethus. Promethus metrics(default) should yield slightly better performance
+#TIMEOUT_LEDGER_STATE=300                               # Timeout in seconds for querying and dumping ledger-state
 
 #WALLET_FOLDER="${CNODE_HOME}/priv/wallet"              # Root folder for Wallets
 #POOL_FOLDER="${CNODE_HOME}/priv/pool"                  # Root folder for Pools
@@ -308,7 +309,9 @@ BYRON_EPOCH_LENGTH=$(( 10 * BYRON_K ))
 [[ -z ${LOG_DIR} ]] && LOG_DIR="${CNODE_HOME}/logs"
 [[ -n ${CNODE_LOG_DIR} ]] && LOG_DIR="${CNODE_LOG_DIR}" # compatibility with older topologyUpdater
 [[ -z ${DB_DIR} ]] && DB_DIR="${CNODE_HOME}/db"
-[[ -z ${TMP_DIR} ]] && TMP_DIR="/tmp"
+[[ -z ${TMP_DIR} ]] && TMP_DIR="/tmp/$(basename "${CNODE_HOME}")"
+if ! mkdir -p "${TMP_DIR}" 2>/dev/null; then echo "ERROR: Failed to create directory for temporary files, please set TMP_DIR to a valid folder in 'env', current folder: ${TMP_DIR}" && exit 1; fi
+[[ -z ${TIMEOUT_LEDGER_STATE} ]] && TIMEOUT_LEDGER_STATE=300
 [[ -z ${WALLET_FOLDER} ]] && WALLET_FOLDER="${CNODE_HOME}/priv/wallet"
 [[ -z ${POOL_FOLDER} ]] && POOL_FOLDER="${CNODE_HOME}/priv/pool"
 [[ -z ${POOL_NAME} ]] && POOL_NAME="CHANGE_ME"

--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -142,19 +142,19 @@ if [[ "${NO_INTERNET_MODE}" == "N" ]]; then
   esac
 
   echo "Guild LiveView version check..."
-  if curl -s -f -m ${CURL_TIMEOUT} -o "/${TMP_DIR}/gLiveView.sh" "${URL}/gLiveView.sh" 2>/dev/null; then
-    GIT_VERSION=$(grep -r ^GLV_VERSION= "/${TMP_DIR}/gLiveView.sh" | cut -d'=' -f2)
+  if curl -s -f -m ${CURL_TIMEOUT} -o "${TMP_DIR}/gLiveView.sh" "${URL}/gLiveView.sh" 2>/dev/null; then
+    GIT_VERSION=$(grep -r ^GLV_VERSION= "${TMP_DIR}/gLiveView.sh" | cut -d'=' -f2)
     : "${GIT_VERSION:=v0.0.0}"
     if ! versionCheck "${GIT_VERSION}" "${GLV_VERSION}"; then
       echo -e "\nA new version of Guild LiveView is available"
       echo "Installed Version : ${GLV_VERSION}"
       echo "Available Version : ${GIT_VERSION}"
       if getAnswer "\nDo you want to upgrade to the latest version of Guild LiveView?"; then
-        TEMPL_CMD=$(awk '/^# Do NOT modify/,0' "/${TMP_DIR}/gLiveView.sh")
+        TEMPL_CMD=$(awk '/^# Do NOT modify/,0' "${TMP_DIR}/gLiveView.sh")
         STATIC_CMD=$(awk '/#!/{x=1}/^# Do NOT modify/{exit} x' "${PARENT}/gLiveView.sh")
-        printf '%s\n%s\n' "$STATIC_CMD" "$TEMPL_CMD" > "/${TMP_DIR}/gLiveView.sh"
+        printf '%s\n%s\n' "$STATIC_CMD" "$TEMPL_CMD" > "${TMP_DIR}/gLiveView.sh"
         mv -f "${PARENT}/gLiveView.sh" "${PARENT}/gLiveView.sh_bkp$(printf '%(%s)T\n' -1)" && \
-        cp -f "/${TMP_DIR}/gLiveView.sh" "${PARENT}/gLiveView.sh" && \
+        cp -f "${TMP_DIR}/gLiveView.sh" "${PARENT}/gLiveView.sh" && \
         chmod 750 "${PARENT}/gLiveView.sh" && \
         myExit 0 "Update applied successfully!\n\nPlease start Guild LiveView again!" || \
         myExit 1 "${FG_RED}Update failed!${NC}\n\nPlease use prereqs.sh or manually download to update gLiveView"

--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -142,19 +142,19 @@ if [[ "${NO_INTERNET_MODE}" == "N" ]]; then
   esac
 
   echo "Guild LiveView version check..."
-  if curl -s -f -m ${CURL_TIMEOUT} -o /tmp/gLiveView.sh "${URL}/gLiveView.sh" 2>/dev/null; then
-    GIT_VERSION=$(grep -r ^GLV_VERSION= /tmp/gLiveView.sh | cut -d'=' -f2)
+  if curl -s -f -m ${CURL_TIMEOUT} -o "/${TMP_DIR}/gLiveView.sh" "${URL}/gLiveView.sh" 2>/dev/null; then
+    GIT_VERSION=$(grep -r ^GLV_VERSION= "/${TMP_DIR}/gLiveView.sh" | cut -d'=' -f2)
     : "${GIT_VERSION:=v0.0.0}"
     if ! versionCheck "${GIT_VERSION}" "${GLV_VERSION}"; then
       echo -e "\nA new version of Guild LiveView is available"
       echo "Installed Version : ${GLV_VERSION}"
       echo "Available Version : ${GIT_VERSION}"
       if getAnswer "\nDo you want to upgrade to the latest version of Guild LiveView?"; then
-        TEMPL_CMD=$(awk '/^# Do NOT modify/,0' /tmp/gLiveView.sh)
+        TEMPL_CMD=$(awk '/^# Do NOT modify/,0' "/${TMP_DIR}/gLiveView.sh")
         STATIC_CMD=$(awk '/#!/{x=1}/^# Do NOT modify/{exit} x' "${PARENT}/gLiveView.sh")
-        printf '%s\n%s\n' "$STATIC_CMD" "$TEMPL_CMD" > /tmp/gLiveView.sh
+        printf '%s\n%s\n' "$STATIC_CMD" "$TEMPL_CMD" > "/${TMP_DIR}/gLiveView.sh"
         mv -f "${PARENT}/gLiveView.sh" "${PARENT}/gLiveView.sh_bkp$(printf '%(%s)T\n' -1)" && \
-        cp -f /tmp/gLiveView.sh "${PARENT}/gLiveView.sh" && \
+        cp -f "/${TMP_DIR}/gLiveView.sh" "${PARENT}/gLiveView.sh" && \
         chmod 750 "${PARENT}/gLiveView.sh" && \
         myExit 0 "Update applied successfully!\n\nPlease start Guild LiveView again!" || \
         myExit 1 "${FG_RED}Update failed!${NC}\n\nPlease use prereqs.sh or manually download to update gLiveView"


### PR DESCRIPTION
Utilize a common TMP_DIR set in `env` as base dir for temporary files. Scripts may create sub-folders to TMP_DIR(default /tmp/cnode) for further separation.

TIMEOUT_LEDGER_STATE set in both cntools and cncli moved to env

Some scripts still use hardcoded /tmp storage due to not sourcing common env:
cabal-build-all.sh
stack-build.sh
setup_mon.sh
prereqs.sh
