### PR TITLE
Skeleton to fill guild mainnet node instances

### DIFF
--- a/files/topology-guild.json
+++ b/files/topology-guild.json
@@ -1,9 +1,8 @@
 {
   "Producers": [
     {"addr": "127.0.0.1"                 ,"port": 7000, "valency": 1},
-    {"addr": "178.238.224.187"           ,"port": 7000, "valency": 1,"name": "rdlrt-1"},
     {"addr": "95.216.188.94"             ,"port": 7000, "valency": 1,"name": "homer"},
-    {"addr": "209.145.50.190"            ,"port": 7000, "valency": 1,"name": "rdlrt-2"},
+    {"addr": "209.145.50.190"            ,"port": 7000, "valency": 1,"name": "rdlrt"},
     {"addr": "relay1-test.ahlnet.nu"     ,"port": 2103, "valency": 1,"name": "ahl-1"},
     {"addr": "guild-relay.bluecheesestakehouse.com","port": 7000,"valency": 1,"name": "westberg"},
     {"addr": "relay-1.stakepool.at","port": 54326,"valency": 1,"name": "atada"},

--- a/files/topology-mainnet.json
+++ b/files/topology-mainnet.json
@@ -1,0 +1,22 @@
+{
+  "Producers": [
+    {"addr": "node-dus.poolunder.com",         "port": 6900, "valency": 1, "pool": "UNDR",   "location": "EU/DE/Dusseldorf" },
+    {"addr": "node-fsn.poolunder.com",         "port": 6900, "valency": 1, "pool": "UNDR",   "location": "EU/DE/Falkenstein" },
+    {"addr": "node-bhs.poolunder.com",         "port": 6900, "valency": 1, "pool": "UNDR",   "location": "NA/CA/Montreal" },
+    {"addr": "node-sin.poolunder.com",         "port": 6900, "valency": 1, "pool": "UNDR",   "location": "AS/SG/Singapore" },
+    {"addr": "node-syd.poolunder.com",         "port": 6900, "valency": 1, "pool": "UNDR",   "location": "OC/AU/Sydney" },
+    {"addr": "88.99.83.86",                    "port": 4091, "valency": 1, "pool": "RDLRT",  "location": "EU/DE/Falkenstein" },
+    {"addr": "209.145.50.190",                 "port": 6001, "valency": 1, "pool": "RDLRT",  "location": "NA/US/StLouis" },
+    {"addr": "159.69.185.211",                 "port": 6000, "valency": 1, "pool": "AAA",    "location": "EU/DE/Falkenstein" },
+    {"addr": "168.119.51.182",                 "port": 6000, "valency": 1, "pool": "AAA",    "location": "EU/DE/Falkenstein" },
+    {"addr": "78.47.99.41",                    "port": 6000, "valency": 1, "pool": "AAA",    "location": "EU/DE/Nuremberg" },
+    {"addr": "relay1-pub.ahlnet.nu",           "port": 2111, "valency": 1, "pool": "AHL",    "location": "EU/SE/Malmo" },
+    {"addr": "relay2-pub.ahlnet.nu",           "port": 2111, "valency": 1, "pool": "AHL",    "location": "EU/SE/Malmo" },
+    {"addr": "relay1.clio.one",                "port": 6010, "valency": 1, "pool": "CLIO",   "location": "EU/IT/Milan" },
+    {"addr": "relay2.clio.one",                "port": 6010, "valency": 1, "pool": "CLIO",   "location": "EU/IT/Bozlano" },
+    {"addr": "relay3.clio.one",                "port": 6010, "valency": 1, "pool": "CLIO",   "location": "EU/IT/Bozlano" },
+    {"addr": "164.90.197.139",                 "port": 6000, "valency": 1, "name": "EDEN",   "location": "EU/NL/Amsterdam" },
+    {"addr": "128.199.187.2",                  "port": 6000, "valency": 1, "name": "EDEN",   "location": "AS/SG/Singapore" },
+    {"addr": "198.199.70.70",                  "port": 6000, "valency": 1, "name": "EDEN",   "location": "NA/US/NorthBergen" }
+  ]
+}


### PR DESCRIPTION
For consistency in naming location, I used `curl -k https://json.geoiplookup.io/<IP>` to use continent_code/country_code/city (stripping out spaces). 