### PR TITLE
Bump node version references

### DIFF
--- a/docs/Build/node-cli.md
+++ b/docs/Build/node-cli.md
@@ -35,11 +35,11 @@ Execute `cardano-cli` and `cardano-node` to verify output as below:
 
 ```bash
 cardano-cli version
-# cardano-cli 1.29.0 - linux-x86_64 - ghc-8.10
-# git rev 4c59442958072657812c6c0bb8e0b4ab85ce1ba2
+# cardano-cli 1.30.1 - linux-x86_64 - ghc-8.10
+# git rev 0fb43f4e3da8b225f4f86557aed90a183981a64f
 cardano-node version
-# cardano-node 1.29.0 - linux-x86_64 - ghc-8.10
-# git rev 4c59442958072657812c6c0bb8e0b4ab85ce1ba2
+# cardano-node 1.30.1 - linux-x86_64 - ghc-8.10
+# git rev 0fb43f4e3da8b225f4f86557aed90a183981a64f
 ```
 
 #### Update port number or pool name for relative paths

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -816,8 +816,8 @@ getEraIdentifier() {
 }
 
 node_version="$(${CCLI} version | head -1 | cut -d' ' -f2)"
-if ! versionCheck "1.29.0" "${node_version}"; then
-  echo -e "\nGuild scripts has now been upgraded to support cardano-node 1.29.0 or higher (${node_version} found).\nPlease update cardano-node (note that you should ideally update your config too) or use tagged branches for older node version.\n\n"
+if ! versionCheck "1.30.1" "${node_version}"; then
+  echo -e "\nGuild scripts has now been upgraded to support cardano-node 1.30.1 or higher (${node_version} found).\nPlease update cardano-node (note that you should ideally update your config too) or use tagged branches for older node version.\n\n"
   return 1
 fi
 


### PR DESCRIPTION
There are no breaking changes, and codebase works fine with both versions - but upgrading to 1.30.1 is prereq for fork. Hence, minimum support baseline could be updated