### PR TITLE
only scripts executables (#1054)

### DIFF
--- a/scripts/cnode-helper-scripts/prereqs.sh
+++ b/scripts/cnode-helper-scripts/prereqs.sh
@@ -511,7 +511,7 @@ updateWithCustomConfig "cntools.config"
 updateWithCustomConfig "logMonitor.sh"
 updateWithCustomConfig "cncli.sh"
 
-chmod -R 755 "${CNODE_HOME}" 2>/dev/null
+find "${CNODE_HOME}/scripts" -name '*.sh' -exec chmod 755 {} \; 2>/dev/null
 chmod -R 700 "${CNODE_HOME}"/priv 2>/dev/null
 
 pushd -0 >/dev/null || err_exit; dirs -c


### PR DESCRIPTION
As per #1054, I've update a chmod in `prereqs.sh` to only target `.sh` scripts. After more checks, I've found `env` and `cntools.library` are only sourced, thus not requiring to be executable.