### PR TITLE
Updates to HAProxy config (and minor alignments from recent discussions)

### DIFF
--- a/scripts/grest-helper-scripts/setup-grest.sh
+++ b/scripts/grest-helper-scripts/setup-grest.sh
@@ -273,7 +273,7 @@
   deploy_postgrest() {
     echo "[Re]Installing PostgREST.."
     pushd ~/tmp >/dev/null || err_exit
-    pgrest_asset_url="$(curl -s https://api.github.com/repos/PostgREST/postgrest/releases/latest | jq -r '.assets[].browser_download_url' | grep 'linux-x64-static.tar.xz')"
+    pgrest_asset_url="$(curl -s https://api.github.com/repos/PostgREST/postgrest/releases/latest | jq -r '.assets[].browser_download_url' | grep 'linux-static-x64.tar.xz')"
     if curl -sL -f -m ${CURL_TIMEOUT} -o postgrest.tar.xz "${pgrest_asset_url}"; then
       tar xf postgrest.tar.xz &>/dev/null && rm -f postgrest.tar.xz
       [[ -f postgrest ]] || err_exit "PostgREST archive downloaded but binary not found after attempting to extract package!"
@@ -509,7 +509,7 @@
     return 0
   }
 
-  # Description : Check sync until Mary hard-fork.
+  # Description : Check sync until Alonzo hard-fork.
   check_db_status() {
     if ! command -v psql &>/dev/null; then
       err_exit "We could not find 'psql' binary in \$PATH , please ensure you've followed the instructions below:\n ${DOCS_URL}/Appendix/postgres"
@@ -517,7 +517,7 @@
     if [[ -z ${PGPASSFILE} || ! -f "${PGPASSFILE}" ]]; then
       err_exit "PGPASSFILE env variable not set or pointing to a non-existing file: ${PGPASSFILE}\n ${DOCS_URL}/Build/dbsync"
     fi
-    if [[ "$(psql -qtAX -d ${PGDATABASE} -c "SELECT protocol_major FROM public.param_proposal WHERE protocol_major >= 4 ORDER BY protocol_major DESC LIMIT 1" 2>/dev/null)" == "" ]]; then
+    if [[ "$(psql -qtAX -d ${PGDATABASE} -c "SELECT protocol_major FROM public.param_proposal WHERE protocol_major > 4 ORDER BY protocol_major DESC LIMIT 1" 2>/dev/null)" == "" ]]; then
       return 1
     fi
 
@@ -554,7 +554,7 @@
     echo "(Re)Deploying Postgres RPCs/views/schedule..."
     check_db_status
     if [[ $? -eq 1 ]]; then
-      err_exit "Please wait for Cardano DBSync to populate PostgreSQL DB at least until Mary fork, and then re-run this setup script with the -q flag."
+      err_exit "Please wait for Cardano DBSync to populate PostgreSQL DB at least until Alonzo fork, and then re-run this setup script with the -q flag."
     fi
 
     echo -e "  Downloading DBSync RPC functions from Guild Operators GitHub store..."

--- a/scripts/grest-helper-scripts/setup-grest.sh
+++ b/scripts/grest-helper-scripts/setup-grest.sh
@@ -56,14 +56,10 @@
         exit 1
       fi
 
-      ENV_UPDATED=N
       checkUpdate env N N N
-      case $? in
-        1) ENV_UPDATED=Y ;;
-        2) exit 1 ;;
-      esac
+      [[ $? -eq 2 ]] && exit 1
 
-      checkUpdate setup-grest.sh ${ENV_UPDATED} N N grest-helper-scripts
+      checkUpdate setup-grest.sh Y N N grest-helper-scripts
       case $? in
         1) echo; $0 "$@" "-u"; exit 0 ;; # re-launch script with same args skipping update check
         2) exit 1 ;;


### PR DESCRIPTION
HAProxy config:
- Add logging placeholder with custom format
- Prevent logs for tip check [lightweight query, and repeated for polling]
- Add backend for Unauthorized access, used by monitoring instances only
- Add CPU map to only use first two cores, specify ulimit
- Reduce DDoS limits from 100/10s to 50/10s
- Enable cache
- Enforce server nomen clature for ssl-enabled servers (will be required for grest-poll.sh updates)

setup-grest:
- Move grest-poll.sh and checkmetrics.sh updates to deploy_config function (so executed with `-f`)
- Supress update prompt for setup-grest script, as it is a lot more independent from env (and skip update can be done via command line param)
- Adapt to PostgREST CI change for binary nomen clature
- Expect baseline for dbsync status to be synched until Alonzo fork (instead of Mary)

grest.conf:
- Update Default max-observations to 1000