### PR TITLE
CNTools 8.4.2

### DIFF
--- a/.github/workflows/shlint.yml
+++ b/.github/workflows/shlint.yml
@@ -15,6 +15,6 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v1
     - name: SH Lint Check
-      uses: azohra/shell-linter@vlatest
+      uses: azohra/shell-linter@latest
       with:
         path: "scripts/cnode-helper-scripts"

--- a/docs/Scripts/cntools-changelog.md
+++ b/docs/Scripts/cntools-changelog.md
@@ -5,6 +5,10 @@ All notable changes to this tool will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.4.2] - 2021-05-16
+##### Fixed
+- cardano-hw-cli version limited to 1.2.0 for current Trezor fw v2.3.6. Please manually downgrade version, available at https://github.com/vacuumlabs/cardano-hw-cli/releases , placing files in $HOME/bin/cardano-hw-cli
+
 ## [8.4.1] - 2021-05-16
 ##### Changed
 - Wallet >> Show no longer require payment.vkey to be present, as long as either payment or base .addr file(s) exist

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -11,7 +11,7 @@ CNTOOLS_MAJOR_VERSION=8
 # Minor: Changes and features of minor character that can be applied without breaking existing functionality or workflow
 CNTOOLS_MINOR_VERSION=4
 # Patch: Backwards compatible bug fixes. No additional functionality or major changes
-CNTOOLS_PATCH_VERSION=1
+CNTOOLS_PATCH_VERSION=2
 CNTOOLS_VERSION="${CNTOOLS_MAJOR_VERSION}.${CNTOOLS_MINOR_VERSION}.${CNTOOLS_PATCH_VERSION}"
 
 ############################################################
@@ -2463,18 +2463,22 @@ unlockHWDevice() {
   device_app="$(cardano-hw-cli device version)"
   device_app_vendor="$(cut -d' ' -f1 <<< "${device_app}")"
   device_app_version="$(cut -d' ' -f4 <<< "${device_app}")"
+  println LOG "hardware device: vendor=${device_app_vendor} version=${device_app_version}"
   if [[ ! ${device_app_version} =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     println ERROR "${FG_RED}ERROR${NC}: unable to identify connected hardware device, is the device plugged in and unlocked?"
     println ERROR "Make sure device is seen by OS using tools like lsusb etc and is working correctly"
     waitForInput && return 1
   elif [[ ${device_app_vendor} = Ledger ]]; then
-    if ! versionCheck "2.2.0" "${device_app_version}"; then
+    if ! versionCheck "2.3.2" "${device_app_version}"; then
       println ERROR "${FG_RED}ERROR${NC}: Cardano app version installed on Ledger is ${FG_LGRAY}v${device_app_version}${NC}, minimum required version is ${FG_GREEN}v2.2.0${NC} !!"
       return 1
     fi
   elif [[ ${device_app_vendor} = Trezor ]]; then
     if ! versionCheck "2.3.6" "${device_app_version}"; then
       println ERROR "${FG_RED}ERROR${NC}: Trezor firmware installed on device is ${FG_LGRAY}v${device_app_version}${NC}, minimum required version is ${FG_GREEN}v2.3.6${NC} !!"
+      return 1
+    elif versionCheck "1.4.0" "${HWCLI_version}" && ! versionCheck "2.3.7" "${device_app_version}"; then
+      println ERROR "${FG_RED}ERROR${NC}: Trezor fw ${FG_LGRAY}v${device_app_version}${NC} not compatible with cardano-hw-cli ${FG_LGRAY}v${HWCLI_version}${NC}, please upgrade Trezor fw version (if available) or downgrade cardano-hw-cli to ${FG_LGRAY}v1.2.0${NC} !!"
       return 1
     fi
   else
@@ -2485,7 +2489,9 @@ unlockHWDevice() {
 }
 
 HWCLIversionCheck() {
+  println ACTION "cardano-hw-cli version"
   HWCLI_version="$(cardano-hw-cli version 2>/dev/null | head -n 1 | cut -d' ' -f6)"
+  println LOG "cardano-hw-cli version: ${HWCLI_version}"
   if ! versionCheck "1.2.0" "${HWCLI_version}"; then
     println ERROR "${FG_RED}ERROR${NC}: Vacuumlabs cardano-hw-cli ${FG_LGRAY}v${HWCLI_version}${NC} installed on system, minimum required version is ${FG_GREEN}v1.1.3${NC} !!"
     println ERROR "Please run ${FG_LGRAY}prereqs.sh -w${NC} to upgrade to the latest version."

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -418,7 +418,6 @@ cmdAvailable() {
 # Parameters  : message  >  [optional]: override default 'press any key to return to home menu' message
 waitToProceed() {
   IFS=';' read -sdR -p $'\E[6n' ROW COL
-  echo
   createDistanceToBottom $(( $# + 1 ))
   ESC=$(printf "\033")
   echo
@@ -431,7 +430,7 @@ waitToProceed() {
   if [[ $key == "$ESC" ]]; then
     read -rsn2 key # read 2 more chars
   fi
-  tput cup ${ROW#*[} ${COL}
+  tput cup ${ROW#*[} 0
   tput ed
 }
 


### PR DESCRIPTION
cardano-hw-cli version limited to 1.2.0 for current Trezor fw v2.3.6. Please manually downgrade version, available at https://github.com/vacuumlabs/cardano-hw-cli/releases , placing files in $HOME/bin/cardano-hw-cli