### PR TITLE
Allow user to run gLiveView.sh from any directory

### DIFF
--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -53,7 +53,7 @@ setTheme() {
 
 GLV_VERSION=v1.19.4
 
-PARENT="$(dirname $0)"
+PARENT=$( [ -d "$CNODE_HOME/scripts" ] && echo "$CNODE_HOME/scripts" || echo "dirname $0" )
 [[ -f "${PARENT}"/.env_branch ]] && BRANCH="$(cat ${PARENT}/.env_branch)" || BRANCH="master"
 
 # Set default for user variables added in recent versions (for those who may not necessarily have it due to upgrade)


### PR DESCRIPTION
The current implementation requires that the user run gLiveView.sh from the `$CNODE_HOME/scripts` directory. Meaning that I can't call it directly from whatever directory I am in. For example, by just typing full path, like this: 

`~/> $CNODE_HOME/scripts/gLiveView.sh`

or by creating a symlink in my home directory called `~/scripts/` that points to the `$CNODE_HOME/scripts` that I can call like this:

`/> ~/scripts/gLiveView.sh`

This patch checks to see if `$CNODE_HOME` is defined and that `$CNODE_HOME/scripts` is a directory. If so, `PARENT` is set to that directory. Otherwise, it reverts to the default implementation.