### PR TITLE
CNTools 8.7.2

### DIFF
--- a/docs/Scripts/cntools-changelog.md
+++ b/docs/Scripts/cntools-changelog.md
@@ -6,6 +6,10 @@ All notable changes to this tool will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.7.2] - 2021-11-08
+#### Changed
+- Remove check if pool reward wallet is a hw wallet, enforce that its also a multi-owner to the pool
+
 ## [8.7.1] - 2021-11-04
 #### Fixed
 - Balance check of wrong wallet in certain circumstances for pool modify

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -11,7 +11,7 @@ CNTOOLS_MAJOR_VERSION=8
 # Minor: Changes and features of minor character that can be applied without breaking existing functionality or workflow
 CNTOOLS_MINOR_VERSION=7
 # Patch: Backwards compatible bug fixes. No additional functionality or major changes
-CNTOOLS_PATCH_VERSION=1
+CNTOOLS_PATCH_VERSION=2
 
 CNTOOLS_VERSION="${CNTOOLS_MAJOR_VERSION}.${CNTOOLS_MINOR_VERSION}.${CNTOOLS_PATCH_VERSION}"
 

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -2006,15 +2006,7 @@ function main {
 
                     getWalletType ${reward_wallet}
                     case $? in
-                      0) hw_reward_is_mu='N'
-                          for wallet_name in "${owner_wallets[@]}"; do # HW reward wallet, make sure its also a multi-owner to the pool
-                            [[ "${wallet_name}" = "${reward_wallet}" ]] && hw_reward_is_mu='Y' && break
-                          done
-                          if [[ ${hw_reward_is_mu} = 'N' ]]; then # main owner, must be a CLI wallet
-                            println ERROR "${FG_RED}ERROR${NC}: reward wallet detected as hardware wallet but NOT a multi-owner to the pool!"
-                            println ERROR "If hardware wallet is to be used for rewards, it MUST also be a multi-owner to the pool"
-                            waitForInput "Unable to reuse old configuration, please set new owner(s) & reward wallet" && owner_wallets=() && reward_wallet="" && reuse_wallets='N'
-                          else hw_reward_wallet='Y'; fi ;;
+                      0) hw_reward_wallet='Y' ;;
                       2) if [[ ${op_mode} = "online" && ${SUBCOMMAND} = "register" && ${hw_owner_wallets} = 'N' ]]; then
                             println ERROR "${FG_RED}ERROR${NC}: signing keys encrypted for reward wallet ${FG_GREEN}${reward_wallet}${NC}, please decrypt before use!"
                             waitForInput && continue


### PR DESCRIPTION
Remove check if pool reward wallet is a hw wallet, enforce that its also a multi-owner to the pool.
Was also only checked if reusing old config, not if specifying new wallets.