### PR TITLE
Add account_updates RPC

### DIFF
--- a/docs/Build/grestsvcs.json
+++ b/docs/Build/grestsvcs.json
@@ -408,6 +408,35 @@
         }
       }
     },
+    "/rpc/account_updates": {
+      "post": {
+        "tags": ["Account Queries"],
+        "summary": "Get the account updates (registration, deregistration, delegation and withdrawals)",
+        "produces": ["application/json", "application/vnd.pgrst.object+json"],
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "required": ["_stake_address_bech32"],
+              "type": "object",
+              "properties": {
+                "_stake_address_bech32": {
+                  "format": "text",
+                  "type": "string"
+                }
+              }
+            },
+            "in": "body",
+            "name": "args"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/rpc/tip": {
       "post": {
         "tags": ["Blockchain Queries"],

--- a/files/grest/rpc/account/account_updates.sql
+++ b/files/grest/rpc/account/account_updates.sql
@@ -1,0 +1,67 @@
+DROP FUNCTION IF EXISTS grest.account_updates (text);
+
+CREATE FUNCTION grest.account_updates (_stake_address text)
+  RETURNS TABLE (
+    action_type text,
+    tx_hash text)
+  LANGUAGE PLPGSQL
+  AS $$
+DECLARE
+  SA_ID integer DEFAULT NULL;
+BEGIN
+  SELECT
+    STAKE_ADDRESS.ID INTO SA_ID
+  FROM
+    STAKE_ADDRESS
+  WHERE
+    STAKE_ADDRESS.VIEW = _stake_address;
+  IF SA_ID IS NULL THEN
+    RETURN;
+  END IF;
+  RETURN QUERY
+  SELECT
+    ACTIONS.action_type,
+    ENCODE(TX.HASH, 'hex') AS tx_hash
+  FROM ((
+      SELECT
+        'registration' AS action_type,
+        tx_id
+      FROM
+        STAKE_REGISTRATION
+      WHERE
+        addr_id = SA_ID)
+    UNION (
+      SELECT
+        'deregistration' AS action_type,
+        tx_id
+      FROM
+        STAKE_DEREGISTRATION
+      WHERE
+        addr_id = SA_ID)
+    UNION (
+      SELECT
+        'delegation' AS action_type,
+        tx_id
+      FROM
+        DELEGATION
+      WHERE
+        addr_id = SA_ID)
+    UNION (
+      SELECT
+        'withdrawal' AS action_type,
+        tx_id
+      FROM
+        WITHDRAWAL
+      WHERE
+        addr_id = SA_ID)) ACTIONS
+  INNER JOIN TX ON TX.ID = ACTIONS.TX_ID
+ORDER BY
+  TX.ID ASC,
+  ACTIONS.action_type DESC;
+  -- Ordering inside each transaction:
+  -- Withdrawal -> Registration -> Delegation -> Deregistration
+END;
+$$;
+
+COMMENT ON FUNCTION grest.account_updates IS 'Get the account updates (registration, deregistration, delegation and withdrawals)';
+


### PR DESCRIPTION
I don't think `withdrawal` belongs to this endpoint, but following our Trello board.

At the moment, only `tx_hash` is returned as additional info for the update action.