### PR TITLE
fix: add --collector.systemd to allow for node_systemd_unit_state

### DIFF
--- a/scripts/cnode-helper-scripts/setup_mon.sh
+++ b/scripts/cnode-helper-scripts/setup_mon.sh
@@ -273,7 +273,7 @@ User=$(whoami)
 Restart=on-failure
 ExecStart=$PROM_DIR/prometheus \
   --config.file=$PROM_DIR/prometheus.yml \
-  --storage.tsdb.path=$PROM_DIR/data --web.listen-address=$PROM_HOST:$PROM_PORT
+  --storage.tsdb.path=$PROM_DIR/data --collector.systemd --web.listen-address=$PROM_HOST:$PROM_PORT
 WorkingDirectory=$PROM_DIR
 LimitNOFILE=10000
 


### PR DESCRIPTION
A useful tool for Grafana monitoring, node_exporter requires this flag to use node_systemd_unit_state.

Additionally, used in IOHK's example Grafana dashboard.

Without the flag, there will be no data. If this is not the case, I'm happy to learn another way.

I'm unsure if this is a way to make a formal community contribution. If not, please let me know.

