### PR TITLE
CNTools 8.1.2

### DIFF
--- a/docs/Scripts/cntools-changelog.md
+++ b/docs/Scripts/cntools-changelog.md
@@ -5,6 +5,11 @@ All notable changes to this tool will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.1.2] - 2021-03-31
+##### Changed
+- Manual CNTools update replaced with automatic by asking to update on startup like the rest of the scripts in the guild repository. 
+- Changelog truncated up to v6.0.0. Minor and patch version changelog entries merged with next major release changelog.
+
 ## [8.1.1] - 2021-03-30
 ##### Fixed
 - Relay registration condition
@@ -197,6 +202,7 @@ Only the most noticeable changes added to changelog.
 #### Fixed
 - As per change to cardano-cli syntax, pool ID requires `--cold-verification-key-file` instead of `--verification-key-file`
 
+
 ## [6.0.0] - 2020-10-15
 
 > This is a major release with a lot of changes. It is highly recommended that you familiarise yourself with the usage for Hybrid or Online v/s Offline mode on a testnet environment before doing it on production. Please visit https://cardano-community.github.io/guild-operators/#/upgrade for details.
@@ -217,116 +223,31 @@ Only the most noticeable changes added to changelog.
 - Backup now offer the ability to create an online backup without wallet payment/stake and pool cold sign keys
 - Regular(offline) backup now display a warning if wallet payment/stake and pool cold sign keys are missing due to being deleted manually or by previous backup
 - Retire notification in pool >> show
-
-##### Changed
-- Improved trap/exit handling
-- Allow thousand separator(`,`) in user input for sending ADA and pledge/cost at pool registration to make it easier to count the zeros
-- User input for files and directories now open a dialog gui to make it easier to find the correct path
-
-##### Fixed
-- Check `pool >> show` stake distribution showing up as always 0.
-- KES expiration calculation
-- Slot interval calculation
-- Custom vname replacement(when using `prereqs.sh -t`) fix for internal update
-- Pool registration and de-registration certificates removed in case of retire/re-registration
-
-
-## [5.4.1] - 2020-09-10
-
-##### Fixed
-- KES Expiry to use KES Period instead of Epoch duration
-
-
-## [5.4.0] - 2020-08-23
-
-> A non-breaking change have been made to files outside of CNTools. Internal update function is not enough to update all files.  
-> - Execute the below (by default it will set you up against mainnet network), do not overwrite config please:  
->    `cd "$CNODE_HOME"/scripts`  
->    `curl -sS -o prereqs.sh https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/prereqs.sh`  
->    `chmod 755 prereqs.sh`  
->    `./prereqs.sh -s`  
-> - Start using updated cnode.sh to run a passive node, or edit the cnode.sh to include your pool keys and run as pool owner.
-
-=======
-
-##### Added
 - Sanity check before launching a second instance of cnode.sh
 - Doc update to run cnode.sh as a systemd service
-
-##### Removed
-- `Pool >> Delegators` removed.
-  - If/when a better option than dumping and parsing ledger-state dump arise re-adding it will be considered. 
-  - Utilize the community explorers listed at https://cardano-community.github.io/support-faq/#/explorers 
-
-##### Fixed
-- Block Collector script adapted for cardano-node 1.19.0.
-  - Block hash is now truncated in log, issue https://github.com/input-output-hk/cardano-node/issues/1738
-- High cpu usage reported in a few cases when running Block Collector
-  - Depending on log level, parsing and byte64 enc each entry with jq could potentially put high load on weaker systems. Replaced with grep to only parse entries containing specific traces.
-- Docs for creating systemd block collector service file updated to include user env in run command
-
-
-## [5.3.6] - 2020-08-22
-
-##### Fixed
-- cardano-node 1.19.0 introduced an issue that required us to use KES as current - 1 while rotating.
-
-
-## [5.3.5] - 2020-08-20
-
-##### Changed
-- CNTools now uses and works with `cardano-node 1.19.0`, please upgrade if you're not using this version.
-
-##### Fixed
-- A new getPoolID helper function added to extract both hex and bech32 pool ID
-  - Added `--output-format hex` when extracting pool ID in hex format
-  - A new pool.id-bech32 file gets created if cold.vkey is available and decrypted
-- Added error check to see if cardano-cli is in $PATH before continuing.
-
-
-## [5.3.4] - 2020-08-18
-
-##### Changed
-- Use manual calculation based on slot tip to get KES period
-
-## [5.3.3] - 2020-08-14
-
-##### Added
 - Use secure remove (`srm`) when available when deleting files.
-
-
-## [5.3.2] - 2020-08-05
-
-##### Fixed
-- Backup & Restore paths were failing on machines due to alnum class availability on certain interpreters.
-- Rewards were not counted in stake and pledge
-
-## [5.3.1] - 2020-08-04
-##### Added
-- Balance check notification added before wallet selection menus are shown to know that work is done in the background 
-
-##### Changed
-- Removed ledger dump dependency from Pool Register, Modify, Retire and List.
-  - The cost of the ledger dump is too high, replaced with a simple check if pools registration certificate exist in pool folder
-  - Pool >> Show|Delegators are now the only options dumping the ledger-state
-
-##### Fixed
-- Removed +i file locking on .addr files when using `Wallet >> Encrypt` as these are re-generated from keys and need to be writable
-- Balance check added to `Funds >> Withdraw` for base address as this is used to pay the withdraw transaction fee
-- Resolve issue with Multi Owner causing an error with new pool registration (error was due to quotes)
-
-
-## [5.3.0] - 2020-08-03
-##### Added
+- Balance check notification added before wallet selection menus are shown to know that work is done in the background
 - Ability to select a different pool owner and reward wallet
 - Multi-owner support using stake vkey/skey files
 - Added TIMEOUT_LEDGER_STATE(default 300s) in cntools.config to be used instead of static 60 seconds for querying shelley ledger-state.
 - Option to delete private keys after successful backup
 - itnRewards.sh script to claim ITN rewards incl docs update
 - More explicit error messages at startup
+- Basic sanity checks for socket file
+- Backup & Restore of wallets, pools and configuration files
+- External KES rotation script using CNTools library
+- Add few flags to control prereqs to allow skipping overwriting files, deploying OS packages, etc
+- cntools.sh: Drop an error if log not found, indicating config with no JSON being used
 
 ##### Changed
-- POOL_PLEDGECERT_FILENAME removed from config, WALLET_DELEGCERT_FILENAME is used instead for delegation cert to pool, no need to keep a separate cert in pool folder for this, its the wallet that is delegated.
+- Improved trap/exit handling
+- Allow thousand separator(`,`) in user input for sending ADA and pledge/cost at pool registration to make it easier to count the zeros
+- User input for files and directories now open a dialog gui to make it easier to find the correct path
+- CNTools now uses and works with `cardano-node 1.19.0`, please upgrade if you're not using this version.
+- Use manual calculation based on slot tip to get KES period
+- Removed ledger dump dependency from Pool Register, Modify, Retire and List.
+  - The cost of the ledger dump is too high, replaced with a simple check if pools registration certificate exist in pool folder
+  - Pool >> Show|Delegators are now the only options dumping the ledger-state
 - Wallet vkeys no longer encrypted as skeys are the only ones in need of protection
 - Update command change (change applied after this release is active):
   - Minor/Patch release: it will warn, backup and replace CNTools script files including cntools.config
@@ -340,99 +261,67 @@ Only the most noticeable changes added to changelog.
 - Pool >> Delegators view also use updated pledge value if a pool modification has been registered to check if pledge is met
 - Use mainnet as default, since other testnets are either retired or not being maintained :(
 - Backup original files when doing upgrades, so that users do not lose their changes.
-
-##### Fixed
-- Mainnet uses dedicated condition for slot checks
-- Timeout moved to a variable in cntools.library
-- KES Calculation for current KES period and KES expiration date
-  **Please re-check expiration date using Pool >> Show**
-
-
-## [5.2.1] - 2020-07-29
-##### Added
-- Basic sanity checks for socket file
-
-##### Fixed
-- calc_slots to be network independent
-- prom_host should be calculated from config file, instead of having to update a config
-
-
-## [5.2.0] - 2020-07-28
-
-##### Changed
 - Major update description updated
-- env file update removed from minor update 
-
-
-## [5.1.0] - 2020-07-28
-##### Added
-- Backup & Restore of wallets, pools and configuration files
-- External KES rotation script using CNTools library
-- Add few flags to control prereqs to allow skipping overwriting files, deploying OS packages, etc
-
-##### Fixed
-- Minor typo in menu
-
-##### Changed
+- env file update removed from minor update
 - Prometheus metrics used for various functions and now required to run CNTools, enabled by default
 - Changed references to ptn0 to generalize the usage
 - Change CNTools changelog heading format - +1 sublevels for headings (used by newer documentation)
 - Delegators previously displayed in `Pool >> Show` now moved to its own menu option
   This is to de-clutter and because it takes time to parse this data from ledger-state
 - stake.cert no longer encrypted in wallet
-
-##### Removed
-- Redundant sections in guide
-
-#### [5.0.6] - 2020-07-26
-##### Fixed
-- Parse Config for virtual forks, which adds supports for MC4
-
-
-#### [5.0.5] - 2020-07-25
-##### Fixed
-- CNTools block collector fix
-
-
-#### [5.0.4] - 2020-07-25
-##### Added
-- cntools.sh: Drop an error if log not found, indicating config with no JSON being used
-
-##### Fixed
-- column application added as a prereq, bsdmainutils/util-linux
-- cntoolsBlockCollector.sh get epoch using function
-- KES count was not showing up in Katip
-- Funds -> Delegation was broken as per recent changes in 1.17, corrected key type for delegation certificate
-
-##### Changed
 - Meta description now has a limit of 255 chars to match smash server limit
 - ledger-state timeout increased to 60s
 - Update ptn0 config to align with hydra config as much as possible, while keeping trace options on
-
-##### Removed
-- Stale delegate.counter
-
-
-#### [5.0.3] - 2020-07-24
-
-##### Changed
 - moved update check to be one of the first things CNTools does after start to be able to show critical changes before anything else runs.
-
-
-#### [5.0.2] - 2020-07-24
-
-##### Changed
 - Parse node logs to check the transition from Byron to shelley era, and save the epoch for transition in db folder. This is required for calculating KES keys.
   - Please make sure to use **config files created by the prereqs.sh, or enable JSON loggers for your config**.
 - Update cnode.sh.templ to archive logs every time node is restart, this ensures that we're not searching for previous log history when network was changed. Network being changed would automatically deduce db folder was deleted.
 - Update default network to MC3
 
+##### Removed
+- `Pool >> Delegators` removed.
+  - If/when a better option than dumping and parsing ledger-state dump arise re-adding it will be considered. 
+  - Utilize the community explorers listed at https://cardano-community.github.io/support-faq/#/explorers 
+- POOL_PLEDGECERT_FILENAME removed from config, WALLET_DELEGCERT_FILENAME is used instead for delegation cert to pool, no need to keep a separate cert in pool folder for this, its the wallet that is delegated.
+- Redundant sections in guide
+- Stale delegate.counter
+
 ##### Fixed
+- Check `pool >> show` stake distribution showing up as always 0.
+- KES expiration calculation
+- Slot interval calculation
+- Custom vname replacement(when using `prereqs.sh -t`) fix for internal update
+- Pool registration and de-registration certificates removed in case of retire/re-registration
+- KES Expiry to use KES Period instead of Epoch duration
+- Block Collector script adapted for cardano-node 1.19.0.
+  - Block hash is now truncated in log, issue https://github.com/input-output-hk/cardano-node/issues/1738
+- High cpu usage reported in a few cases when running Block Collector
+  - Depending on log level, parsing and byte64 enc each entry with jq could potentially put high load on weaker systems. Replaced with grep to only parse entries containing specific traces.
+- Docs for creating systemd block collector service file updated to include user env in run command
+- cardano-node 1.19.0 introduced an issue that required us to use KES as current - 1 while rotating.
+- A new getPoolID helper function added to extract both hex and bech32 pool ID
+  - Added `--output-format hex` when extracting pool ID in hex format
+  - A new pool.id-bech32 file gets created if cold.vkey is available and decrypted
+- Added error check to see if cardano-cli is in $PATH before continuing.
+- Backup & Restore paths were failing on machines due to alnum class availability on certain interpreters.
+- Rewards were not counted in stake and pledge
+- Removed +i file locking on .addr files when using `Wallet >> Encrypt` as these are re-generated from keys and need to be writable
+- Balance check added to `Funds >> Withdraw` for base address as this is used to pay the withdraw transaction fee
+- Resolve issue with Multi Owner causing an error with new pool registration (error was due to quotes)
+- Mainnet uses dedicated condition for slot checks
+- Timeout moved to a variable in cntools.library
+- KES Calculation for current KES period and KES expiration date
+  **Please re-check expiration date using Pool >> Show**
+- calc_slots to be network independent
+- prom_host should be calculated from config file, instead of having to update a config
+- Minor typo in menu
+- Parse Config for virtual forks, which adds supports for MC4
+- CNTools block collector fix
+- column application added as a prereq, bsdmainutils/util-linux
+- cntoolsBlockCollector.sh get epoch using function
+- KES count was not showing up in Katip
+- Funds -> Delegation was broken as per recent changes in 1.17, corrected key type for delegation certificate
 - `Pool >> Show` delegator rewards parsing from ledger-state
-
-
-#### [5.0.1] - 2020-07-22
-##### Fixed
 - Slot sync format improvement
 - kesExpiration function to use 17 fixed byron transition epochs 
 
@@ -447,6 +336,11 @@ Only the most noticeable changes added to changelog.
 - file size check for pool metadata file
 - Add nonce in pool metadata JSON to keep registration attempts unique, avoiding one hash pointing to multiple URLs
 - Change default network to `mainnet_candidate`, and add second argument (g) to run prereqs against guild network
+- allow the use of pre-existing metadata from URL when registering or modifying pool
+- minimum pool cost check against protocol
+- Refresh option to home screen
+- Ability to register multiple relay DNS A records as well as a mix of DNS A and IPv4
+- Valid for pool registration and modification
 
 ##### Changed
 - Default config switched to combinator instead of testnet
@@ -457,61 +351,20 @@ Only the most noticeable changes added to changelog.
 - Default pool cost from 256 -> 400
 - slotinterval calculation to include decentralisation parameter
 - mainnet candidate compatible slot calculation, 17 fixed byron transition epochs (needs to be fixed for mainnet)
-
-##### Removed
-- Delete cntools-updater script
-
-##### Fixed
-- Slots reference was mixing up for shelley testnet in absence of a combinator network
-
-
-#### [4.3.0] - 2020-07-16
-##### Added
-- allow the use of pre-existing metadata from URL when registering or modifying pool
-- minimum pool cost check against protocol
-
-##### Removed
-- NODE_SOCKET_PATH config parameter(replaced by CARDANO_NODE_SOCKET_PATH)
-
-##### Changed
 - Pool metadata information to copy file as-is as well as wait for keypress to make sure file is copied before proceeding with registration.
-
-
-#### [4.2.2] - 2020-07-15
-##### Fixed
-- numfmt dependency removed in favor of printf formatting
-
-
-#### [4.2.1] - 2020-07-15
-##### Fixed
-- Vkey delegation fix due to json format switch
-
-
-#### [4.2.0] - 2020-07-15
-##### Added
-- Refresh option to home screen
-
-##### Fixed
-- ADA not displayed in a couple of the wallet selection menus
-
-
-#### [4.1.0] - 2020-07-14
-##### Added
-- Ability to register multiple relay DNS A records as well as a mix of DNS A and IPv4
-- Valid for pool registration and modification
-
-##### Changed
 - Now use internal table builder to display previous relays
 - Instead of giving relays from previous registration as default values it will now ask if you want to re-register relays exactly as before to minimize steps and complexity
 
+##### Removed
+- Delete cntools-updater script
+- NODE_SOCKET_PATH config parameter(replaced by CARDANO_NODE_SOCKET_PATH)
 
-#### [4.0.2] - 2020-07-13
 ##### Fixed
+- Slots reference was mixing up for shelley testnet in absence of a combinator network
+- numfmt dependency removed in favor of printf formatting
+- Vkey delegation fix due to json format switch
+- ADA not displayed in a couple of the wallet selection menus
 - KES calculation support for both MC and Shelley Testnet
-
-
-#### [4.0.1] - 2020-07-13
-##### Fixed
 - Slot tip reference calculation for shelley testnet
 
 
@@ -525,23 +378,17 @@ Only the most noticeable changes added to changelog.
 
 
 #### [3.0.0] - 2020-07-12
-##### Changed
-- Release `2.1.1` included a change to env file and thus require a major version bump.
-- Modified output on Update screen slightly.
-
-
-#### [2.1.1] - 2020-07-12
 ##### Added
 - Basic health check data on main menu
   - Epoch, time until next epoch, node tip vs calculated reference tip and a warning if node is lagging behind.
 - Address era and encoding to `Wallet >> Show`
 
 ##### Changed
+- Release `2.1.1` included a change to env file and thus require a major version bump.
+- Modified output on Update screen slightly.
 - KES calculation, now take into account the byron era and the transition period until shelley start
   - Credit to Martin @ ATADA for inspiration on how to calculate this
 
-
-#### [2.0.1] - 2020-07-12
 ##### Fixed
 - Version fix to include patch version
 
@@ -566,6 +413,7 @@ Only the most noticeable changes added to changelog.
 - Display all lovelace values in floating point ADA with 6 decimals (lovelaces) using locales
 - Block Collector summary view
 - KES rotation notification/warning on startup and in pool list/show views
+- Live stake and delegators in `Pool >> Show`
 - Changelog 
 
 ##### Changed
@@ -588,66 +436,9 @@ Only the most noticeable changes added to changelog.
 - Delegators rewards in `Pool >> Show`
 - Work-around awk versions that only support 32-bit integers
 - Sometimes cardano-node log contain duplicate traces for the same slot at log file rollover, now filtered
-
-
-#### [1.2.0] - 2020-07-07
-##### Added
-- Live stake and delegators in `Pool >> Show`
-
-##### Fixed
 - Correct nwmagic - was hardcoded to 42
-
-
-#### [1.1.0] - 2020-07-07
-##### Fixed
 - Set script locale to fix format issue
 
 
 #### [1.0.0] - 2020-07-07
-##### Added
-- Wallet upgrade option added for backwards compatibility.  
-`Wallet >> LIST` now offer an upgrade option if it finds a wallet with payment address that has funds in it. Special note added in case a genesis address is found.
-- Update message on startup
-
-##### Changed
-- Support for payment address(aka enterprise) minimised to default on base address support, as Everything that can be done with a payment address can also be done with the base address.
-- Reduce a step to Update (register) wallet keys, and moved this step to delegate/register pool step based on a check to see if the registration is required.
-- Changes for log output and variable names
-- Docs and output update
-- Replace pool JSON hosting instructions, from stout to copying file, to avoid user errors
-- Do not give option or allow sending to same address as source. Base <-> Enterprise for same wallet ok.
-
-##### Fixed
-- Removed debug code in tx
-- A bug fixed for wallet not showing in some cases because reward address file was not generated at wallet creation
-
-
-#### [0.3.0] - 2020-07-01
-##### Fixed
-- In-app update bugfix
-
-#### [0.2.0] - 2020-06-30
-##### Added
-- Default values for relay on pool modify and re-registration
-- New pool config parameter for relay type called `type` containing either IPv4 or DNS_A currently.
-
-##### Changed
-- Old relays table on modify/registration redone to include type. Also put together a little different to handle null values and omit quotation marks.
-- Pool show updated to show type for relay
-- On pool re-registration or modification the old relay valus are now read from pool config. If selection of type match old values the default values are set to old config.
-
-##### Fixed
-- Minor alignment fix of main menu header
-
-
-#### [0.1.0] - 2020-06-29
-##### Added
-- First versioned released  
-  see github commit history for details before this release
-- In-app update for cntools
-
-##### Changed
-- Update CNTools Doco to include Version on home screen
-
-##### Fixed
-- Align table for reading relays
+- First official mayor release

--- a/docs/Scripts/cntools-changelog.md
+++ b/docs/Scripts/cntools-changelog.md
@@ -441,4 +441,4 @@ Only the most noticeable changes added to changelog.
 
 
 #### [1.0.0] - 2020-07-07
-- First official mayor release
+- First official major release

--- a/scripts/cnode-helper-scripts/cncli.sh
+++ b/scripts/cnode-helper-scripts/cncli.sh
@@ -130,7 +130,7 @@ cncliInit() {
   # Check if update is available
   [[ -f "${PARENT}"/.env_branch ]] && BRANCH="$(cat ${PARENT}/.env_branch)" || BRANCH="master"
   URL="https://raw.githubusercontent.com/cardano-community/guild-operators/${BRANCH}/scripts/cnode-helper-scripts"
-  if curl -s -m 10 -o "${PARENT}"/cncli.sh.tmp ${URL}/cncli.sh && curl -s -m 10 -o "${PARENT}"/env.tmp ${URL}/env && [[ -f "${PARENT}"/cncli.sh.tmp && -f "${PARENT}"/env.tmp ]]; then
+  if curl -s -f -m 10 -o "${PARENT}"/cncli.sh.tmp ${URL}/cncli.sh && curl -s -f -m 10 -o "${PARENT}"/env.tmp ${URL}/env && [[ -f "${PARENT}"/cncli.sh.tmp && -f "${PARENT}"/env.tmp ]]; then
     if [[ -f "${PARENT}"/env ]]; then
       if [[ $(grep "_HOME=" "${PARENT}"/env) =~ ^#?([^[:space:]]+)_HOME ]]; then
         vname=$(tr '[:upper:]' '[:lower:]' <<< "${BASH_REMATCH[1]}")

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -6,12 +6,12 @@
 ############################################################
 # The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 # and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
-# Any breaking changes (eg: that requires change of cntools.config, env or a change in priv folder would be considered breaking and will be exempt from auto-update)
+# Major: Any considerable change in the code base, big feature, workflow or breaking change from previous version
 CNTOOLS_MAJOR_VERSION=8
-# Changes that can be applied without breaking existing functionality that can be applied from within CNTools
+# Minor: Changes and features of minor character that can be applied without breaking existing functionality or workflow
 CNTOOLS_MINOR_VERSION=1
-# Backwards compatible bug fixes. No additional functionality or major changes and can be applied from within CNTools
-CNTOOLS_PATCH_VERSION=1
+# Patch: Backwards compatible bug fixes. No additional functionality or major changes
+CNTOOLS_PATCH_VERSION=2
 CNTOOLS_VERSION="${CNTOOLS_MAJOR_VERSION}.${CNTOOLS_MINOR_VERSION}.${CNTOOLS_PATCH_VERSION}"
 
 ############################################################

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -128,17 +128,6 @@ if ! need_cmd "curl" || \
    ! protectionPreRequisites; then myExit 1 "Missing one or more of the required command line tools, press any key to exit"
 fi
 
-if [[ "$CNTOOLS_PATCH_VERSION" -eq 999  ]]; then
-  # CNTools was updated using special 999 patch tag, apply correct version in cntools.library and update variables already sourced
-  sed -i "s/CNTOOLS_MAJOR_VERSION=[[:digit:]]\+/CNTOOLS_MAJOR_VERSION=$((++CNTOOLS_MAJOR_VERSION))/" "${PARENT}/cntools.library"
-  sed -i "s/CNTOOLS_MINOR_VERSION=[[:digit:]]\+/CNTOOLS_MINOR_VERSION=0/" "${PARENT}/cntools.library"
-  sed -i "s/CNTOOLS_PATCH_VERSION=[[:digit:]]\+/CNTOOLS_PATCH_VERSION=0/" "${PARENT}/cntools.library"
-  # CNTOOLS_MAJOR_VERSION variable already updated in sed replace command
-  CNTOOLS_MINOR_VERSION=0
-  CNTOOLS_PATCH_VERSION=0
-  CNTOOLS_VERSION="${CNTOOLS_MAJOR_VERSION}.${CNTOOLS_MINOR_VERSION}.${CNTOOLS_PATCH_VERSION}"
-fi
-
 # Do some checks when run in connected mode
 if [[ ${CNTOOLS_MODE} = "CONNECTED" ]]; then
   # check to see if there are any updates available
@@ -148,11 +137,6 @@ if [[ ${CNTOOLS_MODE} = "CONNECTED" ]]; then
     GIT_MAJOR_VERSION=$(grep -r ^CNTOOLS_MAJOR_VERSION= "${PARENT}"/cntools.library.tmp |sed -e "s#.*=##")
     GIT_MINOR_VERSION=$(grep -r ^CNTOOLS_MINOR_VERSION= "${PARENT}"/cntools.library.tmp |sed -e "s#.*=##")
     GIT_PATCH_VERSION=$(grep -r ^CNTOOLS_PATCH_VERSION= "${PARENT}"/cntools.library.tmp |sed -e "s#.*=##")
-    if [[ "$GIT_PATCH_VERSION" -eq 999  ]]; then
-      ((GIT_MAJOR_VERSION++))
-      GIT_MINOR_VERSION=0
-      GIT_PATCH_VERSION=0
-    fi
     GIT_VERSION="${GIT_MAJOR_VERSION}.${GIT_MINOR_VERSION}.${GIT_PATCH_VERSION}"
     if ! versionCheck "${GIT_VERSION}" "${CNTOOLS_VERSION}"; then
       println "DEBUG" "A new version of CNTools is available"

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -160,14 +160,16 @@ if [[ ${CNTOOLS_MODE} = "CONNECTED" ]]; then
       println "DEBUG" "Installed Version : ${FG_LGRAY}${CNTOOLS_VERSION}${NC}"
       println "DEBUG" "Available Version : ${FG_GREEN}${GIT_VERSION}${NC}"
       if getAnswer "\nDo you want to upgrade to the latest version of CNTools?"; then
-        curl -s -f -m ${CURL_TIMEOUT} -o "${PARENT}"/cntools.sh.tmp "${URL}/cntools.sh" && \
+        if curl -s -f -m ${CURL_TIMEOUT} -o "${PARENT}"/cntools.sh.tmp "${URL}/cntools.sh" && \
         mv -f "${PARENT}"/cntools.sh "${PARENT}/cntools.sh_bkp$(printf '%(%s)T\n' -1)" && \
         mv -f "${PARENT}"/cntools.library "${PARENT}/cntools.library_bkp$(printf '%(%s)T\n' -1)" && \
         mv -f "${PARENT}"/cntools.sh.tmp "${PARENT}"/cntools.sh && \
         mv -f "${PARENT}"/cntools.library.tmp "${PARENT}"/cntools.library && \
-        chmod 750 "${PARENT}"/cntools.sh && \
-        myExit 0 "Update applied successfully!\n\nPlease start CNTools again!" || \
-        myExit 1 "${FG_RED}Update failed!${NC}\n\nPlease use prereqs.sh or manually update CNTools"
+        chmod 750 "${PARENT}"/cntools.sh; then
+          myExit 0 "Update applied successfully!\n\nPlease start CNTools again!"
+        else
+          myExit 1 "${FG_RED}Update failed!${NC}\n\nPlease use prereqs.sh or manually update CNTools"
+        fi
       fi
       #println "DEBUG" "\nGo to Update section for upgrade\n\nAlternately, follow https://cardano-community.github.io/guild-operators/#/basics?id=pre-requisites to update cntools as well alongwith any other files"
       waitForInput "press any key to proceed"

--- a/scripts/cnode-helper-scripts/topologyUpdater.sh
+++ b/scripts/cnode-helper-scripts/topologyUpdater.sh
@@ -53,7 +53,7 @@ shift $((OPTIND -1))
 
 # Check if update is available
 URL="https://raw.githubusercontent.com/cardano-community/guild-operators/${BRANCH}/scripts/cnode-helper-scripts"
-if curl -s -m 10 -o "${PARENT}"/topologyUpdater.sh.tmp ${URL}/topologyUpdater.sh && curl -s -m 10 -o "${PARENT}"/env.tmp ${URL}/env && [[ -f "${PARENT}"/topologyUpdater.sh.tmp && -f "${PARENT}"/env.tmp ]]; then
+if curl -s -f -m 10 -o "${PARENT}"/topologyUpdater.sh.tmp ${URL}/topologyUpdater.sh && curl -s -f -m 10 -o "${PARENT}"/env.tmp ${URL}/env && [[ -f "${PARENT}"/topologyUpdater.sh.tmp && -f "${PARENT}"/env.tmp ]]; then
   if [[ -f "${PARENT}"/env ]]; then
     if [[ $(grep "_HOME=" "${PARENT}"/env) =~ ^#?([^[:space:]]+)_HOME ]]; then
       vname=$(tr '[:upper:]' '[:lower:]' <<< "${BASH_REMATCH[1]}")
@@ -118,7 +118,7 @@ fi
 
 if [[ ${TU_PUSH} = "Y" ]]; then
   fail_cnt=0
-  while ! blockNo=$(curl -s -m ${EKG_TIMEOUT} -H 'Accept: application/json' "http://${EKG_HOST}:${EKG_PORT}/" 2>/dev/null | jq -er '.cardano.node.metrics.blockNum.int.val //0' ); do
+  while ! blockNo=$(curl -s -f -m ${EKG_TIMEOUT} -H 'Accept: application/json' "http://${EKG_HOST}:${EKG_PORT}/" 2>/dev/null | jq -er '.cardano.node.metrics.blockNum.int.val //0' ); do
     ((fail_cnt++))
     [[ ${fail_cnt} -eq 5 ]] && echo "5 consecutive EKG queries failed, aborting!"
     echo "(${fail_cnt}/5) Failed to grab blockNum from node EKG metrics, sleeping for 30s before retrying... (ctrl-c to exit)"


### PR DESCRIPTION
- Manual CNTools update replaced with automatic by asking to update on startup like the rest of the scripts in the guild repository.
- Changelog truncated up to v6.0.0. Minor and patch version changelog entries merged with next major release changelog.
- minor tweak in cncli.sh & topologyUpdater.sh curl commands to handle errors better.