### PR TITLE
Change result object from JSON to Table for rewards_history and totals

### DIFF
--- a/files/grest/rpc/blockchain/rewards_history.sql
+++ b/files/grest/rpc/blockchain/rewards_history.sql
@@ -1,4 +1,4 @@
-DROP FUNCTION IF EXISTS grest.rewards_history;
+DROP FUNCTION IF EXISTS grest.rewards_history (text, numeric);
 
 CREATE FUNCTION grest.rewards_history (_stake_address text DEFAULT NULL, _epoch_no numeric DEFAULT NULL)
     RETURNS TABLE (

--- a/files/grest/rpc/blockchain/rewards_history.sql
+++ b/files/grest/rpc/blockchain/rewards_history.sql
@@ -1,37 +1,31 @@
-CREATE OR REPLACE FUNCTION grest.rewards_history (_stake_address_bech32 text DEFAULT NULL, _epoch_no numeric DEFAULT NULL)
-    RETURNS json STABLE
+CREATE OR REPLACE FUNCTION grest.rewards_history (_stake_address text DEFAULT NULL, _epoch_no numeric DEFAULT NULL)
+    RETURNS TABLE (earned_epoch bigint, stake_pool character varying, reward_amount lovelace, reward_type rewardtype, spendable_epoch bigint)
     LANGUAGE PLPGSQL
     AS $$
 BEGIN
     IF _epoch_no IS NULL THEN
-        RETURN (
+        RETURN QUERY (
             SELECT
-                json_agg(js) json_final
-            FROM (
-                SELECT
-                    json_build_object('earned_epoch', reward.earned_epoch, 'stake_pool', pool_hash.view, 'reward_amount', reward.amount, 'reward_type', reward.type, 'spendable_epoch', reward.spendable_epoch) js
-                FROM
-                    reward
-                    INNER JOIN stake_address ON reward.addr_id = stake_address.id
-                    INNER JOIN pool_hash ON reward.pool_id = pool_hash.id
-                WHERE
-                    stake_address.view = _stake_address_bech32
-                ORDER BY
-                    spendable_epoch DESC) t);
+                r.earned_epoch, ph.view, r.amount, r.type, r.spendable_epoch
+            FROM
+                reward AS r
+                INNER JOIN stake_address AS sa ON r.addr_id = sa.id
+                INNER JOIN pool_hash AS ph ON r.pool_id = ph.id
+            WHERE
+                sa.view = _stake_address
+            ORDER BY
+                r.spendable_epoch DESC);
     ELSE
-        RETURN (
+        RETURN QUERY (
             SELECT
-                json_agg(js) json_final
-            FROM (
-                SELECT
-                    json_build_object('earned_epoch', reward.earned_epoch, 'stake_pool', pool_hash.view, 'reward_amount', reward.amount, 'reward_type', reward.type, 'spendable_epoch', reward.spendable_epoch) js
-                FROM
-                    reward
-                    INNER JOIN stake_address ON reward.addr_id = stake_address.id
-                    INNER JOIN pool_hash ON reward.pool_id = pool_hash.id
-                WHERE
-                    stake_address.view = _stake_address_bech32
-                    AND reward.earned_epoch = _epoch_no) t);
+                r.earned_epoch, ph.view, r.amount, r.type, r.spendable_epoch
+            FROM
+                reward AS r
+                INNER JOIN stake_address AS sa ON r.addr_id = sa.id
+                INNER JOIN pool_hash AS ph ON r.pool_id = ph.id
+            WHERE
+                sa.view = _stake_address
+                AND r.earned_epoch = _epoch_no);
     END IF;
 END;
 $$;

--- a/files/grest/rpc/blockchain/rewards_history.sql
+++ b/files/grest/rpc/blockchain/rewards_history.sql
@@ -1,28 +1,29 @@
-CREATE OR REPLACE FUNCTION grest.rewards_history (_stake_address text DEFAULT NULL, _epoch_no numeric DEFAULT NULL)
-    RETURNS TABLE (earned_epoch bigint, stake_pool character varying, reward_amount lovelace, reward_type rewardtype, spendable_epoch bigint)
+DROP FUNCTION IF EXISTS grest.rewards_history;
+
+CREATE FUNCTION grest.rewards_history (_stake_address text DEFAULT NULL, _epoch_no numeric DEFAULT NULL)
+    RETURNS TABLE (
+        earned_epoch bigint,
+        stake_pool character varying,
+        reward_amount lovelace,
+        reward_type rewardtype,
+        spendable_epoch bigint)
     LANGUAGE PLPGSQL
     AS $$
 BEGIN
     IF _epoch_no IS NULL THEN
         RETURN QUERY (
             SELECT
-                r.earned_epoch, ph.view, r.amount, r.type, r.spendable_epoch
-            FROM
-                reward AS r
+                r.earned_epoch, ph.view, r.amount, r.type, r.spendable_epoch FROM reward AS r
                 INNER JOIN stake_address AS sa ON r.addr_id = sa.id
-                INNER JOIN pool_hash AS ph ON r.pool_id = ph.id
+                LEFT JOIN pool_hash AS ph ON r.pool_id = ph.id
             WHERE
-                sa.view = _stake_address
-            ORDER BY
-                r.spendable_epoch DESC);
+                sa.view = _stake_address ORDER BY r.spendable_epoch DESC);
     ELSE
         RETURN QUERY (
             SELECT
-                r.earned_epoch, ph.view, r.amount, r.type, r.spendable_epoch
-            FROM
-                reward AS r
+                r.earned_epoch, ph.view, r.amount, r.type, r.spendable_epoch FROM reward AS r
                 INNER JOIN stake_address AS sa ON r.addr_id = sa.id
-                INNER JOIN pool_hash AS ph ON r.pool_id = ph.id
+                LEFT JOIN pool_hash AS ph ON r.pool_id = ph.id
             WHERE
                 sa.view = _stake_address
                 AND r.earned_epoch = _epoch_no);

--- a/files/grest/rpc/blockchain/totals.sql
+++ b/files/grest/rpc/blockchain/totals.sql
@@ -1,4 +1,6 @@
-CREATE OR REPLACE FUNCTION grest.totals (_epoch_no numeric DEFAULT NULL)
+DROP FUNCTION grest.totals (numeric);
+
+CREATE FUNCTION grest.totals (_epoch_no numeric DEFAULT NULL)
   RETURNS TABLE (epoch_no uinteger,circulation lovelace,treasury lovelace,reward lovelace,supply numeric,reserves lovelace)
   LANGUAGE PLPGSQL
   AS $$

--- a/files/grest/rpc/blockchain/totals.sql
+++ b/files/grest/rpc/blockchain/totals.sql
@@ -1,32 +1,26 @@
 CREATE OR REPLACE FUNCTION grest.totals (_epoch_no numeric DEFAULT NULL)
-  RETURNS json STABLE
+  RETURNS TABLE (epoch_no uinteger,circulation lovelace,treasury lovelace,reward lovelace,supply numeric,reserves lovelace)
   LANGUAGE PLPGSQL
   AS $$
 BEGIN
   IF _epoch_no IS NULL THEN
-    RETURN (
+    RETURN QUERY (
       SELECT
-        json_agg(js) json_final
-      FROM (
-        SELECT
-          json_build_object('epoch_no', epoch_no, 'circulation', utxo, 'treasury', treasury, 'rewards', rewards, 'supply', (treasury + rewards + utxo + deposits + fees), 'reserves', reserves) js
+          ap.epoch_no, ap.utxo, ap.treasury, ap.rewards, (ap.treasury + ap.rewards + ap.utxo + ap.deposits + ap.fees) as supply, ap.reserves
         FROM
-          public.ada_pots
+          public.ada_pots as ap
         ORDER BY
-          epoch_no DESC) t);
+          ap.epoch_no DESC) ;
   ELSE
-    RETURN (
+    RETURN QUERY (
       SELECT
-        json_agg(js) json_final
-      FROM (
-        SELECT
-          json_build_object('epoch_no', epoch_no, 'circulation', utxo, 'treasury', treasury, 'rewards', rewards, 'supply', (treasury + rewards + utxo + deposits + fees), 'reserves', reserves) js
+          ap.epoch_no, ap.utxo, ap.treasury, ap.rewards, (ap.treasury + ap.rewards + ap.utxo + ap.deposits + ap.fees) as supply, ap.reserves
         FROM
-          public.ada_pots
+          public.ada_pots as ap
         WHERE
-          epoch_no = _epoch_no
+          ap.epoch_no = _epoch_no
         ORDER BY
-          epoch_no DESC) t);
+          ap.epoch_no DESC);
   END IF;
 END;
 $$;


### PR DESCRIPTION
- PostgREST natively adds certain parameters for filtering (eg: `select` for columns, `limit` and `offset` for pagination, etc), in addition to bringing result as a dictionary. Thus, would be good to stick to RETURN TABLE where possible, as other RETURN objects do not follow configuration limits (eg: `max-rows` )

- Rename `_stake_address_bech32` to `_stake_address` (consistent with `_address` on account_balance) as all parameters we use are bech32 format