### PR TITLE
Added logic to hoover down hw-cli archive on Mac OS

### DIFF
--- a/scripts/cnode-helper-scripts/prereqs.sh
+++ b/scripts/cnode-helper-scripts/prereqs.sh
@@ -338,7 +338,11 @@ if [[ "${INSTALL_VCHC}" = "Y" ]]; then
   echo "  downloading Vacuumlabs cardano-hw-cli..."
   pushd /tmp >/dev/null || err_exit
   rm -rf cardano-hw-cli*
-  vchc_asset_url="$(curl -s https://api.github.com/repos/vacuumlabs/cardano-hw-cli/releases/latest | jq -r '.assets[].browser_download_url' | grep '_linux-x64.tar.gz')"
+  if [[ $(uname) == Darwin ]]; then
+    vchc_asset_url="$(curl -s https://api.github.com/repos/vacuumlabs/cardano-hw-cli/releases/latest | jq -r '.assets[].browser_download_url' | grep '_mac-x64.tar.gz')"
+  else
+    vchc_asset_url="$(curl -s https://api.github.com/repos/vacuumlabs/cardano-hw-cli/releases/latest | jq -r '.assets[].browser_download_url' | grep '_linux-x64.tar.gz')"
+  fi
   if curl -sL -f -m ${CURL_TIMEOUT} -o cardano-hw-cli_linux-x64.tar.gz ${vchc_asset_url}; then
     tar zxf cardano-hw-cli_linux-x64.tar.gz &>/dev/null
     rm -f cardano-hw-cli_linux-x64.tar.gz


### PR DESCRIPTION
tar command to open the archive seems to be working on Mac just like it does on Linux so didn't bother with temporary rename of the output file.