### PR TITLE
Prereqs script brew fix

### DIFF
--- a/scripts/cnode-helper-scripts/prereqs.sh
+++ b/scripts/cnode-helper-scripts/prereqs.sh
@@ -218,7 +218,7 @@ if [ "$WANT_BUILD_DEPS" = 'Y' ]; then
   elif [[ $(uname) == Darwin ]]; then
     echo "MacOS detected";
     pkg_list="coreutils gnupg jq libsodium tcptraceroute"
-    brew install "${pkg_list}" > /dev/null;rc=$?
+    brew install ${pkg_list} > /dev/null;rc=$?
 
     if [ $rc != 0 ]; then
       echo "An error occurred while installing the prerequisite packages, please investigate by using the command below:"


### PR DESCRIPTION
On MacOS, scripts/prereqs.sh would not complete because the brew install command was treating the package list as one name. The exact error I was getting is:

> No available formula or cask with the name "coreutils gnupg jq libsodium tcptraceroute".

Removing the quotes around the package list seems to fix it.