### PR TITLE
Account assets rpc

### DIFF
--- a/docs/Build/grestsvcs.json
+++ b/docs/Build/grestsvcs.json
@@ -532,6 +532,45 @@
           }
         }
       }
+    },
+    "/rpc/account_assets": {
+      "post": {
+        "tags": [
+          "Blockchain Queries"
+        ],
+        "summary": "Get the native asset balance of an account",
+        "produces": [
+          "application/json",
+          "application/vnd.pgrst.object+json"
+        ],
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "required": [
+                "_address_bech32"
+              ],
+              "type": "object",
+              "properties": {
+                "_address_bech32": {
+                  "format": "text",
+                  "type": "string"
+                }
+              }
+            },
+            "in": "body",
+            "name": "args"
+          },
+          {
+            "$ref": "#/parameters/preferParams"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
     }
   },
   "parameters": {

--- a/files/grest/rpc/blockchain/account_assets.sql
+++ b/files/grest/rpc/blockchain/account_assets.sql
@@ -1,4 +1,4 @@
-DROP FUNCTION grest.account_assets (text);
+DROP FUNCTION IF EXISTS grest.account_assets (text);
 
 CREATE FUNCTION grest.account_assets (_address text DEFAULT NULL)
     RETURNS TABLE (

--- a/files/grest/rpc/blockchain/account_assets.sql
+++ b/files/grest/rpc/blockchain/account_assets.sql
@@ -17,7 +17,8 @@ BEGIN
         FROM
             STAKE_ADDRESS
         WHERE
-            VIEW = _address;
+            VIEW = _address
+            LIMIT 1;
     ELSE
         -- Payment address
         SELECT

--- a/files/grest/rpc/blockchain/account_assets.sql
+++ b/files/grest/rpc/blockchain/account_assets.sql
@@ -1,0 +1,59 @@
+DROP FUNCTION grest.account_assets (text);
+
+CREATE FUNCTION grest.account_assets (_address text DEFAULT NULL)
+    RETURNS TABLE (
+        asset_policy text,
+        asset_name text,
+        quantity numeric)
+    LANGUAGE PLPGSQL
+    AS $$
+DECLARE
+    SA_ID integer DEFAULT NULL;
+BEGIN
+    IF _address LIKE 'stake%' THEN
+        -- Shelley stake address
+        SELECT
+            ID INTO SA_ID
+        FROM
+            STAKE_ADDRESS
+        WHERE
+            VIEW = _address;
+    ELSE
+        -- Payment address
+        SELECT
+            STAKE_ADDRESS_ID INTO SA_ID
+        FROM
+            TX_OUT
+        WHERE
+            ADDRESS = _address
+        LIMIT 1;
+    END IF;
+    IF SA_ID IS NOT NULL THEN
+        RETURN QUERY
+        SELECT
+            ENCODE(MTX.POLICY::bytea, 'hex') AS asset_policy,
+            ENCODE(MTX.NAME::bytea, 'escape') AS asset_name,
+            sum(MTX.QUANTITY)
+        FROM
+            MA_TX_OUT MTX
+            INNER JOIN TX_OUT TXO ON TXO.ID = MTX.TX_OUT_ID
+                AND TXO.STAKE_ADDRESS_ID = SA_ID
+        WHERE
+            NOT EXISTS (
+                SELECT
+                    TX_OUT.ID
+                FROM
+                    TX_OUT
+                    INNER JOIN TX_IN ON TX_OUT.TX_ID = TX_IN.TX_OUT_ID
+                        AND TX_OUT.INDEX = TX_IN.TX_OUT_INDEX
+                WHERE
+                    TXO.ID = TX_OUT.ID)
+        GROUP BY
+            MTX.POLICY,
+            MTX.NAME;
+    END IF;
+END;
+$$;
+
+COMMENT ON FUNCTION grest.account_balance IS 'Get the native asset balance of an account';
+


### PR DESCRIPTION
Testing (mainnet):

```
-- stake address account
select grest.account_assets('stake1u9xkx899adh6lqx5veq4rzc9mklge65frz74h0f4p678w2gtph5w7'); 

-- same account, just subset address
select grest.account_assets('addr1qyhm3vfej6n8thhquj9ntzmqs8xqmuchq8v43ku7t8kwr2zdvvw2t6m047qdgejp2x9sthd73n4gjx9atw7n2r4uwu5s5p2cpt');

-- invalid address
select grest.account_assets('test');

-- byron address, same as above
select grest.account_assets('Ae2tdPwUPEZ7ZRTYW2rK7hJCZ9DxcgScZ9Uyvm7Aw7Ro91XMdABGZWdSYTu');

select grest.account_assets(NULL);

explain analyze select grest.account_assets('Ae2tdPwUPEZ7ZRTYW2rK7hJCZ9DxcgScZ9Uyvm7Aw7Ro91XMdABGZWdSYTu');

explain analyze select grest.account_assets('addr1qyhm3vfej6n8thhquj9ntzmqs8xqmuchq8v43ku7t8kwr2zdvvw2t6m047qdgejp2x9sthd73n4gjx9atw7n2r4uwu5s5p2cpt');

explain analyze select grest.account_assets('stake1u9xkx899adh6lqx5veq4rzc9mklge65frz74h0f4p678w2gtph5w7'); 
```

```
curl -d _address=stake1u9xkx899adh6lqx5veq4rzc9mklge65frz74h0f4p678w2gtph5w7 'http://localhost:8053/rpc/account_assets'

curl -d _address=addr1qyhm3vfej6n8thhquj9ntzmqs8xqmuchq8v43ku7t8kwr2zdvvw2t6m047qdgejp2x9sthd73n4gjx9atw7n2r4uwu5s5p2cpt 'http://localhost:8053/rpc/account_assets'
```

Peculiar thing: `addr...` is faster than `stake...` 🤔