### PR TITLE
Minor patches

### DIFF
--- a/docs/Build/node-cli.md
+++ b/docs/Build/node-cli.md
@@ -31,15 +31,15 @@ The above would copy the binaries built into `~/.cabal/bin` folder.
 
 ### Verify
 
-Execute `cardano-cli` and `cardano-node` to verify output as below:
+Execute `cardano-cli` and `cardano-node` to verify output as below (the exact version and git rev should depend on your checkout tag on github repository):
 
 ```bash
 cardano-cli version
-# cardano-cli 1.30.1 - linux-x86_64 - ghc-8.10
-# git rev 0fb43f4e3da8b225f4f86557aed90a183981a64f
+# cardano-cli 1.32.1 - linux-x86_64 - ghc-8.10
+# git rev 4f65fb9a27aa7e3a1873ab4211e412af780a3648
 cardano-node version
-# cardano-node 1.30.1 - linux-x86_64 - ghc-8.10
-# git rev 0fb43f4e3da8b225f4f86557aed90a183981a64f
+# cardano-node 1.32.1 - linux-x86_64 - ghc-8.10
+# git rev 4f65fb9a27aa7e3a1873ab4211e412af780a3648
 ```
 
 #### Update port number or pool name for relative paths

--- a/files/grest/apispec/koiosapi.yaml
+++ b/files/grest/apispec/koiosapi.yaml
@@ -66,6 +66,7 @@ info:
 servers:
   - url: https://api.koios.rest/api/v0
   - url: https://guild.koios.rest/api/v0
+  - url: https://testnet.koios.rest/api/v0
 paths:
   /tip: #RPC
     get:

--- a/scripts/cnode-helper-scripts/cabal-build-all.sh
+++ b/scripts/cnode-helper-scripts/cabal-build-all.sh
@@ -8,6 +8,9 @@
 [[ "$1" == "-l" ]] && USE_SYSTEM_LIBSODIUM="package cardano-crypto-praos
   flags: -external-libsodium-vrf"
 
+echo "Deleting build config artifact to remove cached version, this prevents invalid Git Rev"
+find dist-newstyle/build/x86_64-linux/ghc-8.10.?/cardano-config-* >/dev/null 2>&1 && rm -rf "dist-newstyle/build/x86_64-linux/ghc-8.*/cardano-config-*"
+
 if [[ "${PWD##*/}" == "cardano-node" ]] || [[ "${PWD##*/}" == "cardano-db-sync" ]]; then
   echo "Overwriting cabal.project.local to include cardano-addresses and bech32 (previous file, if any, will be saved as cabal.project.local.swp).."
   [[ -f cabal.project.local ]] && mv cabal.project.local cabal.project.local.swp

--- a/scripts/cnode-helper-scripts/prereqs.sh
+++ b/scripts/cnode-helper-scripts/prereqs.sh
@@ -237,7 +237,7 @@ if [ "$WANT_BUILD_DEPS" = 'Y' ]; then
     err_exit
   fi
   export BOOTSTRAP_HASKELL_NO_UPGRADE=1
-  export BOOTSTRAP_HASKELL_GHC_VERSION=8.10.4
+  export BOOTSTRAP_HASKELL_GHC_VERSION=8.10.7
   export BOOTSTRAP_HASKELL_CABAL_VERSION=3.4.0.0
   if ! command -v ghc &>/dev/null; then
     echo "Install ghcup (The Haskell Toolchain installer) .."

--- a/scripts/grest-helper-scripts/grest-poll.sh
+++ b/scripts/grest-helper-scripts/grest-poll.sh
@@ -159,8 +159,9 @@ function chk_limit() {
 function chk_endpt_get() {
   local endpt=${1}
   [[ "${2}" != "rpc" ]] && urlendpt="${URL}/${endpt}" || urlendpt="${URLRPC}/${endpt}"
-  getrslt=$(curl -skL "${urlendpt}" -H "Range: 0-1" 2>/dev/null)
+  getrslt=$(curl -sfkL "${urlendpt}" -H "Range: 0-1" 2>/dev/null)
   if [[ -z "${getrslt}" ]] || [[ "${getrslt}" == "[]" ]]; then
+    [[ "${DEBUG_MODE}" == "1" ]] && echo "Response received for ${urlendpt} : $(curl -skL "${urlendpt}" -H "Range: 0-1" -I)"
     echo "ERROR: Could not fetch from endpoint ${urlendpt} !!"
     optexit
   fi
@@ -196,4 +197,5 @@ chk_endpt_get "tx_metalabels" view
 chk_endpt_get "account_list" view
 chk_endpt_get "totals?_epoch_no=${epoch}" rpc
 chk_endpt_get "epoch_params?_epoch_no=${epoch}" rpc
+chk_endpt_get "epoch_info?_epoch_no=${epoch}" rpc
 chk_endpt_get "pool_list" rpc

--- a/scripts/grest-helper-scripts/setup-grest.sh
+++ b/scripts/grest-helper-scripts/setup-grest.sh
@@ -404,7 +404,7 @@
 			  #bind :8453 ssl crt /etc/ssl/server.pem no-sslv3
 			  http-request use-service prometheus-exporter if { path /metrics }
 			  http-request track-sc0 src table flood_lmt_rate
-			  http-request deny deny_status 429 if { sc_http_req_rate(0) gt 50 }
+			  http-request deny deny_status 429 if { sc_http_req_rate(0) gt 250 }
 			  default_backend grest_core
 			
 			backend grest_core


### PR DESCRIPTION
  - Update GHC version to 8.10.7 (as per upstream changes for node)
  - Update cabal-build-all.sh to add back removal of cardano-config folder, as some components still show old git revision
  - Add epoch_info to grest-poll tests
  - Add Testnet instance URL to API spec
  - For polling GET requests, fail if curl response is invalid, and print response code if DEBUG flag is enabled
  - Bump individual instance flood limit (gateway will still have them), avoids individual instances to know about/configure whitelisted nodes