### PR TITLE
Adapt for changes in cardano-node 1.26.x

### DIFF
--- a/docs/Scripts/cntools-changelog.md
+++ b/docs/Scripts/cntools-changelog.md
@@ -5,7 +5,7 @@ All notable changes to this tool will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [8.1.0] - 2021-03-22
+## [8.1.0] - 2021-03-26
 
 ##### Added
 - IPv6 support in pool registration/modification
@@ -13,6 +13,7 @@ and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ##### Changed
 - Wallet delegation now lets you specify Pool ID in addition to local CNTools pool instead of previous cold.vkey cbor string
 - A couple of functions regarding number validation moved to common env file
+- Code adapted for changes in ledger-state dump used by 'Pool >> Show' 
 
 ## [8.0.2] - 2021-03-15
 

--- a/docs/Scripts/cntools-changelog.md
+++ b/docs/Scripts/cntools-changelog.md
@@ -13,7 +13,10 @@ and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ##### Changed
 - Wallet delegation now lets you specify Pool ID in addition to local CNTools pool instead of previous cold.vkey cbor string
 - A couple of functions regarding number validation moved to common env file
-- Code adapted for changes in ledger-state dump used by 'Pool >> Show' 
+- Code adapted for changes in ledger-state dump used by 'Pool >> Show'
+
+##### Fixed
+- Backup & restore now exclude gpg encrypted keys from online backup and suppression of false alarms
 
 ## [8.0.2] - 2021-03-15
 

--- a/scripts/cnode-helper-scripts/balance.sh
+++ b/scripts/cnode-helper-scripts/balance.sh
@@ -23,7 +23,7 @@ function cleanup() {
 # start with a clean slate
 cleanup
 
-${CCLI} query utxo ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} --address "${WALLET_ADDR}" > "${TMP_DIR}/fullUtxo.out"
+${CCLI} query utxo ${NETWORK_IDENTIFIER} --address "${WALLET_ADDR}" > "${TMP_DIR}/fullUtxo.out"
 tail -n +3 "${TMP_DIR}/fullUtxo.out" | sort -k3 -nr > "${TMP_DIR}/balance.txt"
 
 TOTALBALANCE=0

--- a/scripts/cnode-helper-scripts/cncli.sh
+++ b/scripts/cnode-helper-scripts/cncli.sh
@@ -195,7 +195,7 @@ cncliInit() {
   
   [[ ! -f "${CNCLI}" ]] && echo -e "\nERROR: failed to locate cncli executable, please install with 'prereqs.sh'\n" && exit 1
   CNCLI_VERSION="v$(cncli -V | cut -d' ' -f2)"
-  if ! versionCheck "1.5.0" "${CNCLI_VERSION}"; then echo "ERROR: cncli ${CNCLI_VERSION} installed, please upgrade to latest version!"; exit 1; fi
+  if ! versionCheck "1.5.1" "${CNCLI_VERSION}"; then echo "ERROR: cncli ${CNCLI_VERSION} installed, minimum required version is 1.5.1, please upgrade to latest version!"; exit 1; fi
   
   [[ -z "${CNCLI_DIR}" ]] && CNCLI_DIR="${CNODE_HOME}/guild-db/cncli"
   if ! mkdir -p "${CNCLI_DIR}" 2>/dev/null; then echo "ERROR: Failed to create CNCLI DB directory: ${CNCLI_DIR}"; exit 1; fi

--- a/scripts/cnode-helper-scripts/cncli.sh
+++ b/scripts/cnode-helper-scripts/cncli.sh
@@ -175,10 +175,10 @@ cncliInit() {
       echo -e "This is a mandatory prerequisite, please set variables accordingly in User Variables section in the env file and restart cncli.sh\n"
       exit 0
     fi
-  else # Download failed, ignore update check
-    rm -f "${PARENT}"/cncli.sh.tmp
-    rm -f "${PARENT}"/env.tmp
   fi
+  rm -f "${PARENT}"/cncli.sh.tmp
+  rm -f "${PARENT}"/env.tmp
+
   if [[ ! -f "${PARENT}"/env ]]; then
     echo -e "\nCommon env file missing: ${PARENT}/env"
     echo -e "This is a mandatory prerequisite, please install with prereqs.sh or manually download from GitHub\n"

--- a/scripts/cnode-helper-scripts/cncli.sh
+++ b/scripts/cnode-helper-scripts/cncli.sh
@@ -107,7 +107,7 @@ dumpLedgerState() { # getNodeMetrics expected to have been already run
   ledger_state_file="${TMP_DIR}/ledger-state_${NWMAGIC}_${epochnum}.json"
   [[ -n $(find "${ledger_state_file}" -mmin -60 2>/dev/null) ]] && return 0 # no need to continue, we have a fresh(<1h) ledger-state already
   rm -f "${TMP_DIR}/ledger-state_"* # remove old ledger dumps before creating a new
-  if ! timeout -k 5 "${TIMEOUT_LEDGER_STATE}" ${CCLI} query ledger-state ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} --out-file "${ledger_state_file}"; then
+  if ! timeout -k 5 "${TIMEOUT_LEDGER_STATE}" ${CCLI} query ledger-state ${NETWORK_IDENTIFIER} --out-file "${ledger_state_file}"; then
     echo "ERROR: ledger dump failed/timed out, increase timeout value"
     [[ -f "${ledger_state_file}" ]] && rm -f "${ledger_state_file}"
     return 1

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -11,7 +11,7 @@ CNTOOLS_MAJOR_VERSION=8
 # Changes that can be applied without breaking existing functionality that can be applied from within CNTools
 CNTOOLS_MINOR_VERSION=0
 # Backwards compatible bug fixes. No additional functionality or major changes and can be applied from within CNTools
-CNTOOLS_PATCH_VERSION=4
+CNTOOLS_PATCH_VERSION=5
 CNTOOLS_VERSION="${CNTOOLS_MAJOR_VERSION}.${CNTOOLS_MINOR_VERSION}.${CNTOOLS_PATCH_VERSION}"
 
 ############################################################
@@ -20,6 +20,9 @@ CNTOOLS_VERSION="${CNTOOLS_MAJOR_VERSION}.${CNTOOLS_MINOR_VERSION}.${CNTOOLS_PAT
 ############################################################
 TMP_DIR="${TMP_DIR}/cntools"
 if ! mkdir -p "${TMP_DIR}" 2>/dev/null; then myExit 1 "${FG_RED}ERROR${NC}: Failed to create directory for temporary files: ${TMP_DIR}"; fi
+if ! mkdir -p "${WALLET_FOLDER}" 2>/dev/null; then myExit 1 "${FG_RED}ERROR${NC}: Failed to create wallet directory: ${WALLET_FOLDER}"; fi
+if ! mkdir -p "${POOL_FOLDER}" 2>/dev/null; then myExit 1 "${FG_RED}ERROR${NC}: Failed to create pool directory: ${POOL_FOLDER}"; fi
+if ! mkdir -p "${ASSET_FOLDER}" 2>/dev/null; then myExit 1 "${FG_RED}ERROR${NC}: Failed to create asset directory: ${POOL_ASSET}"; fi
 [[ -z ${TIMEOUT_NO_OF_SLOTS} ]] && TIMEOUT_NO_OF_SLOTS=600
 [[ ${SHELLEY_TRANS_FILENAME} =~ ^${CNODE_HOME}/db/ ]] && mkdir -p "${CNODE_HOME}/guild-db" && SHELLEY_TRANS_FILENAME="${CNODE_HOME}/guild-db/shelley_trans_epoch"
 [[ -z ${WALLET_SELECTION_FILTER_LIMIT} ]] && WALLET_SELECTION_FILTER_LIMIT=10

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -11,7 +11,7 @@ CNTOOLS_MAJOR_VERSION=8
 # Changes that can be applied without breaking existing functionality that can be applied from within CNTools
 CNTOOLS_MINOR_VERSION=0
 # Backwards compatible bug fixes. No additional functionality or major changes and can be applied from within CNTools
-CNTOOLS_PATCH_VERSION=3
+CNTOOLS_PATCH_VERSION=4
 CNTOOLS_VERSION="${CNTOOLS_MAJOR_VERSION}.${CNTOOLS_MINOR_VERSION}.${CNTOOLS_PATCH_VERSION}"
 
 ############################################################

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -11,7 +11,7 @@ CNTOOLS_MAJOR_VERSION=8
 # Changes that can be applied without breaking existing functionality that can be applied from within CNTools
 CNTOOLS_MINOR_VERSION=0
 # Backwards compatible bug fixes. No additional functionality or major changes and can be applied from within CNTools
-CNTOOLS_PATCH_VERSION=2
+CNTOOLS_PATCH_VERSION=3
 CNTOOLS_VERSION="${CNTOOLS_MAJOR_VERSION}.${CNTOOLS_MINOR_VERSION}.${CNTOOLS_PATCH_VERSION}"
 
 ############################################################
@@ -475,7 +475,7 @@ selectWallet() {
         [[ -z ${base_addr} ]] && wallet_dirs+=("${dir}") && continue # ignore and add wallet without extra details
         getBalance ${base_addr}
         if getRewardAddress ${dir}; then
-          delegation_pool_id=$(${CCLI} query stake-address-info ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} --address "${reward_addr}" | jq -r '.[0].delegation // empty')
+          delegation_pool_id=$(${CCLI} query stake-address-info ${NETWORK_IDENTIFIER} --address "${reward_addr}" | jq -r '.[0].delegation // empty')
           unset poolName
           if [[ -n ${delegation_pool_id} ]]; then
             while IFS= read -r -d '' pool; do
@@ -972,7 +972,7 @@ getBalance() {
   asset_name_maxlen=5; asset_amount_maxlen=12
   tx_in=""
   
-  if ! utxo_raw=$(${CCLI} query utxo ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} --address "${1}"); then return 1; fi
+  if ! utxo_raw=$(${CCLI} query utxo ${NETWORK_IDENTIFIER} --address "${1}"); then return 1; fi
   
   [[ -z ${utxo_raw} ]] && return
   
@@ -1003,7 +1003,7 @@ getBalance() {
 
   # Alternative code using jq (jq has issues with large integer numbers)
   : <<'END_COMMENT'
-  if ! utxo_JSON=$(${CCLI} query utxo ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} --address "${1}" --out-file /dev/stdout); then return 1; fi
+  if ! utxo_JSON=$(${CCLI} query utxo ${NETWORK_IDENTIFIER} --address "${1}" --out-file /dev/stdout); then return 1; fi
   
   utxo_cnt=$(jq length <<< ${utxo_JSON})
   [[ ${utxo_cnt} = 0 ]] && return
@@ -1092,8 +1092,8 @@ getRewards() {
 # Parameters  : stake address  >  the address from stake.vkey
 # Return      : populates ${reward_lovelace}
 getRewardsFromAddr() {
-  println "ACTION" "${CCLI} query stake-address-info ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} --address ${1}"
-  stake_address_info=$(${CCLI} query stake-address-info ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} --address ${1})
+  println "ACTION" "${CCLI} query stake-address-info ${NETWORK_IDENTIFIER} --address ${1}"
+  stake_address_info=$(${CCLI} query stake-address-info ${NETWORK_IDENTIFIER} --address ${1})
   reward_lovelace=0
   for reward_entry in $(jq -r '.[] | @base64' <<< "${stake_address_info}"); do
     _jq() { base64 -d <<< ${reward_entry} | jq -r "${1}"; }
@@ -1106,8 +1106,8 @@ getRewardsFromAddr() {
 # Parameters  : wallet name  >  the name of the wallet
 isWalletRegistered() {
   if getRewardAddress $1; then
-    println "ACTION" "${CCLI} query stake-address-info ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} --address ${reward_addr}"
-    stake_address_info=$(${CCLI} query stake-address-info ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} --address ${reward_addr})
+    println "ACTION" "${CCLI} query stake-address-info ${NETWORK_IDENTIFIER} --address ${reward_addr}"
+    stake_address_info=$(${CCLI} query stake-address-info ${NETWORK_IDENTIFIER} --address ${reward_addr})
     [[ -n "${stake_address_info}" && $(jq -r 'length' <<< ${stake_address_info}) -gt 0 ]] && return 0
   fi
   return 1

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -1066,10 +1066,10 @@ getAssetsTxOut() {
 
 # Command     : getMinUTxObalance
 # Description : calculate minimum balance needed in source wallet UTxOs for transaction to be valid
-#               getBalance assumed to be run before and protocol params file available at "${TMP_DIR}"/protparams.json
+#               getBalance assumed to be run before
 # Return      : populates ${min_utxo_balance}
 getMinUTxObalance() {
-  [[ -z ${minUTxOValue} ]] && minUTxOValue=$(jq -r '.minUTxOValue //1000000' "${TMP_DIR}"/protparams.json)
+  [[ -z ${minUTxOValue} ]] && minUTxOValue=$(jq -r '.minUTxOValue //1000000' <<< "${PROT_PARAMS}")
   min_utxo_balance=$(( minUTxOValue + ($((${#assets[@]}-1))*minUTxOValue) ))	# TODO: improve when better calculations are provided in cardano-cli
 }
 
@@ -1191,8 +1191,8 @@ registerStakeWallet() {
   if ! ${CCLI} stake-address registration-certificate --stake-verification-key-file "${stake_vk_file}" --out-file "${stake_cert_file}"; then return 1; fi
 
   if ! getTTL; then return 1; fi
-  keyDeposit=$(jq -r '.keyDeposit' "${TMP_DIR}"/protparams.json)
-  println "LOG" "Key Deposit is ${keyDeposit}"
+  stakeAddressDeposit=$(jq -r '.stakeAddressDeposit' <<< "${PROT_PARAMS}")
+  println "LOG" "Key Deposit is ${stakeAddressDeposit}"
 
   getAssetsTxOut
 
@@ -1213,13 +1213,13 @@ registerStakeWallet() {
   println "LOG" "fee is $(formatLovelace ${min_fee}) Ada"
 
   getMinUTxObalance
-  if [[ ${assets[lovelace]} -lt $(( min_utxo_balance + keyDeposit )) ]]; then
-    println "ERROR" "\n${FG_RED}ERROR${NC}: Not enough Ada in base address ( $(formatLovelace ${assets[lovelace]}) < $(formatLovelace ${keyDeposit}) + $(formatLovelace ${min_utxo_balance}) )"
+  if [[ ${assets[lovelace]} -lt $(( min_utxo_balance + stakeAddressDeposit )) ]]; then
+    println "ERROR" "\n${FG_RED}ERROR${NC}: Not enough Ada in base address ( $(formatLovelace ${assets[lovelace]}) < $(formatLovelace ${stakeAddressDeposit}) + $(formatLovelace ${min_utxo_balance}) )"
     return 1
   fi
 
-  newBalance=$(( ${assets[lovelace]} - min_fee - keyDeposit ))
-  println "LOG" "New balance after tx fee and key deposit is $(formatLovelace ${newBalance}) Ada ($(formatLovelace ${assets[lovelace]}) - $(formatLovelace ${min_fee}) - $(formatLovelace ${keyDeposit}))"
+  newBalance=$(( ${assets[lovelace]} - min_fee - stakeAddressDeposit ))
+  println "LOG" "New balance after tx fee and key deposit is $(formatLovelace ${newBalance}) Ada ($(formatLovelace ${assets[lovelace]}) - $(formatLovelace ${min_fee}) - $(formatLovelace ${stakeAddressDeposit}))"
   
   build_args=(
     ${tx_in}
@@ -1234,7 +1234,7 @@ registerStakeWallet() {
   if [[ ${op_mode} = "hybrid" ]]; then
     if ! buildOfflineJSON "Wallet Registration"; then return 1; fi
     if ! offlineJSON=$(jq ". += { \"wallet-name\": \"${wallet_name}\" }" <<< ${offlineJSON}); then return 1; fi
-    if ! offlineJSON=$(jq ". += { txFee: \"$(( min_fee + keyDeposit ))\" }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txFee: \"$(( min_fee + stakeAddressDeposit ))\" }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_DIR}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"signing-file\": [] }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ".\"signing-file\" += [{ name: \"Wallet '${wallet_name}' payment signing key\", vkey: $(jq -c . "${payment_vk_file}") }]" <<< ${offlineJSON}); then return 1; fi
@@ -1271,8 +1271,8 @@ deregisterStakeWallet() {
 
   if ! getTTL; then return 1; fi
   
-  keyDeposit=$(jq -r '.keyDeposit' "${TMP_DIR}"/protparams.json)
-  println "LOG" "Key Deposit is ${keyDeposit}"
+  stakeAddressDeposit=$(jq -r '.stakeAddressDeposit' <<< "${PROT_PARAMS}")
+  println "LOG" "Key Deposit is ${stakeAddressDeposit}"
 
   getAssetsTxOut
 
@@ -1293,13 +1293,13 @@ deregisterStakeWallet() {
   println "LOG" "fee is $(formatLovelace ${min_fee}) Ada"
 
   getMinUTxObalance
-  if [[ $(( ${assets[lovelace]} + keyDeposit - min_fee )) -lt ${min_utxo_balance} ]]; then
-    println "ERROR" "\n${FG_RED}ERROR${NC}: Not enough Ada in base address ( $(formatLovelace ${assets[lovelace]}) + $(formatLovelace ${keyDeposit}) < $(formatLovelace ${min_utxo_balance}) )"
+  if [[ $(( ${assets[lovelace]} + stakeAddressDeposit - min_fee )) -lt ${min_utxo_balance} ]]; then
+    println "ERROR" "\n${FG_RED}ERROR${NC}: Not enough Ada in base address ( $(formatLovelace ${assets[lovelace]}) + $(formatLovelace ${stakeAddressDeposit}) < $(formatLovelace ${min_utxo_balance}) )"
     return 1
   fi
 
-  newBalance=$(( ${assets[lovelace]} + keyDeposit - min_fee ))
-  println "LOG" "New balance after returned key deposit and subtracted tx fee is $(formatLovelace ${newBalance}) Ada ($(formatLovelace ${assets[lovelace]}) + $(formatLovelace ${keyDeposit}) - $(formatLovelace ${min_fee}))"
+  newBalance=$(( ${assets[lovelace]} + stakeAddressDeposit - min_fee ))
+  println "LOG" "New balance after returned key deposit and subtracted tx fee is $(formatLovelace ${newBalance}) Ada ($(formatLovelace ${assets[lovelace]}) + $(formatLovelace ${stakeAddressDeposit}) - $(formatLovelace ${min_fee}))"
   
   build_args=(
     ${tx_in}
@@ -1314,7 +1314,7 @@ deregisterStakeWallet() {
   if [[ ${op_mode} = "hybrid" ]]; then
     if ! buildOfflineJSON "Wallet De-Registration"; then return 1; fi
     if ! offlineJSON=$(jq ". += { \"wallet-name\": \"${wallet_name}\" }" <<< ${offlineJSON}); then return 1; fi
-    if ! offlineJSON=$(jq ". += { \"amount-returned\": \"${keyDeposit}\" }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { \"amount-returned\": \"${stakeAddressDeposit}\" }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { txFee: \"${min_fee}\" }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_DIR}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"signing-file\": [] }" <<< ${offlineJSON}); then return 1; fi
@@ -1396,7 +1396,7 @@ sendAssets() {
     --out-file "${TMP_DIR}"/tx.raw
   )
   
-  [[ -z ${minUTxOValue} ]] && minUTxOValue=$(jq -r '.minUTxOValue //1000000' "${TMP_DIR}"/protparams.json)
+  [[ -z ${minUTxOValue} ]] && minUTxOValue=$(jq -r '.minUTxOValue //1000000' <<< "${PROT_PARAMS}")
   
   if [[ ${outCount} -eq 1 ]]; then # all assets to destination, nothing to return
     newBalance=0
@@ -1604,8 +1604,8 @@ registerPool() {
   
   if ! getTTL; then return 1; fi
   
-  poolDeposit=$(jq -r '.poolDeposit' "${TMP_DIR}"/protparams.json)
-  println "LOG" "Pool Deposit is ${poolDeposit}"
+  stakePoolDeposit=$(jq -r '.stakePoolDeposit' <<< "${PROT_PARAMS}")
+  println "LOG" "Pool Deposit is ${stakePoolDeposit}"
   
   owner_delegation_cert=""
   [[ ${delegate_owner_wallet} = 'Y' ]] && owner_delegation_cert="--certificate-file ${owner_delegation_cert_file}"
@@ -1649,13 +1649,13 @@ registerPool() {
   println "LOG" "fee is $(formatLovelace ${min_fee}) Ada"
 
   getMinUTxObalance
-  if [[ ${assets[lovelace]} -lt $(( min_utxo_balance + poolDeposit )) ]]; then
-    println "ERROR" "\n${FG_RED}ERROR${NC}: Not enough Ada in base address ( $(formatLovelace ${assets[lovelace]}) < $(formatLovelace ${min_utxo_balance}) + $(formatLovelace ${poolDeposit}) )"
+  if [[ ${assets[lovelace]} -lt $(( min_utxo_balance + stakePoolDeposit )) ]]; then
+    println "ERROR" "\n${FG_RED}ERROR${NC}: Not enough Ada in base address ( $(formatLovelace ${assets[lovelace]}) < $(formatLovelace ${min_utxo_balance}) + $(formatLovelace ${stakePoolDeposit}) )"
     return 1
   fi
 
-  newBalance=$(( ${assets[lovelace]} - min_fee - poolDeposit ))
-  println "LOG" "Balance left to be returned in used UTxO is $(formatLovelace ${newBalance}) Ada ( $(formatLovelace ${assets[lovelace]}) - $(formatLovelace ${min_fee}) - $(formatLovelace ${poolDeposit}) )"
+  newBalance=$(( ${assets[lovelace]} - min_fee - stakePoolDeposit ))
+  println "LOG" "Balance left to be returned in used UTxO is $(formatLovelace ${newBalance}) Ada ( $(formatLovelace ${assets[lovelace]}) - $(formatLovelace ${min_fee}) - $(formatLovelace ${stakePoolDeposit}) )"
   
   build_args=(
     ${tx_in}
@@ -1677,7 +1677,7 @@ registerPool() {
     if ! offlineJSON=$(jq ". += { \"pool-margin\": \"${margin}\" }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"pool-cost\": \"${cost_ada}\" }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"pool-reg-cert\": $(jq -c . "${pool_regcert_file}") }" <<< ${offlineJSON}); then return 1; fi
-    if ! offlineJSON=$(jq ". += { txFee: \"$(( min_fee + poolDeposit ))\" }" <<< ${offlineJSON}); then return 1; fi
+    if ! offlineJSON=$(jq ". += { txFee: \"$(( min_fee + stakePoolDeposit ))\" }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { txBody: $(jq -c . "${TMP_DIR}"/tx.raw) }" <<< ${offlineJSON}); then return 1; fi
     if ! offlineJSON=$(jq ". += { \"signing-file\": [] }" <<< ${offlineJSON}); then return 1; fi
     for index in "${!owner_wallets[@]}"; do

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -2604,7 +2604,6 @@ function main {
                 waitForInput && continue
               fi
               keyFiles=(
-                "${POOL_FOLDER}/${pool_name}/${POOL_COLDKEY_VK_FILENAME}"
                 "${POOL_FOLDER}/${pool_name}/${POOL_COLDKEY_SK_FILENAME}"
               )
               for keyFile in "${keyFiles[@]}"; do
@@ -3246,9 +3245,13 @@ function main {
             case $? in
               0) excluded_files=(
                    "--delete *${WALLET_PAY_SK_FILENAME}"
+                   "--delete *${WALLET_PAY_SK_FILENAME}.gpg"
                    "--delete *${WALLET_STAKE_SK_FILENAME}"
+                   "--delete *${WALLET_STAKE_SK_FILENAME}.gpg"
                    "--delete *${POOL_COLDKEY_SK_FILENAME}"
+                   "--delete *${POOL_COLDKEY_SK_FILENAME}.gpg"
                    "--delete *${ASSET_POLICY_SK_FILENAME}"
+                   "--delete *${ASSET_POLICY_SK_FILENAME}.gpg"
                  )
                  backup_file="${backup_path}online_cntools_backup-$(date '+%Y%m%d%H%M%S').tar"
                  ;;
@@ -3270,7 +3273,7 @@ function main {
                 backup_list+=( "${dir}" )
                 println "DEBUG" "  ${FG_LGRAY}$(basename "${dir}")${NC}"
                 ((backup_cnt++))
-              done < <(find "${item}" -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
+              done < <(find "${item}" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null | sort -z)
             done
             [[ ${backup_cnt} -eq 0 ]] && println "\nNo folders found to include in backup :(" && waitForInput && continue
             echo
@@ -3292,12 +3295,12 @@ function main {
                   println "${FG_YELLOW}WARN${NC}: Wallet ${FG_GREEN}${wallet_name}${NC} missing payment signing key file" && missing_keys="true"
                 [[ -z "$(find "${wallet}" -mindepth 1 -maxdepth 1 -type f \( -name "${WALLET_STAKE_SK_FILENAME}*" -o -name "${WALLET_HW_STAKE_SK_FILENAME}" \) -print)" ]] && \
                   println "${FG_YELLOW}WARN${NC}: Wallet ${FG_GREEN}${wallet_name}${NC} missing stake signing key file" && missing_keys="true"
-              done < <(find "${WALLET_FOLDER}" -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
+              done < <(find "${WALLET_FOLDER}" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null | sort -z)
               while IFS= read -r -d '' pool; do
                 pool_name=$(basename ${pool})
                 [[ -z "$(find "${pool}" -mindepth 1 -maxdepth 1 -type f -name "${POOL_COLDKEY_SK_FILENAME}*" -print)" ]] && \
                   println "${FG_YELLOW}WARN${NC}: Pool ${FG_GREEN}${pool_name}${NC} missing file ${POOL_COLDKEY_SK_FILENAME}" && missing_keys="true"
-              done < <(find "${POOL_FOLDER}" -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
+              done < <(find "${POOL_FOLDER}" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null | sort -z)
               [[ ${missing_keys} = "true" ]] && echo
             fi
              println "DEBUG" "Encrypt backup?"
@@ -3365,7 +3368,7 @@ function main {
                 restore_list+=( "${dir}" )
                 println "DEBUG" "  ${FG_LGRAY}$(basename "${dir}")${NC}"
                 ((restore_cnt++))
-              done < <(find "${item}" -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
+              done < <(find "${item}" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null | sort -z)
             done
             [[ ${restore_cnt} -eq 0 ]] && println "\nNothing in backup file to restore :(" && waitForInput && continue
             echo
@@ -3389,7 +3392,7 @@ function main {
               while IFS= read -r -d '' dir; do
                 archive_list+=( "${item}" )
                 ((source_cnt++))
-              done < <(find "${item}" -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
+              done < <(find "${item}" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null | sort -z)
             done
             if [[ ${source_cnt} -gt 0 ]]; then
               archive_dest="${CNODE_HOME}/priv/archive"
@@ -3413,7 +3416,7 @@ function main {
               dest_path="${item:${#restore_path}}"
               while IFS= read -r -d '' file; do # unlock files to make sure restore is successful
                 unlockFile "${file}"
-              done < <(find "${dest_path}" -mindepth 1 -maxdepth 1 -type f -print0)
+              done < <(find "${dest_path}" -mindepth 1 -maxdepth 1 -type f -print0 2>/dev/null)
               println "ACTION" "cp -rf ${item} $(dirname "${dest_path}")"
               cp -rf "${item}" "$(dirname "${dest_path}")"
             done

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -2303,8 +2303,8 @@ function main {
             tput rc && tput ed
             if [[ ${CNTOOLS_MODE} = "CONNECTED" ]]; then
               tput sc && println "DEBUG" "Dumping ledger-state from node, can take a while on larger networks...\n"
-              println "ACTION" "timeout -k 5 $TIMEOUT_LEDGER_STATE ${CCLI} query ledger-state ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} --out-file ${TMP_DIR}/ledger-state.json"
-              if ! timeout -k 5 $TIMEOUT_LEDGER_STATE ${CCLI} query ledger-state ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} --out-file "${TMP_DIR}"/ledger-state.json; then
+              println "ACTION" "timeout -k 5 $TIMEOUT_LEDGER_STATE ${CCLI} query ledger-state ${NETWORK_IDENTIFIER} --out-file ${TMP_DIR}/ledger-state.json"
+              if ! timeout -k 5 $TIMEOUT_LEDGER_STATE ${CCLI} query ledger-state ${NETWORK_IDENTIFIER} --out-file "${TMP_DIR}"/ledger-state.json; then
                 tput rc && tput ed
                 println "ERROR" "${FG_RED}ERROR${NC}: ledger dump failed/timed out"
                 println "ERROR" "increase timeout value in cntools.config"
@@ -2473,8 +2473,8 @@ function main {
                     println "$(printf "%-21s : ${FG_LGRAY}%s${NC}" "Reward account" "${reward_account}")"
                   fi
                 fi
-                println "ACTION" "LC_NUMERIC=C printf %.10f \$(${CCLI} query stake-distribution ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} | grep ${pool_id_bech32} | tr -s ' ' | cut -d ' ' -f 2))"
-                stake_pct=$(fractionToPCT "$(LC_NUMERIC=C printf "%.10f" "$(${CCLI} query stake-distribution ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} | grep "${pool_id_bech32}" | tr -s ' ' | cut -d ' ' -f 2)")")
+                println "ACTION" "LC_NUMERIC=C printf %.10f \$(${CCLI} query stake-distribution ${NETWORK_IDENTIFIER} | grep ${pool_id_bech32} | tr -s ' ' | cut -d ' ' -f 2))"
+                stake_pct=$(fractionToPCT "$(LC_NUMERIC=C printf "%.10f" "$(${CCLI} query stake-distribution ${NETWORK_IDENTIFIER} | grep "${pool_id_bech32}" | tr -s ' ' | cut -d ' ' -f 2)")")
                 if validateDecimalNbr ${stake_pct}; then
                   println "$(printf "%-21s : ${FG_LBLUE}%s${NC} %%" "Stake distribution" "${stake_pct}")"
                 fi

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -621,8 +621,8 @@ function main {
               fi
             else
               println "ERROR" "\n${FG_RED}ERROR${NC}: no funds available in base address for wallet ${FG_GREEN}${wallet_name}${NC}"
-              keyDeposit=$(jq -r '.keyDeposit' "${TMP_DIR}"/protparams.json)
-              println "DEBUG" "Funds for key deposit($(formatLovelace ${keyDeposit}) Ada) + transaction fee needed to register the wallet"
+              stakeAddressDeposit=$(jq -r '.stakeAddressDeposit' <<< "${PROT_PARAMS}")
+              println "DEBUG" "Funds for key deposit($(formatLovelace ${stakeAddressDeposit}) Ada) + transaction fee needed to register the wallet"
               waitForInput && continue
             fi
             if ! registerStakeWallet ${wallet_name} "true"; then
@@ -680,7 +680,7 @@ function main {
             if ! verifyTx ${base_addr}; then waitForInput && continue; fi
             echo
             println "${FG_GREEN}${wallet_name}${NC} successfully de-registered from chain!"
-            println "Key deposit fee that will be refunded : ${FG_LBLUE}$(formatLovelace ${keyDeposit})${NC} Ada"
+            println "Key deposit fee that will be refunded : ${FG_LBLUE}$(formatLovelace ${stakeAddressDeposit})${NC} Ada"
             waitForInput && continue
             ;; ###################################################################
           list)
@@ -1135,7 +1135,7 @@ function main {
             for asset in "${!assets[@]}"; do
               assets_left[${asset}]=${assets[${asset}]}
             done
-            minUTxOValue=$(jq -r '.minUTxOValue //1000000' "${TMP_DIR}"/protparams.json)
+            minUTxOValue=$(jq -r '.minUTxOValue //1000000' <<< "${PROT_PARAMS}")
             # Amount
             println "DEBUG" "# Amount to Send (in Ada)"
             println "DEBUG" " Valid entry:"
@@ -1583,7 +1583,7 @@ function main {
             else
               margin_fraction=$(pctToFraction "${margin}")
             fi
-            minPoolCost=$(( $(jq -r '.minPoolCost //0' "${TMP_DIR}"/protparams.json) / 1000000 )) # convert to Ada
+            minPoolCost=$(( $(jq -r '.minPoolCost //0' <<< "${PROT_PARAMS}") / 1000000 )) # convert to Ada
             [[ -f ${pool_config} ]] && cost_ada=$(jq -r '.costADA //0' "${pool_config}") || cost_ada=${minPoolCost} # default cost
             [[ ${cost_ada} -lt ${minPoolCost} ]] && cost_ada=${minPoolCost} # raise old value to new minimum cost
             sleep 0.1 && read -r -p "Cost (in Ada, minimum: ${minPoolCost}, default: $(formatAsset ${cost_ada})): " cost_enter 2>&6 && println "LOG" "Cost (in Ada, minimum: ${minPoolCost}, default: $(formatAsset ${cost_ada})): ${cost_enter}"
@@ -2165,10 +2165,10 @@ function main {
             fi
             echo
             epoch=$(getEpoch)
-            eMax=$(jq -r '.eMax' "${TMP_DIR}"/protparams.json)
+            poolRetireMaxEpoch=$(jq -r '.poolRetireMaxEpoch' <<< "${PROT_PARAMS}")
             println "DEBUG" "Current epoch: ${FG_LBLUE}${epoch}${NC}"
             epoch_start=$((epoch + 1))
-            epoch_end=$((epoch + eMax))
+            epoch_end=$((epoch + poolRetireMaxEpoch))
             println "DEBUG" "earlist epoch to retire pool is ${FG_LBLUE}${epoch_start}${NC} and latest ${FG_LBLUE}${epoch_end}${NC}"
             echo
             sleep 0.1 && read -r -p "Enter epoch in which to retire pool (blank for ${epoch_start}): " epoch_enter 2>&6 && println "LOG" "Enter epoch in which to retire pool (blank for ${epoch_start}): ${epoch_enter}"

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -545,9 +545,9 @@ if [[ ${OFFLINE_MODE} = "N" && ! -S ${CARDANO_NODE_SOCKET_PATH} ]]; then
   return 2
 fi
 
-if ! getEraIdentifier; then echo "${FG_RED}Failed to query protocol-parameters from node, not yet fully started?${NC}" && return 2; fi
+if ! ${CCLI} query protocol-parameters ${NETWORK_IDENTIFIER} &>/dev/null; then echo "${FG_RED}Failed to query protocol-parameters from node, not yet fully started?${NC}" && return 2; fi
 
-PROT_PARAMS="$(${CCLI} query protocol-parameters ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} 2>&1)"
+PROT_PARAMS="$(${CCLI} query protocol-parameters ${NETWORK_IDENTIFIER} 2>&1)"
 if [[ -n "${PROT_PARAMS}" ]] && ! DECENTRALISATION=$(jq -er .decentralization <<< ${PROT_PARAMS} 2>/dev/null); then DECENTRALISATION=0.5; fi
 
 return 0

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -545,9 +545,8 @@ if [[ ${OFFLINE_MODE} = "N" && ! -S ${CARDANO_NODE_SOCKET_PATH} ]]; then
   return 2
 fi
 
-if ! ${CCLI} query protocol-parameters ${NETWORK_IDENTIFIER} &>/dev/null; then echo "${FG_RED}Failed to query protocol-parameters from node, not yet fully started?${NC}" && return 2; fi
+if ! PROT_PARAMS="$(${CCLI} query protocol-parameters ${NETWORK_IDENTIFIER} 2>&1)"; then echo -e "${FG_RED}Failed to query protocol-parameters from node, not yet fully started?${NC}" && return 2; fi
 
-PROT_PARAMS="$(${CCLI} query protocol-parameters ${NETWORK_IDENTIFIER} 2>&1)"
-if [[ -n "${PROT_PARAMS}" ]] && ! DECENTRALISATION=$(jq -er .decentralization <<< ${PROT_PARAMS} 2>/dev/null); then DECENTRALISATION=0.5; fi
+if ! DECENTRALISATION=$(jq -er .decentralization <<< ${PROT_PARAMS} 2>/dev/null); then DECENTRALISATION=0.5; fi
 
 return 0

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -319,8 +319,8 @@ if ! mkdir -p "${TMP_DIR}" 2>/dev/null; then echo "ERROR: Failed to create direc
 [[ -z ${ASSET_POLICY_ID_FILENAME} ]] && ASSET_POLICY_ID_FILENAME="policy.id"
 
 node_version="$(${CCLI} version | head -1 | cut -d' ' -f2)"
-if ! versionCheck "1.25.1" "${node_version}"; then
-  echo -e "\nGuild scripts has now been upgraded to support cardano-node 1.25.1 or higher (${node_version} found).\nPlease update cardano-node (note that you should ideally update your config too) or use tagged branches for older node version.\n\n"
+if ! versionCheck "1.26.0" "${node_version}"; then
+  echo -e "\nGuild scripts has now been upgraded to support cardano-node 1.26.0 or higher (${node_version} found).\nPlease update cardano-node (note that you should ideally update your config too) or use tagged branches for older node version.\n\n"
   return 1
 fi
 
@@ -548,6 +548,6 @@ fi
 if ! getEraIdentifier; then echo "${FG_RED}Failed to query protocol-parameters from node, not yet fully started?${NC}" && return 2; fi
 
 PROT_PARAMS="$(${CCLI} query protocol-parameters ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} 2>&1)"
-if [[ -n "${PROT_PARAMS}" ]] && ! DECENTRALISATION=$(jq -er .decentralisationParam <<< ${PROT_PARAMS} 2>/dev/null); then DECENTRALISATION=0.5; fi
+if [[ -n "${PROT_PARAMS}" ]] && ! DECENTRALISATION=$(jq -er .decentralization <<< ${PROT_PARAMS} 2>/dev/null); then DECENTRALISATION=0.5; fi
 
 return 0

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -409,10 +409,10 @@ getNodeMetrics() {
     tx_processed=${node_metrics_arr[5]}; mempool_tx=${node_metrics_arr[6]}; mempool_bytes=${node_metrics_arr[7]}
     kesperiod=${node_metrics_arr[8]}; remaining_kes_periods=${node_metrics_arr[9]}
     isleader=${node_metrics_arr[10]}; adopted=${node_metrics_arr[11]}; didntadopt=${node_metrics_arr[12]}; about_to_lead=${node_metrics_arr[13]}
-    uptimens=$(( $(date +%s) - node_metrics_arr[14] ))
+    uptimes=$(( $(date +%s) - node_metrics_arr[14] ))
   else
     node_metrics=$(curl -s -m ${EKG_TIMEOUT} "http://${PROM_HOST}:${PROM_PORT}/metrics" 2>/dev/null)
-    [[ ${node_metrics} =~ cardano_node_metrics_nodeStartTime_int[[:space:]]([^[:space:]]*) ]] && uptimens=$(( $(date +%s) - BASH_REMATCH[1] )) || uptimens=0
+    [[ ${node_metrics} =~ cardano_node_metrics_nodeStartTime_int[[:space:]]([^[:space:]]*) ]] && uptimes=$(( $(date +%s) - BASH_REMATCH[1] )) || uptimes=0
     [[ ${node_metrics} =~ cardano_node_metrics_blockNum_int[[:space:]]([^[:space:]]*) ]] && blocknum=${BASH_REMATCH[1]} || blocknum=0
     [[ ${node_metrics} =~ cardano_node_metrics_epoch_int[[:space:]]([^[:space:]]*) ]] && epochnum=${BASH_REMATCH[1]} || epochnum=0
     [[ ${node_metrics} =~ cardano_node_metrics_slotInEpoch_int[[:space:]]([^[:space:]]*) ]] && slot_in_epoch=${BASH_REMATCH[1]} || slot_in_epoch=0

--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -482,7 +482,7 @@ while true; do
   if [[ -z "${PROT_PARAMS}" ]]; then
     getEraIdentifier
     PROT_PARAMS="$(${CCLI} query protocol-parameters ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} 2>/dev/null)"
-    if [[ -n "${PROT_PARAMS}" ]] && ! DECENTRALISATION=$(jq -re .decentralisationParam <<< ${PROT_PARAMS} 2>/dev/null); then DECENTRALISATION=0.5; fi
+    if [[ -n "${PROT_PARAMS}" ]] && ! DECENTRALISATION=$(jq -re .decentralization <<< ${PROT_PARAMS} 2>/dev/null); then DECENTRALISATION=0.5; fi
   fi
   
   if [[ ${show_peers} = "false" ]]; then
@@ -508,7 +508,7 @@ while true; do
       curr_epoch=${epochnum}
       getEraIdentifier
       PROT_PARAMS="$(${CCLI} query protocol-parameters ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} 2>/dev/null)"
-      if [[ -n "${PROT_PARAMS}" ]] && ! DECENTRALISATION=$(jq -re .decentralisationParam <<< ${PROT_PARAMS} 2>/dev/null); then DECENTRALISATION=0.5; fi
+      if [[ -n "${PROT_PARAMS}" ]] && ! DECENTRALISATION=$(jq -re .decentralization <<< ${PROT_PARAMS} 2>/dev/null); then DECENTRALISATION=0.5; fi
     fi
   fi
 

--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -480,8 +480,7 @@ while true; do
   fi
   
   if [[ -z "${PROT_PARAMS}" ]]; then
-    getEraIdentifier
-    PROT_PARAMS="$(${CCLI} query protocol-parameters ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} 2>/dev/null)"
+    PROT_PARAMS="$(${CCLI} query protocol-parameters ${NETWORK_IDENTIFIER} 2>/dev/null)"
     if [[ -n "${PROT_PARAMS}" ]] && ! DECENTRALISATION=$(jq -re .decentralization <<< ${PROT_PARAMS} 2>/dev/null); then DECENTRALISATION=0.5; fi
   fi
   
@@ -506,8 +505,7 @@ while true; do
     fi
     if [[ ${curr_epoch} -ne ${epochnum} ]]; then # only update on new epoch to save on processing
       curr_epoch=${epochnum}
-      getEraIdentifier
-      PROT_PARAMS="$(${CCLI} query protocol-parameters ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} 2>/dev/null)"
+      PROT_PARAMS="$(${CCLI} query protocol-parameters ${NETWORK_IDENTIFIER} 2>/dev/null)"
       if [[ -n "${PROT_PARAMS}" ]] && ! DECENTRALISATION=$(jq -re .decentralization <<< ${PROT_PARAMS} 2>/dev/null); then DECENTRALISATION=0.5; fi
     fi
   fi

--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -51,7 +51,7 @@ setTheme() {
 # Do NOT modify code below           #
 ######################################
 
-GLV_VERSION=v1.19.5
+GLV_VERSION=v1.19.6
 
 PARENT="$(dirname $0)"
 [[ -f "${PARENT}"/.env_branch ]] && BRANCH="$(cat ${PARENT}/.env_branch)" || BRANCH="master"

--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -145,20 +145,20 @@ if [[ "${NO_INTERNET_MODE}" == "N" ]]; then
   esac
 
   echo "Guild LiveView version check..."
-  if curl -s -f -m ${CURL_TIMEOUT} -o "${TMP_DIR}/gLiveView.sh" "${URL}/gLiveView.sh" 2>/dev/null; then
-    GIT_VERSION=$(grep -r ^GLV_VERSION= "${TMP_DIR}/gLiveView.sh" | cut -d'=' -f2)
+  if curl -s -f -m ${CURL_TIMEOUT} -o "${PARENT}"/gLiveView.sh.tmp ${URL}/gLiveView.sh 2>/dev/null && [[ -f "${PARENT}"/gLiveView.sh.tmp ]]; then
+    GIT_VERSION=$(grep -r ^GLV_VERSION= "${PARENT}"/gLiveView.sh.tmp | cut -d'=' -f2)
     : "${GIT_VERSION:=v0.0.0}"
     if ! versionCheck "${GIT_VERSION}" "${GLV_VERSION}"; then
       echo -e "\nA new version of Guild LiveView is available"
       echo "Installed Version : ${GLV_VERSION}"
       echo "Available Version : ${GIT_VERSION}"
       if getAnswer "\nDo you want to upgrade to the latest version of Guild LiveView?"; then
-        TEMPL_CMD=$(awk '/^# Do NOT modify/,0' "${TMP_DIR}/gLiveView.sh")
-        STATIC_CMD=$(awk '/#!/{x=1}/^# Do NOT modify/{exit} x' "${PARENT}/gLiveView.sh")
-        printf '%s\n%s\n' "$STATIC_CMD" "$TEMPL_CMD" > "${TMP_DIR}/gLiveView.sh"
-        mv -f "${PARENT}/gLiveView.sh" "${PARENT}/gLiveView.sh_bkp$(printf '%(%s)T\n' -1)" && \
-        cp -f "${TMP_DIR}/gLiveView.sh" "${PARENT}/gLiveView.sh" && \
-        chmod 750 "${PARENT}/gLiveView.sh" && \
+        TEMPL_CMD=$(awk '/^# Do NOT modify/,0' "${PARENT}"/gLiveView.sh.tmp)
+        STATIC_CMD=$(awk '/#!/{x=1}/^# Do NOT modify/{exit} x' "${PARENT}"/gLiveView.sh)
+        printf '%s\n%s\n' "$STATIC_CMD" "$TEMPL_CMD" > "${PARENT}"/gLiveView.sh.tmp
+        mv -f "${PARENT}"/gLiveView.sh "${PARENT}/gLiveView.sh_bkp$(printf '%(%s)T\n' -1)" && \
+        mv -f "${PARENT}"/gLiveView.sh.tmp "${PARENT}"/gLiveView.sh && \
+        chmod 750 "${PARENT}"/gLiveView.sh && \
         myExit 0 "Update applied successfully!\n\nPlease start Guild LiveView again!" || \
         myExit 1 "${FG_RED}Update failed!${NC}\n\nPlease use prereqs.sh or manually download to update gLiveView"
       fi
@@ -167,6 +167,7 @@ if [[ "${NO_INTERNET_MODE}" == "N" ]]; then
     echo -e "\nFailed to download gLiveView.sh from GitHub, unable to perform version check!"
     waitToProceed
   fi
+  rm -f "${PARENT}"/gLiveView.sh.tmp
 else
   # source common env variables in offline mode
   if ! . "${PARENT}"/env offline; then myExit 1; fi

--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -465,7 +465,7 @@ while true; do
   # Gather some data
   getNodeMetrics
   [[ ${fail_count} -eq ${RETRIES} ]] && myExit 1 "${style_status_3}COULD NOT CONNECT TO A RUNNING INSTANCE, ${RETRIES} FAILED ATTEMPTS IN A ROW!${NC}"
-  if [[ ${uptimens} -le 0 ]]; then
+  if [[ ${uptimes} -le 0 ]]; then
     ((fail_count++))
     clear && tput cup 1 1
     printf "${style_status_3}Connection to node lost, retrying (${fail_count}/${RETRIES})!${NC}"
@@ -518,7 +518,7 @@ while true; do
 
   ## main section ##
   printf "${tdivider}\n" && ((line++))
-  printf "${VL} Uptime: ${style_values_1}%s${NC}" "$(timeLeft $(( uptimens/1000 )))"
+  printf "${VL} Uptime: ${style_values_1}%s${NC}" "$(timeLeft ${uptimes})"
   tput cup ${line} $(( width - ${#title} - 3 - ${#CNODE_PORT} - 9 ))
   printf "${VL} Port: ${style_values_2}${CNODE_PORT} "
   tput cup ${line} $(( width - ${#title} - 3 ))

--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -403,8 +403,7 @@ checkPeers() {
       else # cncli, ss & tcptraceroute missing and ping failed
         peerRTT=99999
       fi
-      ! isNumber ${peerRTT} && peerRTT=99999
-      [[ ${peerRTT} -ne 99999 ]] && peerRTTSUM=$((peerRTTSUM + peerRTT))
+      ! isNumber ${peerRTT} && peerRTT=99999 || peerRTTSUM=$((peerRTTSUM + peerRTT))
     elif checkPEER=$(ping -c 2 -i 0.3 -w 1 "${peerIP}" 2>&1); then # Incoming connection, ping OK, show RTT.
       peerRTT=$(echo "${checkPEER}" | tail -n 1 | cut -d/ -f5 | cut -d. -f1)
       ! isNumber ${peerRTT} && peerRTT=99999 || peerRTTSUM=$((peerRTTSUM + peerRTT))

--- a/scripts/cnode-helper-scripts/prereqs.sh
+++ b/scripts/cnode-helper-scripts/prereqs.sh
@@ -325,7 +325,7 @@ if [[ "${INSTALL_CNCLI}" = "Y" ]]; then
     git checkout --quiet ${cncli_git_latestTag}
     echo "  building CNCLI ${cncli_git_latestTag} ..."
     if ! output=$(cargo install --path . --force --locked 2>&1); then echo -e "${output}" && err_exit; fi
-    echo "  v$(cncli -V) installed!"
+    echo "  $(cncli -V) installed!"
   else
     echo "  CNCLI already latest version [${cncli_version}], skipping!"
   fi

--- a/scripts/cnode-helper-scripts/sLiveView.sh
+++ b/scripts/cnode-helper-scripts/sLiveView.sh
@@ -49,7 +49,7 @@ do
   epochnum=$(jq '.cardano.node.metrics.epoch.int.val //0' <<< "${data}")
   slotnum=$(jq '.cardano.node.metrics.slotInEpoch.int.val //0' <<< "${data}")
   density=$(jq -r '.cardano.node.metrics.density.real.val //0' <<< "${data}")
-  uptimens=$(( $(date +%s) - $(jq '.cardano.node.metrics.nodeStartTime.int.val //0' <<< "${data}") ))
+  uptimes=$(( $(date +%s) - $(jq '.cardano.node.metrics.nodeStartTime.int.val //0' <<< "${data}") ))
   transactions=$(jq '.cardano.node.metrics.txsProcessedNum.int.val //0' <<< "${data}")
   kesperiod=$(jq '.cardano.node.metrics.currentKESPeriod.int.val //0' <<< "${data}")
   kesremain=$(jq '.cardano.node.metrics.remainingKESPeriods.int.val //0' <<< "${data}")
@@ -64,7 +64,7 @@ do
     name=$(printf "%s - Relay\n" "${nodename}")
   fi
 
-  if ((uptimens<=0)); then
+  if ((uptimes<=0)); then
     echo -e "${REKT}COULD NOT CONNECT TO A RUNNING INSTANCE! PLEASE CHECK THE PROMETHEUS PORT AND TRY AGAIN!${NC}"
     exit
   fi
@@ -82,7 +82,6 @@ do
     forged=0
   fi
 
-  uptimes=$(( uptimens / 1000))
   min=0
   hour=0
   day=0

--- a/scripts/cnode-helper-scripts/sendADA.sh
+++ b/scripts/cnode-helper-scripts/sendADA.sh
@@ -45,7 +45,7 @@ fi
 rm -f "${TMP_FOLDER}"/*
 
 # Get protocol parameters and save to ${TMP_FOLDER}/protparams.json
-${CCLI} query protocol-parameters ${ERA_IDENTIFIER} ${NETWORK_IDENTIFIER} --out-file ${TMP_FOLDER}/protparams.json || {
+${CCLI} query protocol-parameters ${NETWORK_IDENTIFIER} --out-file ${TMP_FOLDER}/protparams.json || {
   echo
   echo -e "${RED}ERROR${NC}: failed to query protocol parameters, node running and env parameters correct?"
   customExit 1

--- a/scripts/cnode-helper-scripts/topologyUpdater.sh
+++ b/scripts/cnode-helper-scripts/topologyUpdater.sh
@@ -98,10 +98,10 @@ if curl -s -m 10 -o "${PARENT}"/topologyUpdater.sh.tmp ${URL}/topologyUpdater.sh
     echo -e "This is a mandatory prerequisite, please set variables accordingly in User Variables section in the env file and restart topologyUpdater.sh\n"
     exit 0
   fi
-else # Download failed, ignore update check
-  rm -f "${PARENT}"/topologyUpdater.sh.tmp
-  rm -f "${PARENT}"/env.tmp
 fi
+rm -f "${PARENT}"/topologyUpdater.sh.tmp
+rm -f "${PARENT}"/env.tmp
+
 if [[ ! -f "${PARENT}"/env ]]; then
   echo -e "\nCommon env file missing: ${PARENT}/env"
   echo -e "This is a mandatory prerequisite, please install with prereqs.sh or manually download from GitHub\n"


### PR DESCRIPTION
- [x] Update Protocol parameters as per new naming convention
- [x] Dont fail at startup due to lack of ERA Identifier check
- [x] Remove era identifiers where appropriate for cardano-cli execution
  - [x] For now, any calls to build-tx dont resolve ${ERA_IDENTIFIER} , this automatically bypasses adding era to the transaction build commands.
- [x] CNTools code adapted for changes in ledger-state dump used by 'Pool >> Show'