### PR TITLE
Add address_txs RPC

### DIFF
--- a/docs/Build/grestsvcs.json
+++ b/docs/Build/grestsvcs.json
@@ -670,10 +670,10 @@
           {
             "required": true,
             "schema": {
-              "required": ["_payment_address_arr"],
+              "required": ["_payment_addresses"],
               "type": "object",
               "properties": {
-                "_payment_address_arr": {
+                "_payment_addresses": {
                   "type": "array",
                   "items": { "type": "string" },
                   "minItems": 1

--- a/docs/Build/grestsvcs.json
+++ b/docs/Build/grestsvcs.json
@@ -644,9 +644,39 @@
               "required": ["_payment_address_bech32"],
               "type": "object",
               "properties": {
-                "_address": {
+                "_payment_address_bech32": {
                   "format": "text",
                   "type": "string"
+                }
+              }
+            },
+            "in": "body",
+            "name": "args"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/rpc/address_txs": {
+      "post": {
+        "tags": ["Address Queries"],
+        "summary": "Get the transaction hash list of a payment address array, optionally filtering after specified block height (inclusive)",
+        "produces": ["application/json", "application/vnd.pgrst.object+json"],
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "required": ["_payment_address_arr"],
+              "type": "object",
+              "properties": {
+                "_payment_address_arr": {
+                  "type": "array",
+                  "items": { "type": "string" },
+                  "minItems": 1
                 }
               }
             },

--- a/files/grest/rpc/address/address_txs.sql
+++ b/files/grest/rpc/address/address_txs.sql
@@ -1,6 +1,6 @@
 DROP FUNCTION IF EXISTS grest.address_txs (text[], integer);
 
-CREATE FUNCTION grest.address_txs (_payment_address_arr text[], _after_block_height integer DEFAULT NULL)
+CREATE FUNCTION grest.address_txs (_payment_addresses text[], _after_block_height integer DEFAULT NULL)
   RETURNS TABLE (
     tx_hash text)
   LANGUAGE PLPGSQL
@@ -15,7 +15,7 @@ BEGIN
       INNER JOIN public.tx ON tx_out.tx_id = tx.id
       INNER JOIN public.block ON block.id = tx.block_id
     WHERE
-      tx_out.address = ANY (_payment_address_arr)
+      tx_out.address = ANY (_payment_addresses)
       AND block.block_no >= _after_block_height;
   ELSE
     RETURN QUERY
@@ -25,7 +25,7 @@ BEGIN
       public.tx_out
       INNER JOIN public.tx ON tx_out.tx_id = tx.id
     WHERE
-      tx_out.address = ANY (_payment_address_arr);
+      tx_out.address = ANY (_payment_addresses);
   END IF;
 END;
 $$;

--- a/files/grest/rpc/address/address_txs.sql
+++ b/files/grest/rpc/address/address_txs.sql
@@ -1,6 +1,6 @@
-DROP FUNCTION IF EXISTS grest.address_txs (text);
+DROP FUNCTION IF EXISTS grest.address_txs (text[], integer);
 
-CREATE FUNCTION grest.address_txs (_payment_address text, _after_block_height integer DEFAULT NULL)
+CREATE FUNCTION grest.address_txs (_payment_address text[], _after_block_height integer DEFAULT NULL)
   RETURNS TABLE (
     tx_hash text)
   LANGUAGE PLPGSQL
@@ -15,7 +15,7 @@ BEGIN
       INNER JOIN public.tx ON tx_out.tx_id = tx.id
       INNER JOIN public.block ON block.id = tx.block_id
     WHERE
-      tx_out.address = _payment_address
+      tx_out.address = ANY (_payment_address)
       AND block.block_no >= _after_block_height;
   ELSE
     RETURN QUERY
@@ -25,10 +25,10 @@ BEGIN
       public.tx_out
       INNER JOIN public.tx ON tx_out.tx_id = tx.id
     WHERE
-      tx_out.address = _payment_address;
+      tx_out.address = ANY (_payment_address);
   END IF;
 END;
 $$;
 
-COMMENT ON FUNCTION grest.address_txs IS 'Get transaction hash list of a payment address, optionally filtering after specified block height.';
+COMMENT ON FUNCTION grest.address_txs IS 'Get transaction hash list of a payment address, optionally filtering after specified block height (inclusive).';
 

--- a/files/grest/rpc/address/address_txs.sql
+++ b/files/grest/rpc/address/address_txs.sql
@@ -1,0 +1,34 @@
+DROP FUNCTION IF EXISTS grest.address_txs (text);
+
+CREATE FUNCTION grest.address_txs (_payment_address text, _after_block_height integer DEFAULT NULL)
+  RETURNS TABLE (
+    tx_hash text)
+  LANGUAGE PLPGSQL
+  AS $$
+BEGIN
+  IF _after_block_height IS NOT NULL THEN
+    RETURN QUERY
+    SELECT
+      ENCODE(tx.hash, 'hex') as tx_hash
+    FROM
+      public.tx_out
+      INNER JOIN public.tx ON tx_out.tx_id = tx.id
+      INNER JOIN public.block ON block.id = tx.block_id
+    WHERE
+      tx_out.address = _payment_address
+      AND block.block_no >= _after_block_height;
+  ELSE
+    RETURN QUERY
+    SELECT
+      ENCODE(tx.hash, 'hex') as tx_hash
+    FROM
+      public.tx_out
+      INNER JOIN public.tx ON tx_out.tx_id = tx.id
+    WHERE
+      tx_out.address = _payment_address;
+  END IF;
+END;
+$$;
+
+COMMENT ON FUNCTION grest.address_txs IS 'Get transaction hash list of a payment address, optionally filtering after specified block height.';
+

--- a/files/grest/rpc/address/address_txs.sql
+++ b/files/grest/rpc/address/address_txs.sql
@@ -1,6 +1,6 @@
 DROP FUNCTION IF EXISTS grest.address_txs (text[], integer);
 
-CREATE FUNCTION grest.address_txs (_payment_address text[], _after_block_height integer DEFAULT NULL)
+CREATE FUNCTION grest.address_txs (_payment_address_arr text[], _after_block_height integer DEFAULT NULL)
   RETURNS TABLE (
     tx_hash text)
   LANGUAGE PLPGSQL
@@ -15,7 +15,7 @@ BEGIN
       INNER JOIN public.tx ON tx_out.tx_id = tx.id
       INNER JOIN public.block ON block.id = tx.block_id
     WHERE
-      tx_out.address = ANY (_payment_address)
+      tx_out.address = ANY (_payment_address_arr)
       AND block.block_no >= _after_block_height;
   ELSE
     RETURN QUERY
@@ -25,10 +25,10 @@ BEGIN
       public.tx_out
       INNER JOIN public.tx ON tx_out.tx_id = tx.id
     WHERE
-      tx_out.address = ANY (_payment_address);
+      tx_out.address = ANY (_payment_address_arr);
   END IF;
 END;
 $$;
 
-COMMENT ON FUNCTION grest.address_txs IS 'Get transaction hash list of a payment address, optionally filtering after specified block height (inclusive).';
+COMMENT ON FUNCTION grest.address_txs IS 'Get the transaction hash list of a payment address array, optionally filtering after specified block height (inclusive).';
 


### PR DESCRIPTION
Currently gets the tx hash list and has an optional `after_block_height` filter.

But we talked about the possibility of bulk addresses received to this endpoint - I need clarification on that.

If we receive bulk addresses, how is that useful for the user if we are only listing tx hashes? Do we need to return a structure of:

```
[
  address1: { tx_hash1, tx_hash2 },
  address2: { tx_hash1, tx_hash2 }
]
```
in that case?