### PR TITLE
Fix mission column executable error. Removed duplicated wget in apt list

### DIFF
--- a/files/docker/node/dockerfile_stage3
+++ b/files/docker/node/dockerfile_stage3
@@ -36,7 +36,7 @@ RUN sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen \
     && echo "export LANGUAGE=en_US.UTF-8" >> ~/.bashrc
 
 # PREREQ
-RUN apt-get update && apt-get install -y libcap2 libselinux1 libc6 libsodium-dev ncurses-bin iproute2 curl wget apt-utils xz-utils netbase sudo coreutils dnsutils net-tools procps tcptraceroute bc usbip sqlite3 python3 tmux jq ncurses-base libtool autoconf git wget gnupg tcptraceroute util-linux less openssl \
+RUN apt-get update && apt-get install -y libcap2 libselinux1 libc6 libsodium-dev ncurses-bin iproute2 curl wget apt-utils xz-utils netbase sudo coreutils dnsutils net-tools procps tcptraceroute bc usbip sqlite3 python3 tmux jq ncurses-base libtool autoconf git bsdmainutils gnupg tcptraceroute util-linux less openssl \
     && apt-get install -y --no-install-recommends cron \
     && sudo apt-get -y purge && sudo apt-get -y clean && sudo apt-get -y autoremove && sudo rm -rf /var/lib/apt/lists/* # && sudo rm -rf /usr/bin/apt*
 


### PR DESCRIPTION
Adds missing bsdmainutils which contains column executable needed for cntools (https://command-not-found.com/column)

Fixes #1227 