### PR TITLE
Add db size metric (monitoring)

### DIFF
--- a/files/grest/grafana/guild-dashboard.json
+++ b/files/grest/grafana/guild-dashboard.json
@@ -16,6 +16,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
+  "id": 24,
   "links": [
     {
       "icon": "external link",
@@ -1049,102 +1050,296 @@
       }
     },
     {
-      "type": "graph",
-      "title": "DB Size",
-      "gridPos": {
-        "x": 6,
-        "y": 26,
-        "w": 6,
-        "h": 7
-      },
-      "id": 159,
-      "targets": [
-        {
-          "expr": "dbsize",
-          "legendFormat": "{{ service }}",
-          "interval": "",
-          "exemplar": true,
-          "refId": "A"
-        }
-      ],
-      "options": {
-        "alertThreshold": true
-      },
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
-          "unit": "bytes"
+          "unit": "decbytes"
         },
         "overrides": []
       },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 18
+      },
+      "hiddenSeries": false,
+      "id": 162,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
       "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
       "renderer": "flot",
-      "yaxes": [
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
         {
-          "label": null,
-          "show": true,
-          "logBase": 1,
-          "min": null,
-          "max": null,
-          "format": "bytes",
-          "$$hashKey": "object:57"
-        },
-        {
-          "label": null,
-          "show": true,
-          "logBase": 1,
-          "min": null,
-          "max": null,
-          "format": "short",
-          "$$hashKey": "object:58"
+          "exemplar": true,
+          "expr": "pubschsize",
+          "interval": "",
+          "legendFormat": "{{ service }}",
+          "refId": "A"
         }
       ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Public Schema Size",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
       "xaxis": {
-        "show": true,
+        "buckets": null,
         "mode": "time",
         "name": null,
-        "values": [],
-        "buckets": null
+        "show": true,
+        "values": []
       },
+      "yaxes": [
+        {
+          "$$hashKey": "object:495",
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:496",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
       "yaxis": {
         "align": false,
         "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 26
+      },
+      "hiddenSeries": false,
+      "id": 161,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
       },
       "lines": true,
-      "fill": 1,
       "linewidth": 1,
-      "dashLength": 10,
-      "spaceLength": 10,
-      "pointradius": 2,
-      "legend": {
-        "show": true,
-        "values": false,
-        "min": false,
-        "max": false,
-        "current": false,
-        "total": false,
-        "avg": false
-      },
       "nullPointMode": "null",
-      "tooltip": {
-        "value_type": "individual",
-        "shared": true,
-        "sort": 0
+      "options": {
+        "alertThreshold": true
       },
-      "aliasColors": {},
+      "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
       "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "grestschsize",
+          "interval": "",
+          "legendFormat": "{{ service }}",
+          "refId": "A"
+        }
+      ],
       "thresholds": [],
       "timeRegions": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "fillGradient": 0,
-      "dashes": false,
-      "hiddenSeries": false,
-      "points": false,
+      "title": "gRest Schema Size",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:495",
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:496",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
       "bars": false,
-      "stack": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 6,
+        "y": 34
+      },
+      "hiddenSeries": false,
+      "id": 159,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.5.7",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
       "steppedLine": false,
-      "datasource": null
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "dbsize",
+          "interval": "",
+          "legendFormat": "{{ service }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "DB Size",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:57",
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:58",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": "30s",

--- a/files/grest/grafana/guild-dashboard.json
+++ b/files/grest/grafana/guild-dashboard.json
@@ -1047,6 +1047,104 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "type": "graph",
+      "title": "DB Size",
+      "gridPos": {
+        "x": 6,
+        "y": 26,
+        "w": 6,
+        "h": 7
+      },
+      "id": 159,
+      "targets": [
+        {
+          "expr": "dbsize",
+          "legendFormat": "{{ service }}",
+          "interval": "",
+          "exemplar": true,
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "alertThreshold": true
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "pluginVersion": "7.5.7",
+      "renderer": "flot",
+      "yaxes": [
+        {
+          "label": null,
+          "show": true,
+          "logBase": 1,
+          "min": null,
+          "max": null,
+          "format": "bytes",
+          "$$hashKey": "object:57"
+        },
+        {
+          "label": null,
+          "show": true,
+          "logBase": 1,
+          "min": null,
+          "max": null,
+          "format": "short",
+          "$$hashKey": "object:58"
+        }
+      ],
+      "xaxis": {
+        "show": true,
+        "mode": "time",
+        "name": null,
+        "values": [],
+        "buckets": null
+      },
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      },
+      "lines": true,
+      "fill": 1,
+      "linewidth": 1,
+      "dashLength": 10,
+      "spaceLength": 10,
+      "pointradius": 2,
+      "legend": {
+        "show": true,
+        "values": false,
+        "min": false,
+        "max": false,
+        "current": false,
+        "total": false,
+        "avg": false
+      },
+      "nullPointMode": "null",
+      "tooltip": {
+        "value_type": "individual",
+        "shared": true,
+        "sort": 0
+      },
+      "aliasColors": {},
+      "seriesOverrides": [],
+      "thresholds": [],
+      "timeRegions": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "fillGradient": 0,
+      "dashes": false,
+      "hiddenSeries": false,
+      "points": false,
+      "bars": false,
+      "stack": false,
+      "percentage": false,
+      "steppedLine": false,
+      "datasource": null
     }
   ],
   "refresh": "30s",

--- a/scripts/grest-helper-scripts/getmetrics.sh
+++ b/scripts/grest-helper-scripts/getmetrics.sh
@@ -57,7 +57,6 @@ function get-metrics() {
   export METRIC_cpuutil="${cpuutil}"
   export METRIC_load1m="$(( load1m ))"
   export METRIC_dbsize="${dbsize}"
-
   #export METRIC_cnodeversion="$(echo $(cardano-node --version) | awk '{print $2 "-" $9}')"
   #export METRIC_dbsyncversion="$(echo $(cardano-db-sync-extended --version) | awk '{print $2 "-" $9}')"
   #export METRIC_psqlversion="$(echo "" | psql cexplorer -c "SELECT version();" | grep PostgreSQL | awk '{print $2}')"

--- a/scripts/grest-helper-scripts/getmetrics.sh
+++ b/scripts/grest-helper-scripts/getmetrics.sh
@@ -43,6 +43,7 @@ function get-metrics() {
   memtotal=$(( $(echo "${meminf}" | grep MemTotal | awk '{print $2}') + $(echo "${meminf}" | grep SwapTotal | awk '{print $2}') ))
   memused=$(( memtotal - $(echo "${meminf}" | grep MemFree | awk '{print $2}') - $(echo "${meminf}" | grep SwapFree | awk '{print $2}') - $(echo "${meminf}" | grep ^Buffers | awk '{print $2}') - $(echo "${meminf}" | grep ^Cached | awk '{print $2}') ))
   cpuutil=$(awk -v a="$(awk '/cpu /{print $2+$4,$2+$4+$5}' /proc/stat; sleep 1)" '/cpu /{split(a,b," "); print 100*($2+$4-b[1])/($2+$4+$5-b[2])}'  /proc/stat)
+  dbsize=$(psql -d cexplorer -c "select pg_database_size ('cexplorer');" | awk 'FNR == 3 {print $1 $2}') # in Bytes
 
   # Metrics
   [[ -n "${dbsyncProm}" ]] && export METRIC_dbsynctipref=$(( currslottip - $(printf %f "$(echo "${dbsyncProm}" | grep cardano_db_sync_db_slot_height | awk '{print $2}')" |cut -d. -f1) ))
@@ -55,6 +56,8 @@ function get-metrics() {
   export METRIC_memused="${memused}"
   export METRIC_cpuutil="${cpuutil}"
   export METRIC_load1m="$(( load1m ))"
+  export METRIC_dbsize="${dbsize}"
+
   #export METRIC_cnodeversion="$(echo $(cardano-node --version) | awk '{print $2 "-" $9}')"
   #export METRIC_dbsyncversion="$(echo $(cardano-db-sync-extended --version) | awk '{print $2 "-" $9}')"
   #export METRIC_psqlversion="$(echo "" | psql cexplorer -c "SELECT version();" | grep PostgreSQL | awk '{print $2}')"

--- a/scripts/grest-helper-scripts/getmetrics.sh
+++ b/scripts/grest-helper-scripts/getmetrics.sh
@@ -43,7 +43,10 @@ function get-metrics() {
   memtotal=$(( $(echo "${meminf}" | grep MemTotal | awk '{print $2}') + $(echo "${meminf}" | grep SwapTotal | awk '{print $2}') ))
   memused=$(( memtotal - $(echo "${meminf}" | grep MemFree | awk '{print $2}') - $(echo "${meminf}" | grep SwapFree | awk '{print $2}') - $(echo "${meminf}" | grep ^Buffers | awk '{print $2}') - $(echo "${meminf}" | grep ^Cached | awk '{print $2}') ))
   cpuutil=$(awk -v a="$(awk '/cpu /{print $2+$4,$2+$4+$5}' /proc/stat; sleep 1)" '/cpu /{split(a,b," "); print 100*($2+$4-b[1])/($2+$4+$5-b[2])}'  /proc/stat)
-  dbsize=$(psql -d cexplorer -c "select pg_database_size ('cexplorer');" | awk 'FNR == 3 {print $1 $2}') # in Bytes
+  # in Bytes
+  pubschsize=$(psql -d cexplorer -c "SELECT sum(pg_relation_size(quote_ident(schemaname) || '.' || quote_ident(tablename))::bigint) FROM pg_tables WHERE schemaname = 'public'" | awk 'FNR == 3 {print $1 $2}')
+  grestschsize=$(psql -d cexplorer -c "SELECT sum(pg_relation_size(quote_ident(schemaname) || '.' || quote_ident(tablename))::bigint) FROM pg_tables WHERE schemaname = 'grest'" | awk 'FNR == 3 {print $1 $2}')
+  dbsize=$(expr $pubschsize + $grestschsize)
 
   # Metrics
   [[ -n "${dbsyncProm}" ]] && export METRIC_dbsynctipref=$(( currslottip - $(printf %f "$(echo "${dbsyncProm}" | grep cardano_db_sync_db_slot_height | awk '{print $2}')" |cut -d. -f1) ))
@@ -56,6 +59,8 @@ function get-metrics() {
   export METRIC_memused="${memused}"
   export METRIC_cpuutil="${cpuutil}"
   export METRIC_load1m="$(( load1m ))"
+  export METRIC_pubschsize="${pubschsize}"
+  export METRIC_grestschsize="${grestschsize}"
   export METRIC_dbsize="${dbsize}"
   #export METRIC_cnodeversion="$(echo $(cardano-node --version) | awk '{print $2 "-" $9}')"
   #export METRIC_dbsyncversion="$(echo $(cardano-db-sync-extended --version) | awk '{print $2 "-" $9}')"


### PR DESCRIPTION
Do we want this to track the growth of the DB?

We can also add the sizes of separate schemas (`public, grest`)to track them individually?