### PR TITLE
[cntools] Added check_KES to toggle startup KES check

### DIFF
--- a/scripts/cnode-helper-scripts/cntools.config
+++ b/scripts/cnode-helper-scripts/cntools.config
@@ -6,6 +6,8 @@ TIMEOUT_NO_OF_SLOTS=600 # used when waiting for a new block to be created
 CNTOOLS_LOG="${LOG_DIR}/cntools-history.log"
 
 # kes rotation warning (in seconds)
+# if disabled KES check will be skipped on startup
+#CHECK_KES=false
 KES_ALERT_PERIOD=172800 # default 2 days
 KES_WARNING_PERIOD=604800 # default 7 days
 

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -11,7 +11,7 @@ CNTOOLS_MAJOR_VERSION=8
 # Minor: Changes and features of minor character that can be applied without breaking existing functionality or workflow
 CNTOOLS_MINOR_VERSION=4
 # Patch: Backwards compatible bug fixes. No additional functionality or major changes
-CNTOOLS_PATCH_VERSION=16
+CNTOOLS_PATCH_VERSION=17
 CNTOOLS_VERSION="${CNTOOLS_MAJOR_VERSION}.${CNTOOLS_MINOR_VERSION}.${CNTOOLS_PATCH_VERSION}"
 
 ############################################################
@@ -32,6 +32,7 @@ if ! mkdir -p "${ASSET_FOLDER}" 2>/dev/null; then myExit 1 "${FG_RED}ERROR${NC}:
 [[ -z ${ENABLE_CHATTR} ]] && ENABLE_CHATTR=true
 [[ -z ${ENABLE_DIALOG} ]] && ENABLE_DIALOG=true
 [[ ${ENABLE_ADVANCED} = "true" ]] && ADVANCED_MODE="true"
+[[ -z ${CHECK_KES} ]] && CHECK_KES=true
 
 ############################################################
 # library sourced by cntools with common taskes to perform #


### PR DESCRIPTION
Fixes the following edge case:
- Node holds block producer VRF keys to check leaderlog
- Node does not have access to block producer EKG port
- Node can thus not receive KES EKG data breaking the KES startup check of cntools 
- The simple toggle in cntools.config allows disabling CHECK_KES at startup, by default the check is true