### PR TITLE
Pre-source env in online mode where applicable to avoid setting OFFLINE_MODE to 'Y' in parent scripts

### DIFF
--- a/docs/Scripts/cntools-changelog.md
+++ b/docs/Scripts/cntools-changelog.md
@@ -5,6 +5,10 @@ All notable changes to this tool will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.4.12] - 2021-06-28
+##### Fixed
+- Pre-source env in offline/online mode for checkUpdate depending on argument provided to cntools.sh
+
 ## [8.4.11] - 2021-06-25
 ##### Changed
 - KES calculation moved from CNTools & gLiveView into a common function in env file. For online mode node metrics is used for KES expiration instead of static pool KES start period.

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -11,7 +11,7 @@ CNTOOLS_MAJOR_VERSION=8
 # Minor: Changes and features of minor character that can be applied without breaking existing functionality or workflow
 CNTOOLS_MINOR_VERSION=4
 # Patch: Backwards compatible bug fixes. No additional functionality or major changes
-CNTOOLS_PATCH_VERSION=11
+CNTOOLS_PATCH_VERSION=12
 CNTOOLS_VERSION="${CNTOOLS_MAJOR_VERSION}.${CNTOOLS_MINOR_VERSION}.${CNTOOLS_PATCH_VERSION}"
 
 ############################################################

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -27,8 +27,6 @@ myExit() {
   cleanup "$1"
 }
 
-clear
-
 usage() {
   cat <<-EOF
 		Usage: $(basename "$0") [-o] [-a] [-b <branch name>]
@@ -67,7 +65,12 @@ if [[ ! -f "${PARENT}"/env ]]; then
   myExit 1
 fi
 
-. "${PARENT}"/env offline &>/dev/null # ignore any errors, re-sourced later
+# Source env file, re-sourced later
+if [[ "${CNTOOLS_MODE}" == "OFFLINE" ]]; then
+  . "${PARENT}"/env offline &>/dev/null
+else
+  . "${PARENT}"/env &>/dev/null
+fi
 
 if [[ ${CNTOOLS_MODE} = "CONNECTED" ]]; then
   if [[ "${UPDATE_CHECK}" == "Y" ]]; then

--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -54,7 +54,7 @@ setTheme() {
 # Do NOT modify code below           #
 ######################################
 
-GLV_VERSION=v1.20.9
+GLV_VERSION=v1.20.10
 
 PARENT="$(dirname $0)"
 
@@ -113,7 +113,7 @@ if [[ ! -f "${PARENT}"/env ]]; then
   myExit 1
 fi
 
-. "${PARENT}"/env offline &>/dev/null # ignore any errors, re-sourced later
+. "${PARENT}"/env &>/dev/null # ignore any errors, re-sourced later
 
 if [[ "${UPDATE_CHECK}" == "Y" ]]; then
   echo "Checking for script updates..."


### PR DESCRIPTION
Using `./env offline` enforces variable OFFLINE_MODE to "Y" in scripts, rendering checkUpdate calls to exit without actual checks