### PR TITLE
[RPC] accept list of IDs for pool_info

### DIFF
--- a/files/grest/apispec/koiosapi.yaml
+++ b/files/grest/apispec/koiosapi.yaml
@@ -1300,6 +1300,56 @@ components:
             type: integer
             description: Slot after which transaction cannot be validated
             example: 42332172
+          collaterals:
+            type: array
+            description: An array collateral inputs needed when dealing with smart contracts
+            items:
+              type: object
+              properties:
+                payment_addr:
+                  type: object
+                  properties:
+                    bech32:
+                      type: string
+                      description: A Cardano payment/base address (bech32 encoded) for transaction's input UTxO
+                      example: addr1qxkfe8s6m8qt5436lec3f0320hrmpppwqgs2gah4360krvyssntpwjcz303mx3h4avg7p29l3zd8u3jyglmewds9ezrqdc3cxp
+                    cred:
+                      type: string
+                      description: Payment credential
+                      example: ac9c9e1ad9c0ba563afe7114be2a7dc7b0842e0220a476f58e9f61b0
+                stake_addr:
+                  type: string
+                  description: A Cardano staking address (reward account, bech32 encoded) for transaction's input UTxO
+                  example: stake1uxggf4shfvpghcangm67ky0q4zlc3xn7gezy0auhxczu3pslm9wrj
+                tx_hash:
+                  type: string
+                  description: Hash of Transaction for input UTxO
+                  example: f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
+                tx_index:
+                  type: integer
+                  description: Index of input UTxO on the mentioned address used for input
+                  example: 0
+                value:
+                  type: string
+                  description: Balance on the selected input transaction
+                  example: 158005617
+                asset_list:
+                  type: array
+                  description: An array of assets contained on input UTxO
+                  items:
+                    properties:
+                      policy_id:
+                        type: string
+                        description: Asset Policy ID (hex)
+                        example: 6cf6b5cf0fefbe9e69d640d8be84912bb2c9e132671954548790bcfb
+                      asset_name:
+                        type: string
+                        description: Asset Name (hex)
+                        example: 6d65736d6572697a65723038353436
+                      quantity:
+                        type: string
+                        description: Asset balance on the selected input transaction
+                        example: 1
           inputs:
             type: array
             description: An array with details about inputs used in a transaction

--- a/files/grest/apispec/koiosapi.yaml
+++ b/files/grest/apispec/koiosapi.yaml
@@ -583,20 +583,24 @@ paths:
       summary: Pool List
       description: A list of all currently registered/retiring (not retired) pools
   /pool_info: #RPC
-    get:
+    post:
       tags:
         - Pool
-      parameters:
-        - $ref: "#/components/parameters/_pool_bech32"
+      requestBody:
+        $ref: "#/components/requestBodies/pool_ids"
       responses:
         "200":
-          $ref: "#/components/responses/OK"
+          description: Array of pool information
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/pool_info"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
       summary: Pool Information
-      description: Current pool status and details for specified pool id
+      description: Current pool statuses and details for a specified list of pool ids
   /pool_delegators: #RPC
     get:
       tags:
@@ -944,6 +948,25 @@ components:
             type: string
             format: binary
             example: f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
+    pool_ids:
+      content:
+        application/json:
+          schema:
+            required:
+              - _pool_bech32_ids
+            type: object
+            properties:
+              _pool_bech32_ids:
+                format: text
+                type: array
+                items:
+                  type: string
+                description: Array of Cardano pool IDs (bech32 format)
+            example:
+              _pool_bech32_ids:
+                - pool100wj94uzf54vup2hdzk0afng4dhjaqggt7j434mtgm8v2gfvfgp
+                - pool102s2nqtea2hf5q0s4amj0evysmfnhrn4apyyhd4azcmsclzm96m
+                - pool102vsulhfx8ua2j9fwl2u7gv57fhhutc3tp6juzaefgrn7ae35wm
   securitySchemes: {}
   schemas:
     tip:
@@ -1066,6 +1089,137 @@ components:
             type: string
             description: Pool ticker
             example: JAZZ
+    pool_info:
+      type: array
+      items:
+        type: object
+        properties:
+          pool_id_bech32:
+            type: string
+            description: Pool ID (bech32 format)
+            example: pool155efqn9xpcf73pphkk88cmlkdwx4ulkg606tne970qswczg3asc
+          pool_id_hex:
+            type: string
+            description: Pool ID (Hex format)
+            example: a532904ca60e13e88437b58e7c6ff66b8d5e7ec8d3f4b9e4be7820ec
+          active_epoch_no:
+            type: integer
+            description: Block number on chain where transaction was included
+            example: 6354154
+          vrf_key_hash:
+            type: string
+            description: Pool VRF key hash
+            example: 25efdad1bc12944d38e4e3c26c43565bec84973a812737b163b289e87d0d5ed3
+          margin:
+            type: number
+            description: Margin (decimal format)
+            example: 0.1
+          fixed_cost:
+            type: integer
+            description: Pool fixed cost per epoch
+            example: 500000000
+          pledge:
+            type: string
+            description: Pool pledge in lovelace
+            example: "64000000000000"
+          reward_addr:
+            type: string
+            description: Pool reward address
+            example: stake1uy6yzwsxxc28lfms0qmpxvyz9a7y770rtcqx9y96m42cttqwvp4m5
+          owners:
+            type: array
+            items:
+              type: string
+              description: Pool (co)owner address
+              example: stake1u8088wvudd7dp3rxl0v9xgng8r3j50s65ge3l3jvgd94keqfm3nv3
+          relays:
+            type: array
+            items:
+              type: object
+              properties:
+                dns:
+                  type: string
+                  description: DNS name of the relay (nullable)
+                  example: relays-new.cardano-mainnet.iohk.io
+                srv:
+                  type: string
+                  description: DNS service name of the relay (nullable)
+                  example: biostakingpool3.hopto.org
+                ipv4:
+                  type: string
+                  description: IPv4 address of the relay (nullable)
+                  example: "54.220.20.40"
+                ipv6:
+                  type: string
+                  description: IPv6 address of the relay (nullable)
+                  example: 2604:ed40:1000:1711:6082:78ff:fe0c:ebf
+                port:
+                  type: string
+                  description: Port number of the relay (nullable)
+                  example: 6000
+          meta_url:
+            type: string
+            description: Pool metadata URL
+            example: https://pools.iohk.io/IOGP.json
+          meta_hash:
+            type: string
+            description: Pool metadata hash
+            example: 37eb004c0dd8a221ac3598ca1c6d6257fb5207ae9857b7c163ae0f39259d6cc0
+          meta_json:
+            type: object
+            properties:
+              name:
+                type: string
+                description: Pool name
+                example: Input Output Global (IOHK) - Private
+              ticker:
+                type: string
+                description: Pool ticker
+                example: IOGP
+              homepage:
+                type: string
+                description: Pool homepage URL
+                example: https://iohk.io
+              description:
+                type: string
+                description: Pool description
+                example: Our mission is to provide economic identity to the billions of people who lack it. IOHK will not use the IOHK ticker.
+          pool_status:
+            type: string
+            description: Pool status (registered | retiring | retired)
+            example: registered
+          retiring_epoch:
+            type: integer
+            description: Announced retiring epoch (nullable)
+            example: null
+          op_cert:
+            type: string
+            description: Pool latest operational certificate hash
+            example: 37eb004c0dd8a221ac3598ca1c6d6257fb5207ae9857b7c163ae0f39259d6cc0
+          op_cert_counter:
+            type: integer
+            description: Pool latest operational certificate counter value
+            example: 8
+          active_stake:
+            type: string
+            description: Pool active stake
+            example: "64328627680963"
+          block_count:
+            type: integer
+            description: Total pool blocks on chain
+            example: 4509
+          live_stake:
+            type: string
+            description: Pool live stake
+            example: "64328627680963"
+          live_delegators:
+            type: integer
+            description: Pool live delegator count
+            example: 5
+          live_saturation:
+            type: number
+            description: Pool live saturation (decimal format)
+            example: 94.52
     epoch_info:
       type: array
       items:

--- a/files/grest/apispec/koiosapi.yaml
+++ b/files/grest/apispec/koiosapi.yaml
@@ -1301,55 +1301,9 @@ components:
             description: Slot after which transaction cannot be validated
             example: 42332172
           collaterals:
-            type: array
-            description: An array collateral inputs needed when dealing with smart contracts
-            items:
-              type: object
-              properties:
-                payment_addr:
-                  type: object
-                  properties:
-                    bech32:
-                      type: string
-                      description: A Cardano payment/base address (bech32 encoded) for transaction's input UTxO
-                      example: addr1qxkfe8s6m8qt5436lec3f0320hrmpppwqgs2gah4360krvyssntpwjcz303mx3h4avg7p29l3zd8u3jyglmewds9ezrqdc3cxp
-                    cred:
-                      type: string
-                      description: Payment credential
-                      example: ac9c9e1ad9c0ba563afe7114be2a7dc7b0842e0220a476f58e9f61b0
-                stake_addr:
-                  type: string
-                  description: A Cardano staking address (reward account, bech32 encoded) for transaction's input UTxO
-                  example: stake1uxggf4shfvpghcangm67ky0q4zlc3xn7gezy0auhxczu3pslm9wrj
-                tx_hash:
-                  type: string
-                  description: Hash of Transaction for input UTxO
-                  example: f144a8264acf4bdfe2e1241170969c930d64ab6b0996a4a45237b623f1dd670e
-                tx_index:
-                  type: integer
-                  description: Index of input UTxO on the mentioned address used for input
-                  example: 0
-                value:
-                  type: string
-                  description: Balance on the selected input transaction
-                  example: 158005617
-                asset_list:
-                  type: array
-                  description: An array of assets contained on input UTxO
-                  items:
-                    properties:
-                      policy_id:
-                        type: string
-                        description: Asset Policy ID (hex)
-                        example: 6cf6b5cf0fefbe9e69d640d8be84912bb2c9e132671954548790bcfb
-                      asset_name:
-                        type: string
-                        description: Asset Name (hex)
-                        example: 6d65736d6572697a65723038353436
-                      quantity:
-                        type: string
-                        description: Asset balance on the selected input transaction
-                        example: 1
+            type: string
+            description: An array of collateral inputs needed when dealing with smart contracts (same json schema as inputs)
+            example: '[]'
           inputs:
             type: array
             description: An array with details about inputs used in a transaction

--- a/files/grest/rpc/pool/pool_info.sql
+++ b/files/grest/rpc/pool/pool_info.sql
@@ -20,7 +20,7 @@ CREATE FUNCTION grest.pool_info (_pool_bech32_ids text[])
     op_cert text,
     op_cert_counter word63type,
     active_stake text,
-    epoch_block_cnt numeric,
+    block_count numeric,
     live_stake text,
     live_delegators bigint,
     live_saturation numeric
@@ -80,10 +80,10 @@ BEGIN
     WHERE
       sl.pool_hash_id = pic.pool_hash_id
     GROUP BY
-	    b.op_cert,
-	    b.op_cert_counter
+      b.op_cert,
+      b.op_cert_counter
     ORDER BY
-	    b.op_cert_counter DESC
+      b.op_cert_counter DESC
     LIMIT 1
   ) block_data ON TRUE
   LEFT JOIN LATERAL(

--- a/files/grest/rpc/pool/pool_list.sql
+++ b/files/grest/rpc/pool/pool_list.sql
@@ -8,19 +8,32 @@ CREATE FUNCTION grest.pool_list ()
   AS $$
   # variable_conflict use_column
 BEGIN
-  RETURN QUERY SELECT DISTINCT ON (pic.pool_id_bech32)
-    pool_id_bech32,
-    pod.ticker_name
-  FROM
-    grest.pool_info_cache AS pic
-  LEFT JOIN public.pool_offline_data AS pod ON pod.pmr_id = pic.meta_id
-WHERE
-  pic.pool_status != 'retired'
-ORDER BY
-  pic.pool_id_bech32,
-  pic.tx_id DESC;
+
+  RETURN QUERY (
+    WITH
+      -- Get last pool update for each pool
+      _pool_updates AS (
+        SELECT
+          DISTINCT ON (pic.pool_id_bech32) pool_id_bech32,
+          pod.ticker_name,
+          pic.pool_status
+        FROM
+          grest.pool_info_cache AS pic
+          LEFT JOIN public.pool_offline_data AS pod ON pod.pmr_id = pic.meta_id
+        ORDER BY
+          pool_id_bech32,
+          tx_id DESC
+      )
+
+    SELECT
+      pool_id_bech32,
+      ticker_name
+    FROM
+      _pool_updates
+    WHERE
+      pool_status != 'retired'
+
+  );
+
 END;
 $$;
-
-COMMENT ON FUNCTION grest.pool_list IS 'A list of all currently registered/retiring (not retired) pools';
-


### PR DESCRIPTION
Switched to `POST` endpoint to support sending multiple pool IDs at once. This is a breaking change for consumers of this endpoint.

`active_epoch_no` -> this field should probably be renamed as it returns `epoch when the last pool update became active` from what I can tell.