### PR TITLE
Update yum install error message to include all arguments

### DIFF
--- a/scripts/cnode-helper-scripts/prereqs.sh
+++ b/scripts/cnode-helper-scripts/prereqs.sh
@@ -204,7 +204,7 @@ if [ "$WANT_BUILD_DEPS" = 'Y' ]; then
     $sudo yum -y --allowerasing install ${pkg_list} > /dev/null;rc=$?
     if [ $rc != 0 ]; then
       echo "An error occurred while installing the prerequisite packages, please investigate by using the command below:"
-      echo "sudo yum -y install ${pkg_list}"
+      echo "sudo yum -y --allowerasing install ${pkg_list}"
       echo "It would be best if you could submit an issue at ${REPO} with the details to tackle in future, as some errors may be due to external/already present dependencies"
       err_exit
     fi


### PR DESCRIPTION
This just updates the error message to include all args when packages fail to install.

Not including the `--allowerasing` flag in the error message is confusing since the printed command run in RHEL7 just fine, but fails with the `--allowerasing` flag. Including the flag allows the user to try to command that was actually run.