### PR TITLE
CNTools 8.4.4 & gLiveView 1.20.7

### DIFF
--- a/docs/Scripts/cntools-changelog.md
+++ b/docs/Scripts/cntools-changelog.md
@@ -5,6 +5,10 @@ All notable changes to this tool will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.4.4] - 2021-05-19
+##### Fixed
+- Typo in Ledger ledger version requirement error and make it clearer that its the app version, not fw version.
+
 ## [8.4.3] - 2021-05-17
 ##### Fixed
 - Token Mint/Burn script file signing not completely removed in all places (1.27.0 change)

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -11,7 +11,7 @@ CNTOOLS_MAJOR_VERSION=8
 # Minor: Changes and features of minor character that can be applied without breaking existing functionality or workflow
 CNTOOLS_MINOR_VERSION=4
 # Patch: Backwards compatible bug fixes. No additional functionality or major changes
-CNTOOLS_PATCH_VERSION=3
+CNTOOLS_PATCH_VERSION=4
 CNTOOLS_VERSION="${CNTOOLS_MAJOR_VERSION}.${CNTOOLS_MINOR_VERSION}.${CNTOOLS_PATCH_VERSION}"
 
 ############################################################
@@ -2468,7 +2468,7 @@ unlockHWDevice() {
     waitForInput && return 1
   elif [[ ${device_app_vendor} = Ledger ]]; then
     if ! versionCheck "2.3.2" "${device_app_version}"; then
-      println ERROR "${FG_RED}ERROR${NC}: Cardano app version installed on Ledger is ${FG_LGRAY}v${device_app_version}${NC}, minimum required version is ${FG_GREEN}v2.2.0${NC} !!"
+      println ERROR "${FG_RED}ERROR${NC}: Cardano app version installed on Ledger is ${FG_LGRAY}v${device_app_version}${NC}, minimum required app version is ${FG_GREEN}v2.3.2${NC} !!"
       return 1
     fi
   elif [[ ${device_app_vendor} = Trezor ]]; then

--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -54,7 +54,7 @@ setTheme() {
 # Do NOT modify code below           #
 ######################################
 
-GLV_VERSION=v1.20.6
+GLV_VERSION=v1.20.7
 
 PARENT="$(dirname $0)"
 [[ -f "${PARENT}"/.env_branch ]] && BRANCH="$(cat ${PARENT}/.env_branch)" || BRANCH="master"
@@ -125,11 +125,10 @@ if [[ "${UPDATE_CHECK}" == "Y" ]]; then
   fi
   # check for env update
   ! checkUpdate env && myExit 1
-  ! . "${PARENT}"/env && myExit 1 "ERROR: gLiveView failed to load common env file\nPlease verify set values in 'User Variables' section in env file or log an issue on GitHub"
   # source common env variables in case it was updated
   . "${PARENT}"/env
   case $? in
-    1) myExit 1 ;;
+    1) myExit 1 "ERROR: gLiveView failed to load common env file\nPlease verify set values in 'User Variables' section in env file or log an issue on GitHub" ;;
     2) clear ;;
   esac
 
@@ -160,7 +159,7 @@ else
   # source common env variables in offline mode
   . "${PARENT}"/env offline
   case $? in
-    1) myExit 1 ;;
+    1) myExit 1 "ERROR: gLiveView failed to load common env file\nPlease verify set values in 'User Variables' section in env file or log an issue on GitHub" ;;
     2) clear ;;
   esac
 fi


### PR DESCRIPTION
CNTools 8.4.4
Typo in Ledger ledger version requirement error and make it clearer that its the app version, not fw version.

gLiveView 1.20.7
env sourcing issue, should not fail on socket missing. env sourced twice in succession.