### PR TITLE
Add Submit-API and Ogmios to GRest

### DIFF
--- a/docs/Build/node-cli.md
+++ b/docs/Build/node-cli.md
@@ -74,9 +74,20 @@ cd $CNODE_HOME/scripts
 
 Stop the node by hitting Ctrl-C.
 
+#### Start the submit-api
+
+`cardano-submit-api` is one of the binaries built as part of `cardano-node` repository and allows you to submit transactions over a Web API. To run this service interactively, you can use the pre-built script below (`submitapi.sh`). Make sure to update `submitapi.sh` script to change listen IP or Port that you'd want to make this service available on.
+
+```bash
+cd $CNODE_HOME/scripts
+./submitapi.sh
+```
+
+To stop the process, hit Ctrl-C
+
 #### Run as systemd service {: id="systemd"}
 
-The preferred way to run the node is through a service manager like systemd. This section explains how to setup a systemd service file.
+The preferred way to run the node (and submit-api) is through a service manager like systemd. This section explains how to setup a systemd service file.
 
 **1. Deploy as a systemd service**  
 Execute the below command to deploy your node as a systemd service (from the respective scripts folder):
@@ -85,18 +96,25 @@ cd $CNODE_HOME/scripts
 ./cnode.sh -d
 # Deploying cnode.service as systemd service..
 # cnode.service deployed successfully!!
+
+./submitapi.sh -d
+# Deploying cnode-submit-api.service as systemd service..
+# cnode-submit-api deployed successfully!!
+
 ```
 
-**2. Start the node**  
+**2. Start the service**  
 Run below commands to enable automatic start of service on startup and start it.
 ``` bash
 sudo systemctl start cnode.service
+sudo systemctl start cnode-submit-api.service
 ```
 
 **3. Check status and stop/start commands** 
 Replace `status` with `stop`/`start`/`restart` depending on what action to take.
 ``` bash
 sudo systemctl status cnode.service
+sudo systemctl status cnode-submit-api.service
 ```
 
 !!! important

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -33,7 +33,7 @@ chmod 755 prereqs.sh
 Please familiarise with the syntax of `prereqs.sh` before proceeding. The usage syntax can be checked using `./prereqs.sh -h` , sample output below:
 
 ``` bash
-Usage: prereqs.sh [-f] [-s] [-i] [-l] [-c] [-w] [-b <branch>] [-n <mainnet|testnet|guild|staging>] [-t <name>] [-m <seconds>]
+Usage: prereqs.sh [-f] [-s] [-i] [-l] [-c] [-w] [-o] [-b <branch>] [-n <mainnet|testnet|guild|staging>] [-t <name>] [-m <seconds>]
 Install pre-requisites for building cardano-node and using CNTools
 
 -f    Force overwrite of all files including normally saved user config sections in env, cnode.sh and gLiveView.sh
@@ -46,6 +46,7 @@ Install pre-requisites for building cardano-node and using CNTools
 -l    Use system libsodium instead of IOG fork (Default: use libsodium from IOG fork)
 -c    Install/Upgrade and build CNCLI with RUST
 -w    Install/Upgrade Vacuumlabs cardano-hw-cli for hardware wallet support
+-o    Install/Upgrade Ogmios Server binary
 -b    Use alternate branch of scripts to download - only recommended for testing/development (Default: master)
 -i    Interactive mode (Default: silent mode)
 ```

--- a/docs/build.md
+++ b/docs/build.md
@@ -11,26 +11,30 @@ graph TB
   C(Manage pool-ops, <br/> asset operation tasks <br/> easily?)
   D(Create Custom Assets?)
   E(Monitor node <br/> using Terminal UI)
-  O(Node)
+  N(Node)
   F(Manage Pool/Wallet Keys<br/>and tx signing<br/>offline)
+  O(Ogmios)
   P(gRest/Koios)
   Q(DBSync)
   R(Wallet)
   S(CNTools)
+  T(Tx Submit API)
   U(GraphQL)
   V(OfflineMetadataTools)
   X(gLiveView)
 
 F --x S
-O --x C --x S
-O --x D
+N --x C --x S
+N --x D
 D --x S
 D --x V
-O --x E --x X
-O --x B
+N --x E --x X
+N --x B
 B --x U --x Q
 B --x P --x Q
-O --x A --x R
+P --x O
+P --x T
+N --x A --x R
 ```
 
 !!! warning "Important"

--- a/files/config-guild-p2p.json
+++ b/files/config-guild-p2p.json
@@ -17,6 +17,8 @@
   "ShelleyGenesisFile": "/opt/cardano/cnode/files/shelley-genesis.json",
   "ShelleyGenesisHash": "6e32e475f05087edc92945a9fbebe8aa15fdb4333cbd3842737152967065fbf0",
   "EnableP2P": true,
+  "EnableLogging": true,
+  "EnableLogMetrics": false,
   "TargetNumberOfRootPeers": 5,
   "TargetNumberOfKnownPeers": 10,
   "TargetNumberOfEstablishedPeers": 10,

--- a/files/config-guild.json
+++ b/files/config-guild.json
@@ -13,6 +13,8 @@
   "PBftSignatureThreshold": 1,
   "ShelleyGenesisFile": "/opt/cardano/cnode/files/shelley-genesis.json",
   "ShelleyGenesisHash": "6e32e475f05087edc92945a9fbebe8aa15fdb4333cbd3842737152967065fbf0",
+  "EnableLogging": true,
+  "EnableLogMetrics": false,
   "TraceBlockFetchClient": true,
   "TraceBlockFetchDecisions": true,
   "TraceBlockFetchProtocol": false,

--- a/files/config-mainnet.json
+++ b/files/config-mainnet.json
@@ -10,6 +10,8 @@
   "Protocol": "Cardano",
   "RequiresNetworkMagic": "RequiresNoMagic",
   "ShelleyGenesisFile": "/opt/cardano/cnode/files/shelley-genesis.json",
+  "EnableLogging": true,
+  "EnableLogMetrics": false,
   "TraceBlockFetchClient": true,
   "TraceBlockFetchDecisions": true,
   "TraceBlockFetchProtocol": false,

--- a/files/config-staging.json
+++ b/files/config-staging.json
@@ -10,6 +10,8 @@
   "Protocol": "Cardano",
   "RequiresNetworkMagic": "RequiresNoMagic",
   "ShelleyGenesisFile": "/opt/cardano/cnode/files/shelley-genesis.json",
+  "EnableLogging": true,
+  "EnableLogMetrics": false,
   "TraceBlockFetchClient": true,
   "TraceBlockFetchDecisions": true,
   "TraceBlockFetchProtocol": false,

--- a/files/config-testnet.json
+++ b/files/config-testnet.json
@@ -10,6 +10,8 @@
   "Protocol": "Cardano",
   "RequiresNetworkMagic": "RequiresMagic",
   "ShelleyGenesisFile": "/opt/cardano/cnode/files/shelley-genesis.json",
+  "EnableLogging": true,
+  "EnableLogMetrics": false,
   "TraceBlockFetchClient": true,
   "TraceBlockFetchDecisions": true,
   "TraceBlockFetchProtocol": false,

--- a/files/grest/topology-guild.json
+++ b/files/grest/topology-guild.json
@@ -1,8 +1,8 @@
 {
   "Providers": [
-    {"name":"rdlrt","addr":"209.145.50.190","port":443,"ssl":true},
-    {"name":"ola","addr":"koios-guild.ahlnet.nu","port":2165,"ssl":true},
-    {"name":"damjan","addr":"195.201.129.190","port":8053},
+    {"name":"rdlrt","addr":"209.145.50.190","port":443,"ssl":"true"},
+    {"name":"ola","addr":"koios-guild.ahlnet.nu","port":2165,"ssl":"true"},
+    {"name":"damjan","addr":"95.216.160.145","port":8053},
     {"name":"homer","addr":"95.216.188.94","port":8053},
     {"name":"gufmar","addr":"185.161.193.105","port":6029}
   ],

--- a/files/grest/topology-mainnet.json
+++ b/files/grest/topology-mainnet.json
@@ -1,11 +1,12 @@
 {
   "Providers": [
       { "name": "damjan", "addr": "65.21.183.97", "port": 8053 },
-      { "name": "old-rdlrt", "addr": "207.244.252.116", "port": 8453, "ssl": true},
+      { "name": "old-rdlrt", "addr": "207.244.252.116", "port": 8453, "ssl": "true"},
       { "name": "rdlrt", "addr": "194.36.145.157", "port": 8053 },
       { "name": "markus", "addr": "185.161.193.32", "port": 8053},
       { "name": "homer-redoracle", "addr": "194.233.71.104", "port": 8053},
       { "name": "docker", "addr": "92.204.53.48", "port": 8053},
+      { "name": "rdlrt2", "addr": "194.36.145.157", "port": 8053}
   ],
   "Consumers": []
 }

--- a/files/grest/topology-mainnet.json
+++ b/files/grest/topology-mainnet.json
@@ -2,6 +2,7 @@
   "Providers": [
       { "name": "damjan", "addr": "65.21.183.97", "port": 8053 },
       { "name": "old-rdlrt", "addr": "207.244.252.116", "port": 8453, "ssl": true},
+      { "name": "rdlrt", "addr": "194.36.145.157", "port": 8053 },
       { "name": "markus", "addr": "185.161.193.32", "port": 8053},
       { "name": "homer-redoracle", "addr": "194.233.71.104", "port": 8053},
       { "name": "docker", "addr": "92.204.53.48", "port": 8053},

--- a/files/grest/topology-testnet.json
+++ b/files/grest/topology-testnet.json
@@ -1,6 +1,6 @@
 {
   "Providers": [
-    {"name":"ola","addr":"koios-testnet.ahlnet.nu","port":2153},
+    {"name":"olassl","addr":"koios-testnet.ahlnet.nu","port":2155,"ssl":"true"},
     {"name":"damjan","addr":"195.201.129.190","port":7053},
     {"name":"homer","addr":"95.216.173.194","port":8053}
   ],

--- a/files/grest/topology-testnet.json
+++ b/files/grest/topology-testnet.json
@@ -1,7 +1,7 @@
 {
   "Providers": [
     {"name":"olassl","addr":"koios-testnet.ahlnet.nu","port":2155,"ssl":"true"},
-    {"name":"damjan","addr":"195.201.129.190","port":7053},
+    {"name":"damjan","addr":"195.201.129.190","port":8053},
     {"name":"homer","addr":"95.216.173.194","port":8053}
   ],
   "Consumers": []

--- a/scripts/cnode-helper-scripts/cabal-build-all.sh
+++ b/scripts/cnode-helper-scripts/cabal-build-all.sh
@@ -41,7 +41,7 @@ cabal update 2>&1 | tee /tmp/cabal-build.log
 echo "Building.."
 cabal build all 2>&1 | tee /tmp/build.log
 
-grep "^Linking" /tmp/build.log | grep -Ev 'test|golden|demo' | while read -r line ; do
+grep "^Linking" /tmp/build.log | grep -Ev 'test|golden|demo|chairman|locli|ledger|topology' | while read -r line ; do
     act_bin_path=$(echo "$line" | awk '{print $2}')
     act_bin=$(echo "$act_bin_path" | awk -F "/" '{print $NF}')
     echo "Copying $act_bin to $HOME/.cabal/bin/"

--- a/scripts/cnode-helper-scripts/deploy-as-systemd.sh
+++ b/scripts/cnode-helper-scripts/deploy-as-systemd.sh
@@ -30,6 +30,13 @@ echo "launches the main submitapi.sh script to deploy cardano-submit-api as serv
 echo
 ./submitapi.sh -d
 
+if command -v ogmios >/dev/null 2>&1 ; then
+  echo -e "\e32m~~ Cardano Ogmios Server ~~\e[0m"
+  echo "launches the ogmios.sh script to deploy ogmios"
+  echo
+  ./ogmios.sh -d
+fi
+
 echo
 echo -e "\e[32m~~ Topology Updater ~~\e[0m"
 echo "An intermediate centralized solution for relay nodes to handle the static topology files until P2P network module is implemented on protocol level."

--- a/scripts/cnode-helper-scripts/deploy-as-systemd.sh
+++ b/scripts/cnode-helper-scripts/deploy-as-systemd.sh
@@ -14,16 +14,21 @@ fi
 . "${PARENT}"/env offline
 
 echo -e "\e[32m~~ Cardano Node ~~\e[0m"
-echo "launches the main cnode.sh script to start cardano-node"
+echo "launches the main cnode.sh script to deploy cardano-node"
 echo
 ./cnode.sh -d
 
 if grep -q "^PGPASSFILE=" "${CNODE_HOME}/scripts/dbsync.sh" 2> /dev/null || [[ -f "${CNODE_HOME}/priv/.pgpass" ]]; then
   echo -e "\e[32m~~ Cardano DB Sync ~~\e[0m"
-  echo "launches the dbsync.sh script to start cardano-db-sync"
+  echo "launches the dbsync.sh script to deploy cardano-db-sync"
   echo
   ./dbsync.sh -d
 fi
+
+echo -e "\e[32m~~ Cardano Submit API ~~\e[0m"
+echo "launches the main submitapi.sh script to deploy cardano-submit-api as service"
+echo
+./submitapi.sh -d
 
 echo
 echo -e "\e[32m~~ Topology Updater ~~\e[0m"

--- a/scripts/cnode-helper-scripts/prereqs.sh
+++ b/scripts/cnode-helper-scripts/prereqs.sh
@@ -17,6 +17,7 @@ unset CNODE_HOME
 #LIBSODIUM_FORK='Y'     # Use IOG fork of libsodium instead of official repositories - Recommended as per IOG instructions (Default: IOG fork)
 #INSTALL_CNCLI='N'      # Install/Upgrade and build CNCLI with RUST
 #INSTALL_VCHC='N'       # Install/Upgrade Vacuumlabs cardano-hw-cli for hardware wallet support
+#INSTALL_OGMIOS='N'     # Install Ogmios Server
 #CNODE_NAME='cnode'     # Alternate name for top level folder, non alpha-numeric chars will be replaced with underscore (Default: cnode)
 #CURL_TIMEOUT=60        # Maximum time in seconds that you allow the file download operation to take before aborting (Default: 60s)
 #UPDATE_CHECK='Y'       # Check if there is an updated version of prereqs.sh script to download
@@ -58,7 +59,7 @@ versionCheck() { printf '%s\n%s' "${1//v/}" "${2//v/}" | sort -C -V; } #$1=avail
 usage() {
   cat <<EOF >&2
 
-Usage: $(basename "$0") [-f] [-s] [-i] [-l] [-c] [-w] [-p] [-b <branch>] [-n <mainnet|testnet|guild|staging>] [-t <name>] [-m <seconds>]
+Usage: $(basename "$0") [-f] [-s] [-i] [-l] [-c] [-w] [-o] [-b <branch>] [-n <mainnet|testnet|guild|staging>] [-t <name>] [-m <seconds>]
 Install pre-requisites for building cardano node and using CNTools
 
 -f    Force overwrite of all files including normally saved user config sections in env, cnode.sh and gLiveView.sh
@@ -71,6 +72,7 @@ Install pre-requisites for building cardano node and using CNTools
 -l    Use system libsodium instead of IOG fork (Default: use libsodium from IOG fork)
 -c    Install/Upgrade and build CNCLI with RUST
 -w    Install/Upgrade Vacuumlabs cardano-hw-cli for hardware wallet support
+-o    Install/Upgrade Ogmios Server binary
 -b    Use alternate branch of scripts to download - only recommended for testing/development (Default: master)
 -i    Interactive mode (Default: silent mode)
 
@@ -78,7 +80,7 @@ EOF
   exit 1
 }
 
-while getopts :in:sflcwt:m:b: opt; do
+while getopts :in:sflcwot:m:b: opt; do
   case ${opt} in
     i ) INTERACTIVE='Y' ;;
     n ) NETWORK=${OPTARG} ;;
@@ -87,6 +89,7 @@ while getopts :in:sflcwt:m:b: opt; do
     l ) LIBSODIUM_FORK='N' ;;
     c ) INSTALL_CNCLI='Y' ;;
     w ) INSTALL_VCHC='Y' ;;
+    o ) INSTALL_OGMIOS='Y' ;;
     t ) CNODE_NAME=${OPTARG//[^[:alnum:]]/_} ;;
     m ) CURL_TIMEOUT=${OPTARG} ;;
     b ) BRANCH=${OPTARG} ;;
@@ -102,6 +105,7 @@ shift $((OPTIND -1))
 [[ -z ${LIBSODIUM_FORK} ]] && LIBSODIUM_FORK='Y'
 [[ -z ${INSTALL_CNCLI} ]] && INSTALL_CNCLI='N'
 [[ -z ${INSTALL_VCHC} ]] && INSTALL_VCHC='N'
+[[ -z ${INSTALL_OGMIOS} ]] && INSTALL_OGMIOS='N'
 [[ -z ${CNODE_NAME} ]] && CNODE_NAME='cnode'
 [[ -z ${INTERACTIVE} ]] && INTERACTIVE='N'
 [[ -z ${CURL_TIMEOUT} ]] && CURL_TIMEOUT=60
@@ -383,6 +387,30 @@ if [[ "${INSTALL_VCHC}" = "Y" ]]; then
   fi
 fi
 
+if [[ "${INSTALL_OGMIOS}" = "Y" ]]; then
+  echo "Installing Ogmios"
+  if command -v ogmios >/dev/null; then ogmios_version="$(ogmios --version)"; else ogmios_version="v0.0.0"; fi
+  rm -rf /tmp/ogmios && mkdir /tmp/ogmios
+  pushd /tmp/ogmios >/dev/null || err_exit
+  ogmios_asset_url=$(curl -s https://github.com/CardanoSolutions/ogmios/releases/latest | jq -r '.assets[].browser_download_url')
+  if curl -sL -f -m ${CURL_TIMEOUT} -o ogmios.zip ${ogmios_asset_url}; then
+    unzip ogmios.zip &>/dev/null
+    rm -f ogmios.zip
+    [[ -f bin/ogmios ]] || err_exit "ogmios downloaded but binary not found after extracting package!"
+    ogmios_git_version="$(ogmios --version)"
+    if ! versionCheck "${ogmios_git_version}" "${ogmios_version}"; then
+      [[ "${ogmios_version}" = "0.0.0" ]] && echo "  latest version: ${ogmios_git_version}" || echo "  installed version: ${ogmios_version} | latest version: ${ogmios_git_version}"
+      mv -f /tmp/ogmios/bin/ogmios "${HOME}"/.cabal/bin/
+      echo "  ogmios ${ogmios_git_version} installed!"
+    else
+      rm -rf /tmp/ogmios #cleanup in /tmp
+      echo "  ogmios already latest version [${ogmios_version}], skipping!"
+    fi
+  else
+    err_exit "Download of latest release of ogmios archive from GitHub failed! Please retry or manually install it."
+  fi
+fi
+
 $sudo mkdir -p "${CNODE_HOME}"/files "${CNODE_HOME}"/db "${CNODE_HOME}"/guild-db "${CNODE_HOME}"/logs "${CNODE_HOME}"/scripts "${CNODE_HOME}"/sockets "${CNODE_HOME}"/priv
 $sudo chown -R "$U_ID":"$G_ID" "${CNODE_HOME}" 2>/dev/null
 
@@ -443,6 +471,7 @@ curl -s -f -m ${CURL_TIMEOUT} -o setup-grest.sh ${URL_RAW}/scripts/grest-helper-
 curl -s -f -m ${CURL_TIMEOUT} -o topologyUpdater.sh.tmp ${URL_RAW}/scripts/cnode-helper-scripts/topologyUpdater.sh
 curl -s -f -m ${CURL_TIMEOUT} -o cabal-build-all.sh ${URL_RAW}/scripts/cnode-helper-scripts/cabal-build-all.sh
 curl -s -f -m ${CURL_TIMEOUT} -o submitapi.sh.tmp ${URL_RAW}/scripts/cnode-helper-scripts/submitapi.sh
+curl -s -f -m ${CURL_TIMEOUT} -o ogmios.sh.tmp ${URL_RAW}/scripts/cnode-helper-scripts/ogmios.sh
 curl -s -f -m ${CURL_TIMEOUT} -o system-info.sh ${URL_RAW}/scripts/cnode-helper-scripts/system-info.sh
 curl -s -f -m ${CURL_TIMEOUT} -o sLiveView.sh ${URL_RAW}/scripts/cnode-helper-scripts/sLiveView.sh
 curl -s -f -m ${CURL_TIMEOUT} -o gLiveView.sh.tmp ${URL_RAW}/scripts/cnode-helper-scripts/gLiveView.sh
@@ -476,12 +505,13 @@ updateWithCustomConfig() {
   mv -f ${file}.tmp ${file}
 }
 
-[[ ${FORCE_OVERWRITE} = 'Y' ]] && echo "Forced full upgrade! Please edit scripts/env, scripts/cnode.sh, scripts/dbsync.sh, scripts/submitapi.sh, scripts/gLiveView.sh and scripts/topologyUpdater.sh (alongwith files/topology.json, files/config.json, files/dbsync.json) as required/"
+[[ ${FORCE_OVERWRITE} = 'Y' ]] && echo "Forced full upgrade! Please edit scripts/env, scripts/cnode.sh, scripts/dbsync.sh, scripts/submitapi.sh, scripts/ogmios.sh, scripts/gLiveView.sh and scripts/topologyUpdater.sh (alongwith files/topology.json, files/config.json, files/dbsync.json) as required/"
 
 updateWithCustomConfig "env"
 updateWithCustomConfig "cnode.sh"
 updateWithCustomConfig "dbsync.sh"
-updateWithCustomConfig "submiapi.sh"
+updateWithCustomConfig "submitapi.sh"
+updateWithCustomConfig "ogmios.sh"
 updateWithCustomConfig "gLiveView.sh"
 updateWithCustomConfig "topologyUpdater.sh"
 updateWithCustomConfig "logMonitor.sh"

--- a/scripts/cnode-helper-scripts/prereqs.sh
+++ b/scripts/cnode-helper-scripts/prereqs.sh
@@ -442,6 +442,7 @@ curl -s -f -m ${CURL_TIMEOUT} -o setup_mon.sh ${URL_RAW}/scripts/cnode-helper-sc
 curl -s -f -m ${CURL_TIMEOUT} -o setup-grest.sh ${URL_RAW}/scripts/grest-helper-scripts/setup-grest.sh
 curl -s -f -m ${CURL_TIMEOUT} -o topologyUpdater.sh.tmp ${URL_RAW}/scripts/cnode-helper-scripts/topologyUpdater.sh
 curl -s -f -m ${CURL_TIMEOUT} -o cabal-build-all.sh ${URL_RAW}/scripts/cnode-helper-scripts/cabal-build-all.sh
+curl -s -f -m ${CURL_TIMEOUT} -o submitapi.sh.tmp ${URL_RAW}/scripts/cnode-helper-scripts/submitapi.sh
 curl -s -f -m ${CURL_TIMEOUT} -o system-info.sh ${URL_RAW}/scripts/cnode-helper-scripts/system-info.sh
 curl -s -f -m ${CURL_TIMEOUT} -o sLiveView.sh ${URL_RAW}/scripts/cnode-helper-scripts/sLiveView.sh
 curl -s -f -m ${CURL_TIMEOUT} -o gLiveView.sh.tmp ${URL_RAW}/scripts/cnode-helper-scripts/gLiveView.sh
@@ -475,11 +476,12 @@ updateWithCustomConfig() {
   mv -f ${file}.tmp ${file}
 }
 
-[[ ${FORCE_OVERWRITE} = 'Y' ]] && echo "Forced full upgrade! Please edit scripts/env, scripts/cnode.sh, scripts/dbsync.sh, scripts/gLiveView.sh and scripts/topologyUpdater.sh (alongwith files/topology.json, files/config.json, files/dbsync.json) as required/"
+[[ ${FORCE_OVERWRITE} = 'Y' ]] && echo "Forced full upgrade! Please edit scripts/env, scripts/cnode.sh, scripts/dbsync.sh, scripts/submitapi.sh, scripts/gLiveView.sh and scripts/topologyUpdater.sh (alongwith files/topology.json, files/config.json, files/dbsync.json) as required/"
 
 updateWithCustomConfig "env"
 updateWithCustomConfig "cnode.sh"
 updateWithCustomConfig "dbsync.sh"
+updateWithCustomConfig "submiapi.sh"
 updateWithCustomConfig "gLiveView.sh"
 updateWithCustomConfig "topologyUpdater.sh"
 updateWithCustomConfig "logMonitor.sh"

--- a/scripts/cnode-helper-scripts/submitapi.sh
+++ b/scripts/cnode-helper-scripts/submitapi.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2086
+#shellcheck source=/dev/null
+
+. "$(dirname $0)"/env offline
+
+######################################
+# User Variables - Change as desired #
+# Common variables set in env file   #
+######################################
+
+#SUBMITAPIBIN="${HOME}"/.cabal/bin/cardano-submit-api # Path for cardano-submit-api binary, if not in $PATH
+#HOSTADDR=127.0.0.1                                 # Default Listen IP/Hostname for Submit API
+#HOSTPORT=8090                                      # Default Listen port for Submit API
+
+######################################
+# Do NOT modify code below           #
+######################################
+
+#####################
+# Functions         #
+#####################
+
+usage() {
+  cat <<-EOF
+		
+		Usage: $(basename "$0") [-d]
+		
+		Cardano Submit API wrapper script !!
+		-d    Deploy cardano-submit-api as a systemd service
+		
+		EOF
+  exit 1
+}
+
+set_defaults() {
+  [[ -z "${SUBMITAPIBIN}" ]] && SUBMITAPIBIN="${HOME}"/.cabal/bin/cardano-submit-api
+  [[ -z "${HOSTADDR}" ]] && HOSTADDR=127.0.0.1
+  [[ -z "${HOSTPORT}" ]] && HOSTPORT=8090
+}
+
+pre_startup_sanity() {
+  [[ ! -f "${SUBMITAPIBIN}" ]] && SUBMITAPIBIN=$(command -v cardano-submit-api)
+  if [[ ! -S "${CARDANO_NODE_SOCKET_PATH}" ]]; then
+    echo "ERROR: Could not locate socket file at ${CARDANO_NODE_SOCKET_PATH}, the node may not have completed startup !!"
+    exit 1
+  fi
+}
+
+deploy_systemd() {
+  echo "Deploying ${CNODE_VNAME}-submit-api as systemd service.."
+  sudo bash -c "cat <<-'EOF' > /etc/systemd/system/${CNODE_VNAME}-submit-api.service
+	[Unit]
+	Description=Cardano Node Submit API
+	Wants=network-online.target
+	After=network-online.target
+	
+	[Service]
+	Type=simple
+	Restart=always
+	RestartSec=5
+	User=${USER}
+	LimitNOFILE=1048576
+	WorkingDirectory=${CNODE_HOME}/scripts
+	ExecStart=/bin/bash -l -c \"exec ${CNODE_HOME}/scripts/submitapi.sh\"
+	KillSignal=SIGINT
+	SuccessExitStatus=143
+	StandardOutput=syslog
+	StandardError=syslog
+	SyslogIdentifier=${CNODE_VNAME}-submit-api
+	TimeoutStopSec=5
+	KillMode=mixed
+	
+	[Install]
+	WantedBy=multi-user.target
+	EOF" && echo "${CNODE_VNAME}-submit-api.service deployed successfully!!" && sudo systemctl daemon-reload && sudo systemctl enable ${CNODE_VNAME}-submit-api.service
+}
+
+###################
+# Execution       #
+###################
+
+# Parse command line options
+while getopts :d opt; do
+  case ${opt} in
+    d ) DEPLOY_SYSTEMD="Y" ;;
+    \? ) usage ;;
+  esac
+done
+
+# Check if env file is missing in current folder (no update checks as will mostly run as daemon), source env if present
+[[ ! -f "$(dirname $0)"/env ]] && echo -e "\nCommon env file missing, please ensure latest prereqs.sh was run and this script is being run from ${CNODE_HOME}/scripts folder! \n" && exit 1
+. "$(dirname $0)"/env offline
+case $? in
+  1) echo -e "ERROR: Failed to load common env file\nPlease verify set values in 'User Variables' section in env file or log an issue on GitHub" && exit 1;;
+  2) clear ;;
+esac
+
+# Set defaults and do basic sanity checks
+set_defaults
+#Deploy systemd if -d argument was specified
+if [[ "${DEPLOY_SYSTEMD}" == "Y" ]]; then
+  deploy_systemd && exit 0
+  exit 2
+fi
+pre_startup_sanity
+
+# Run Submit API
+"${SUBMITAPIBIN}" --config "${CONFIG}" --testnet-magic ${NWMAGIC} --socket-path "${CARDANO_NODE_SOCKET_PATH}" --listen-address ${HOSTADDR} --port ${HOSTPORT}

--- a/scripts/grest-helper-scripts/checkstatus.sh
+++ b/scripts/grest-helper-scripts/checkstatus.sh
@@ -11,4 +11,4 @@
 # Do NOT modify code below           #
 ######################################
 
-watch 'echo "show stat" | nc -U '"$(dirname "$0")"'/../sockets/haproxy.socket | grep -e svname -e ^grest | cut -d, -f 2,18,20,74 | tr "," " " | column -t'
+watch 'echo "show stat" | nc -U '"$(dirname "$0")"'/../sockets/haproxy.socket | grep -e svname -e ^grest -e ^ogmios -e ^submitapi | sed -e '"'"'s#no check#NoCheck#'"'"' | cut -d, -f 1,2,18,19,20,74 | tr "," " " | column -t'


### PR DESCRIPTION
HAProxy:
- [x] Add submit-api backend
- [x] Add ogmios backend (requires seperate frontend for failover on monitoring instances only at 7443 port)
- [x] Add ACL to redirect to submitapi and ogmios backends

Configs:
- [x] Add `EnableLogging` and `EnableLogMetrics` keywords to node configs to be able to reuse same config for submit-api.

CheckStatus script:
- [x] Add a column for the component (backend/frontend name), and include ogmios/submitapi backends to result

Scripts:
- [x] Create new script for submitapi.sh using node template (to allow to deploy as systemd)
- [x] Create new script for ogmios using node template (to allow to deploy as systemd)
- [x] Append the above scripts to deploy-as-systemd.sh

Docs:
- [x] Update node-cli documentation page to start submit-api
- [x] Add section for ogmios compilation and startup