### PR TITLE
Move epoch info cache to cron

### DIFF
--- a/files/grest/apispec/koiosapi.yaml
+++ b/files/grest/apispec/koiosapi.yaml
@@ -996,7 +996,7 @@ components:
       type: array
       items:
         properties:
-          epoch:
+          epoch_no:
             type: integer
             description: Epoch number
             example: 294
@@ -1032,6 +1032,10 @@ components:
       type: array
       items:
         properties:
+          epoch_no:
+            type: integer
+            description: Epoch number
+            example: 294
           min_fee_a:
             type: integer
             description: The 'a' parameter to calculate the minimum transaction fee

--- a/files/grest/cron/jobs/epoch-info-cache-update.sh
+++ b/files/grest/cron/jobs/epoch-info-cache-update.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+DB_NAME=cexplorer
+
+echo "$(date +%F_%H:%M:%S) Running epoch info cache update..."
+psql ${DB_NAME} -qbt -c "SELECT GREST.EPOCH_INFO_CACHE_UPDATE();" 2>&1 1>/dev/null
+echo "$(date +%F_%H:%M:%S) Job done!"

--- a/files/grest/rpc/01_cached_tables/epoch_info_cache.sql
+++ b/files/grest/rpc/01_cached_tables/epoch_info_cache.sql
@@ -41,6 +41,11 @@ CREATE TABLE IF NOT EXISTS grest.epoch_info_cache (
 
 COMMENT ON TABLE grest.epoch_info_cache IS 'Get detailed info for epoch including protocol parameters';
 
+-- Dropping triggers, here just for making updates easier by automatically removing stale triggers.
+-- Should be removed after updates are done:
+DROP TRIGGER IF EXISTS epoch_info_update_trigger ON public.block;
+DROP TRIGGER IF EXISTS new_epoch_insert_trigger ON public.epoch;
+
 
 DROP FUNCTION IF EXISTS grest.EPOCH_INFO_CACHE_UPDATE CASCADE;
 

--- a/files/grest/rpc/01_cached_tables/epoch_info_cache.sql
+++ b/files/grest/rpc/01_cached_tables/epoch_info_cache.sql
@@ -1,6 +1,4 @@
-DROP TABLE IF EXISTS grest.epoch_info_cache;
-
-CREATE TABLE grest.epoch_info_cache (
+CREATE TABLE IF NOT EXISTS grest.epoch_info_cache (
   epoch uinteger PRIMARY KEY NOT NULL,
   i_out_sum word128type NOT NULL,
   i_fees lovelace NOT NULL,
@@ -43,143 +41,139 @@ CREATE TABLE grest.epoch_info_cache (
 
 COMMENT ON TABLE grest.epoch_info_cache IS 'Get detailed info for epoch including protocol parameters';
 
-INSERT INTO grest.epoch_info_cache SELECT DISTINCT ON (b.time)
-  e.no AS epoch,
-  e.out_sum AS i_out_sum,
-  e.fees AS i_fees,
-  e.tx_count AS i_tx_count,
-  e.blk_count AS i_blk_count,
-  e.start_time AS i_first_block_time,
-  e.end_time AS i_last_block_time,
-  ep.min_fee_a AS p_min_fee_a,
-  ep.min_fee_b AS p_min_fee_b,
-  ep.max_block_size AS p_max_block_size,
-  ep.max_tx_size AS p_max_tx_size,
-  ep.max_bh_size AS p_max_bh_size,
-  ep.key_deposit AS p_key_deposit,
-  ep.pool_deposit AS p_pool_deposit,
-  ep.max_epoch AS p_max_epoch,
-  ep.optimal_pool_count AS p_optimal_pool_count,
-  ep.influence AS p_influence,
-  ep.monetary_expand_rate AS p_monetary_expand_rate,
-  ep.treasury_growth_rate AS p_treasury_growth_rate,
-  ep.decentralisation AS p_decentralisation,
-  ENCODE(ep.entropy, 'hex') AS p_entropy,
-  ep.protocol_major AS p_protocol_major,
-  ep.protocol_minor AS p_protocol_minor,
-  ep.min_utxo_value AS p_min_utxo_value,
-  ep.min_pool_cost AS p_min_pool_cost,
-  ENCODE(ep.nonce, 'hex') AS p_nonce,
-  ENCODE(b.hash, 'hex') AS p_block_hash,
-  cm.costs AS p_cost_models,
-  ep.price_mem AS p_price_mem,
-  ep.price_step AS p_price_step,
-  ep.max_tx_ex_mem AS p_max_tx_ex_mem,
-  ep.max_tx_ex_steps AS p_max_tx_ex_steps,
-  ep.max_block_ex_mem AS p_max_block_ex_mem,
-  ep.max_block_ex_steps AS p_max_block_ex_steps,
-  ep.max_val_size AS p_max_val_size,
-  ep.collateral_percent AS p_collateral_percent,
-  ep.max_collateral_inputs AS p_max_collateral_inputs,
-  ep.coins_per_utxo_word AS p_coins_per_utxo_word
-FROM
-  epoch e
-  LEFT JOIN epoch_param ep ON ep.epoch_no = e.no
-  LEFT JOIN cost_model cm ON cm.id = ep.cost_model_id
-  INNER JOIN block b ON b.time = e.start_time
-ORDER BY
-  b.time ASC,
-  b.id ASC,
-  e.no ASC;
 
--- Trigger for updating current epoch data
-DROP TRIGGER IF EXISTS epoch_info_update_trigger ON public.block;
+DROP FUNCTION IF EXISTS grest.EPOCH_INFO_CACHE_UPDATE CASCADE;
 
-DROP FUNCTION IF EXISTS grest.epoch_info_update;
-
-CREATE FUNCTION grest.epoch_info_update ()
-  RETURNS TRIGGER
-  AS $epoch_info_update$
+CREATE FUNCTION grest.EPOCH_INFO_CACHE_UPDATE (_epoch_no_to_insert_from bigint default NULL)
+  RETURNS void
+  LANGUAGE plpgsql
+  AS $$
 DECLARE
-  _current_epoch integer DEFAULT NULL;
-  _current_end_time timestamp without time zone DEFAULT NULL;
-  _current_end_time_cache timestamp without time zone DEFAULT NULL;
+  _curr_epoch bigint;
+  _latest_epoch_no_in_cache bigint;
 BEGIN
-  SELECT
-    end_time
-  FROM
-    epoch
-  WHERE
-    NO = (
-      SELECT
-        MAX(NO)
-      FROM
-        epoch) INTO _current_end_time;
-  SELECT
-    i_last_block_time
-  FROM
-    grest.epoch_info_cache
-  WHERE
-    epoch = (
-      SELECT
-        MAX(epoch)
-      FROM
-        grest.epoch_info_cache) INTO _current_end_time_cache;
+  -- Check previous cache update completed before running
   IF (
     SELECT
-      EXTRACT(EPOCH FROM (_current_end_time - _current_end_time_cache)) >= 900) THEN
-    SELECT
-      MAX(epoch)
+      COUNT(pid) > 1
     FROM
-      grest.epoch_info_cache INTO _current_epoch;
-    UPDATE
-      grest.epoch_info_cache
-    SET
-      i_out_sum = update_table.out_sum,
-      i_fees = update_table.fees,
-      i_tx_count = update_table.tx_count,
-      i_blk_count = update_table.blk_count,
-      i_last_block_time = update_table.end_time
-    FROM (
-      SELECT
-        e.out_sum,
-        e.fees,
-        e.tx_count,
-        e.blk_count,
-        e.end_time
-      FROM
-        epoch e
-      WHERE
-        e.no = _current_epoch) update_table
-  WHERE
-    epoch = _current_epoch;
-  END IF;
-  RETURN NULL;
+      pg_stat_activity
+    WHERE
+      state = 'active' AND query ILIKE '%GREST.EPOCH_INFO_CACHE_UPDATE%'
+      AND datname = (SELECT current_database())
+    ) THEN
+        RAISE EXCEPTION 'Previous EPOCH_INFO_CACHE_UPDATE query still running but should have completed! Exiting...';
+    END IF;
+
+  -- GREST control table entry
+  INSERT INTO GREST.CONTROL_TABLE (key, last_value)
+    VALUES('epoch_info_cache_last_update', NOW() at time zone 'utc')
+    ON CONFLICT (key)
+    DO UPDATE
+      SET last_value = NOW() at time zone 'utc';
+
+  IF _epoch_no_to_insert_from IS NULL THEN
+    SELECT
+      COALESCE(MAX(epoch_no), 0) INTO _latest_epoch_no_in_cache
+    FROM
+      grest.epoch_info_cache;
+
+    IF _latest_epoch_no_in_cache = 0 THEN
+      RAISE NOTICE 'Epoch info cache table is empty, starting initial population...';
+      PERFORM grest.EPOCH_INFO_CACHE_UPDATE (0);
+      RETURN;
+    END IF;
+
+    SELECT
+      MAX(no) INTO _curr_epoch
+    FROM
+      public.epoch;
+
+    RAISE NOTICE 'Latest epoch in cache: %, current epoch: %.', _latest_epoch_no_in_cache, _curr_epoch;
+
+    IF _curr_epoch = _latest_epoch_no_in_cache THEN
+      RAISE NOTICE 'Updating latest epoch info in cache...';
+      PERFORM grest.UPDATE_LATEST_EPOCH_INFO_CACHE(_latest_epoch_no_in_cache);
+      RETURN;
+    END IF;
+
+    IF _latest_epoch_no_in_cache > _curr_epoch THEN
+      RAISE NOTICE 'No update needed, exiting...';
+      RETURN;
+    END IF;
+
+    RAISE NOTICE 'Updating cache with new epoch(s) data...';
+    -- We need to update last epoch one last time before going to new one
+    PERFORM grest.UPDATE_LATEST_EPOCH_INFO_CACHE(_latest_epoch_no_in_cache);
+    _epoch_no_to_insert_from := _latest_epoch_no_in_cache + 1;
+  END IF;  
+
+  RAISE NOTICE 'Deleting cache records from epoch % onwards...', _epoch_no_to_insert_from;
+  DELETE FROM grest.epoch_info_cache
+  WHERE epoch_no >= _epoch_no_to_insert_from;
+
+  INSERT INTO grest.epoch_info_cache
+    SELECT DISTINCT ON (b.time)
+      e.no AS epoch,
+      e.out_sum AS i_out_sum,
+      e.fees AS i_fees,
+      e.tx_count AS i_tx_count,
+      e.blk_count AS i_blk_count,
+      e.start_time AS i_first_block_time,
+      e.end_time AS i_last_block_time,
+      ep.min_fee_a AS p_min_fee_a,
+      ep.min_fee_b AS p_min_fee_b,
+      ep.max_block_size AS p_max_block_size,
+      ep.max_tx_size AS p_max_tx_size,
+      ep.max_bh_size AS p_max_bh_size,
+      ep.key_deposit AS p_key_deposit,
+      ep.pool_deposit AS p_pool_deposit,
+      ep.max_epoch AS p_max_epoch,
+      ep.optimal_pool_count AS p_optimal_pool_count,
+      ep.influence AS p_influence,
+      ep.monetary_expand_rate AS p_monetary_expand_rate,
+      ep.treasury_growth_rate AS p_treasury_growth_rate,
+      ep.decentralisation AS p_decentralisation,
+      ENCODE(ep.entropy, 'hex') AS p_entropy,
+      ep.protocol_major AS p_protocol_major,
+      ep.protocol_minor AS p_protocol_minor,
+      ep.min_utxo_value AS p_min_utxo_value,
+      ep.min_pool_cost AS p_min_pool_cost,
+      ENCODE(ep.nonce, 'hex') AS p_nonce,
+      ENCODE(b.hash, 'hex') AS p_block_hash,
+      cm.costs AS p_cost_models,
+      ep.price_mem AS p_price_mem,
+      ep.price_step AS p_price_step,
+      ep.max_tx_ex_mem AS p_max_tx_ex_mem,
+      ep.max_tx_ex_steps AS p_max_tx_ex_steps,
+      ep.max_block_ex_mem AS p_max_block_ex_mem,
+      ep.max_block_ex_steps AS p_max_block_ex_steps,
+      ep.max_val_size AS p_max_val_size,
+      ep.collateral_percent AS p_collateral_percent,
+      ep.max_collateral_inputs AS p_max_collateral_inputs,
+      ep.coins_per_utxo_word AS p_coins_per_utxo_word
+    FROM
+      epoch e
+      LEFT JOIN epoch_param ep ON ep.epoch_no = e.no
+      LEFT JOIN cost_model cm ON cm.id = ep.cost_model_id
+      INNER JOIN block b ON b.time = e.start_time
+    WHERE
+      e.no >= _epoch_no_to_insert_from
+    ORDER BY
+      b.time ASC,
+      b.id ASC,
+      e.no ASC;
 END;
-$epoch_info_update$
-LANGUAGE plpgsql;
+$$;
 
-CREATE TRIGGER epoch_info_update_trigger
-  AFTER INSERT ON public.block
-  FOR EACH STATEMENT
-  EXECUTE PROCEDURE grest.epoch_info_update ();
+-- Helper function for updating current epoch data
+DROP FUNCTION IF EXISTS grest.UPDATE_LATEST_EPOCH_INFO_CACHE;
 
--- Trigger for inserting new epoch data
-DROP TRIGGER IF EXISTS new_epoch_insert_trigger ON public.epoch;
-
-DROP FUNCTION IF EXISTS grest.new_epoch_insert CASCADE;
-
-CREATE FUNCTION grest.new_epoch_insert ()
-  RETURNS TRIGGER
-  AS $new_epoch_insert$
-DECLARE
-  _previous_epoch integer DEFAULT NULL;
+CREATE FUNCTION grest.UPDATE_LATEST_EPOCH_INFO_CACHE (_epoch_no_to_update bigint default NULL)
+  RETURNS void
+  LANGUAGE plpgsql
+  AS $$
 BEGIN
-  -- First, we have to make sure that the previous epoch has been updated one last time
-  SELECT
-    MAX(epoch)
-  FROM
-    grest.epoch_info_cache INTO _previous_epoch;
   UPDATE
     grest.epoch_info_cache
   SET
@@ -198,68 +192,9 @@ BEGIN
     FROM
       epoch e
     WHERE
-      e.no = _previous_epoch) update_table
-WHERE
-  epoch = _previous_epoch;
-  -- Then, insert the new epoch data
-  INSERT INTO grest.epoch_info_cache
-  SELECT
-    e.no AS epoch,
-    e.out_sum AS i_out_sum,
-    e.fees AS i_fees,
-    e.tx_count AS i_tx_count,
-    e.blk_count AS i_blk_count,
-    e.start_time AS i_first_block_time,
-    e.end_time AS i_last_block_time,
-    ep.min_fee_a AS p_min_fee_a,
-    ep.min_fee_b AS p_min_fee_b,
-    ep.max_block_size AS p_max_block_size,
-    ep.max_tx_size AS p_max_tx_size,
-    ep.max_bh_size AS p_max_bh_size,
-    ep.key_deposit AS p_key_deposit,
-    ep.pool_deposit AS p_pool_deposit,
-    ep.max_epoch AS p_max_epoch,
-    ep.optimal_pool_count AS p_optimal_pool_count,
-    ep.influence AS p_influence,
-    ep.monetary_expand_rate AS p_monetary_expand_rate,
-    ep.treasury_growth_rate AS p_treasury_growth_rate,
-    ep.decentralisation AS p_decentralisation,
-    ENCODE(ep.entropy, 'hex') AS p_entropy,
-    ep.protocol_major AS p_protocol_major,
-    ep.protocol_minor AS p_protocol_minor,
-    ep.min_utxo_value AS p_min_utxo_value,
-    ep.min_pool_cost AS p_min_pool_cost,
-    ENCODE(ep.nonce, 'hex') AS p_nonce,
-    ENCODE(b.hash, 'hex') AS p_block_hash,
-    cm.costs AS p_cost_models,
-    ep.price_mem AS p_price_mem,
-    ep.price_step AS p_price_step,
-    ep.max_tx_ex_mem AS p_max_tx_ex_mem,
-    ep.max_tx_ex_steps AS p_max_tx_ex_steps,
-    ep.max_block_ex_mem AS p_max_block_ex_mem,
-    ep.max_block_ex_steps AS p_max_block_ex_steps,
-    ep.max_val_size AS p_max_val_size,
-    ep.collateral_percent AS p_collateral_percent,
-    ep.max_collateral_inputs AS p_max_collateral_inputs,
-    ep.coins_per_utxo_word AS p_coins_per_utxo_word
-  FROM
-    epoch e
-    INNER JOIN epoch_param ep ON ep.epoch_no = e.no
-    LEFT JOIN cost_model cm ON cm.id = ep.cost_model_id
-    INNER JOIN block b ON b.id = ep.block_id
+      e.no = _epoch_no_to_update
+  ) update_table
   WHERE
-    e.no = (
-      SELECT
-        MAX(NO)
-      FROM
-        epoch);
-  RETURN NULL;
+    epoch = _epoch_no_to_update;
 END;
-$new_epoch_insert$
-LANGUAGE plpgsql;
-
-CREATE TRIGGER new_epoch_insert_trigger
-  AFTER INSERT ON public.epoch
-  FOR EACH ROW
-  EXECUTE PROCEDURE grest.new_epoch_insert ();
-
+$$;

--- a/files/grest/rpc/01_cached_tables/epoch_info_cache.sql
+++ b/files/grest/rpc/01_cached_tables/epoch_info_cache.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS grest.epoch_info_cache (
-  epoch uinteger PRIMARY KEY NOT NULL,
+  epoch_no uinteger PRIMARY KEY NOT NULL,
   i_out_sum word128type NOT NULL,
   i_fees lovelace NOT NULL,
   i_tx_count uinteger NOT NULL,
@@ -114,7 +114,7 @@ BEGIN
 
   INSERT INTO grest.epoch_info_cache
     SELECT DISTINCT ON (b.time)
-      e.no AS epoch,
+      e.no AS epoch_no,
       e.out_sum AS i_out_sum,
       e.fees AS i_fees,
       e.tx_count AS i_tx_count,
@@ -195,6 +195,6 @@ BEGIN
       e.no = _epoch_no_to_update
   ) update_table
   WHERE
-    epoch = _epoch_no_to_update;
+    epoch_no = _epoch_no_to_update;
 END;
 $$;

--- a/files/grest/rpc/epoch/epoch_info.sql
+++ b/files/grest/rpc/epoch/epoch_info.sql
@@ -2,7 +2,7 @@ DROP FUNCTION IF EXISTS grest.epoch_info (numeric);
 
 CREATE FUNCTION grest.epoch_info (_epoch_no numeric DEFAULT NULL)
   RETURNS TABLE (
-    epoch uinteger,
+    epoch_no uinteger,
     out_sum word128type,
     fees lovelace,
     tx_count uinteger,
@@ -16,7 +16,7 @@ BEGIN
   IF _epoch_no IS NULL THEN
     RETURN QUERY
     SELECT
-      ei.epoch,
+      ei.epoch_no,
       ei.i_out_sum AS tx_output_sum,
       ei.i_fees AS tx_fees_sum,
       ei.i_tx_count AS tx_count,
@@ -32,7 +32,7 @@ BEGIN
   ELSE
     RETURN QUERY
     SELECT
-      ei.epoch,
+      ei.epoch_no,
       ei.i_out_sum AS tx_output_sum,
       ei.i_fees AS tx_fees_sum,
       ei.i_tx_count AS tx_count,

--- a/files/grest/rpc/epoch/epoch_params.sql
+++ b/files/grest/rpc/epoch/epoch_params.sql
@@ -2,6 +2,7 @@ DROP FUNCTION IF EXISTS grest.epoch_params (numeric);
 
 CREATE FUNCTION grest.epoch_params (_epoch_no numeric DEFAULT NULL)
   RETURNS TABLE (
+    epoch_no uinteger,
     min_fee_a uinteger,
     min_fee_b uinteger,
     max_block_size uinteger,
@@ -39,6 +40,7 @@ BEGIN
   IF _epoch_no IS NULL THEN
     RETURN QUERY
     SELECT
+      ei.epoch_no,
       ei.p_min_fee_a AS min_fee_a,
       ei.p_min_fee_b AS min_fee_b,
       ei.p_max_block_size AS max_block_size,
@@ -77,6 +79,7 @@ BEGIN
   ELSE
     RETURN QUERY
     SELECT
+      ei.epoch_no,
       ei.p_min_fee_a AS min_fee_a,
       ei.p_min_fee_b AS min_fee_b,
       ei.p_max_block_size AS max_block_size,

--- a/scripts/grest-helper-scripts/setup-grest.sh
+++ b/scripts/grest-helper-scripts/setup-grest.sh
@@ -139,6 +139,10 @@
     set_cron_variables "pool-history-cache-update"
     install_cron_job "pool-history-cache-update" "*/10 * * * *"
 
+    get_cron_job_executable "epoch-info-cache-update"
+    set_cron_variables "epoch-info-cache-update"
+    install_cron_job "epoch-info-cache-update" "*/15 * * * *"
+
     # Only testnet and mainnet asset registries supported
     # Possible future addition for the Guild network once there is a guild registry
     if [[ ${NWMAGIC} -eq 764824073 || ${NWMAGIC} -eq 1097911063 ]]; then


### PR DESCRIPTION
Moving cache setup to cron to avoid impact on db-sync with postgres triggers. Job set to run every 15 mins ATM.

Includes alignment of nomenclature for `epoch` -> `epoch_no`.

Logs from guild network (all cron invocations):
1) initial population
```
2021-12-28_11:22:01 Running epoch info cache update...
NOTICE:  Epoch info cache table is empty, starting initial population...
NOTICE:  Deleting cache records from epoch 0 onwards...
2021-12-28_11:22:01 Job done!
```

2) in-epoch updates (last block time, total fees etc)
```
2021-12-28_11:23:01 Running epoch info cache update...
NOTICE:  Latest epoch in cache: 445, current epoch: 445.
NOTICE:  Updating latest epoch info in cache...
2021-12-28_11:23:01 Job done!

2021-12-28_11:24:01 Running epoch info cache update...
NOTICE:  Latest epoch in cache: 445, current epoch: 445.
NOTICE:  Updating latest epoch info in cache...
2021-12-28_11:24:01 Job done!
...
```

3) New epoch transition
```
2021-12-28_11:57:01 Running epoch info cache update...
NOTICE:  Latest epoch in cache: 445, current epoch: 446.
NOTICE:  Updating cache with new epoch(s) data...
NOTICE:  Deleting cache records from epoch 446 onwards...
2021-12-28_11:57:02 Job done!

2021-12-28_11:58:01 Running epoch info cache update...
NOTICE:  Latest epoch in cache: 446, current epoch: 446.
NOTICE:  Updating latest epoch info in cache...
2021-12-28_11:58:01 Job done!
```