### PR TITLE
CNTools - 9.0.3 (Allow TX_TTL to be user defined)

### DIFF
--- a/docs/Scripts/cntools-changelog.md
+++ b/docs/Scripts/cntools-changelog.md
@@ -6,6 +6,10 @@ All notable changes to this tool will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.0.3] - 2022-02-01
+#### Added
+- Add a config variable TX_TTL to allow transaction to be valid (by default for 3600 slots) from the point of creation - previous default of 10 minutes on mainnet could be hit-and-miss with the state of network.
+
 ## [9.0.2] - 2022-01-22
 #### Changed
 - Add decimal param to token metadata creator and increase ticker max length to 9 chars according to spec changes.

--- a/files/topology-mainnet.json
+++ b/files/topology-mainnet.json
@@ -1,21 +1,21 @@
 {
   "Producers": [
-    {"addr": "node-dus.poolunder.com",         "port": 6900, "valency": 1, "pool": "UNDR",   "location": "EU/DE/Dusseldorf" },
-    {"addr": "node-fsn.poolunder.com",         "port": 6900, "valency": 1, "pool": "UNDR",   "location": "EU/DE/Falkenstein" },
-    {"addr": "node-bhs.poolunder.com",         "port": 6900, "valency": 1, "pool": "UNDR",   "location": "NA/CA/Montreal" },
-    {"addr": "node-sin.poolunder.com",         "port": 6900, "valency": 1, "pool": "UNDR",   "location": "AS/SG/Singapore" },
-    {"addr": "node-syd.poolunder.com",         "port": 6900, "valency": 1, "pool": "UNDR",   "location": "OC/AU/Sydney" },
-    {"addr": "88.99.83.86",                    "port": 4091, "valency": 1, "pool": "RDLRT",  "location": "EU/DE/Falkenstein" },
-    {"addr": "209.145.50.190",                 "port": 6001, "valency": 1, "pool": "RDLRT",  "location": "NA/US/StLouis" },
-    {"addr": "148.72.153.168",                "port": 16000, "valency": 1, "pool": "AAA",    "location": "US/StLouis" },
-    {"addr": "78.47.99.41",                    "port": 6000, "valency": 1, "pool": "AAA",    "location": "EU/DE/Nuremberg" },
-    {"addr": "relay1-pub.ahlnet.nu",           "port": 2111, "valency": 1, "pool": "AHL",    "location": "EU/SE/Malmo" },
-    {"addr": "relay2-pub.ahlnet.nu",           "port": 2111, "valency": 1, "pool": "AHL",    "location": "EU/SE/Malmo" },
-    {"addr": "relay1.clio.one",                "port": 6010, "valency": 1, "pool": "CLIO",   "location": "EU/IT/Milan" },
-    {"addr": "relay2.clio.one",                "port": 6010, "valency": 1, "pool": "CLIO",   "location": "EU/IT/Bozlano" },
-    {"addr": "relay3.clio.one",                "port": 6010, "valency": 1, "pool": "CLIO",   "location": "EU/IT/Bozlano" },
-    {"addr": "164.90.197.139",                 "port": 6000, "valency": 1, "name": "EDEN",   "location": "EU/NL/Amsterdam" },
-    {"addr": "128.199.187.2",                  "port": 6000, "valency": 1, "name": "EDEN",   "location": "AS/SG/Singapore" },
-    {"addr": "198.199.70.70",                  "port": 6000, "valency": 1, "name": "EDEN",   "location": "NA/US/NorthBergen" }
+    {"addr": "node-dus.poolunder.com", "port": 6900, "valency": 1, "pool": "UNDR",   "location": "EU/DE/Dusseldorf" },
+    {"addr": "node-fsn.poolunder.com", "port": 6900, "valency": 1, "pool": "UNDR",   "location": "EU/DE/Falkenstein" },
+    {"addr": "node-bhs.poolunder.com", "port": 6900, "valency": 1, "pool": "UNDR",   "location": "NA/CA/Montreal" },
+    {"addr": "node-sin.poolunder.com", "port": 6900, "valency": 1, "pool": "UNDR",   "location": "AS/SG/Singapore" },
+    {"addr": "node-syd.poolunder.com", "port": 6900, "valency": 1, "pool": "UNDR",   "location": "OC/AU/Sydney" },
+    {"addr": "194.36.145.157",         "port": 6000, "valency": 1, "pool": "RDLRT",  "location": "EU/DE/Baden" },
+    {"addr": "209.145.50.190",         "port": 6001, "valency": 1, "pool": "RDLRT",  "location": "NA/US/StLouis" },
+    {"addr": "148.72.153.168",         "port": 16000, "valency": 1, "pool": "AAA",    "location": "US/StLouis" },
+    {"addr": "78.47.99.41",            "port": 6000, "valency": 1, "pool": "AAA",    "location": "EU/DE/Nuremberg" },
+    {"addr": "relay1-pub.ahlnet.nu",   "port": 2111, "valency": 1, "pool": "AHL",    "location": "EU/SE/Malmo" },
+    {"addr": "relay2-pub.ahlnet.nu",   "port": 2111, "valency": 1, "pool": "AHL",    "location": "EU/SE/Malmo" },
+    {"addr": "relay1.clio.one",        "port": 6010, "valency": 1, "pool": "CLIO",   "location": "EU/IT/Milan" },
+    {"addr": "relay2.clio.one",        "port": 6010, "valency": 1, "pool": "CLIO",   "location": "EU/IT/Bozlano" },
+    {"addr": "relay3.clio.one",        "port": 6010, "valency": 1, "pool": "CLIO",   "location": "EU/IT/Bozlano" },
+    {"addr": "164.90.197.139",         "port": 6000, "valency": 1, "name": "EDEN",   "location": "EU/NL/Amsterdam" },
+    {"addr": "128.199.187.2",          "port": 6000, "valency": 1, "name": "EDEN",   "location": "AS/SG/Singapore" },
+    {"addr": "198.199.70.70",          "port": 6000, "valency": 1, "name": "EDEN",   "location": "NA/US/NorthBergen" }
   ]
 }

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -1120,7 +1120,7 @@ getTTL() {
     fi
     ttl=$(( tip_ref + (ttl_enter/SLOT_LENGTH) ))
   else
-    ttl=$(( tip_ref + (TX_TTL/SLOT_LENGTH) )) # TTL default: 10min
+    ttl=$(( tip_ref + (TX_TTL/SLOT_LENGTH) ))
   fi
   println LOG "Current slot is ${tip_ref}, setting ttl to ${ttl}"
 }

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -11,7 +11,7 @@ CNTOOLS_MAJOR_VERSION=9
 # Minor: Changes and features of minor character that can be applied without breaking existing functionality or workflow
 CNTOOLS_MINOR_VERSION=0
 # Patch: Backwards compatible bug fixes. No additional functionality or major changes
-CNTOOLS_PATCH_VERSION=2
+CNTOOLS_PATCH_VERSION=3
 
 CNTOOLS_VERSION="${CNTOOLS_MAJOR_VERSION}.${CNTOOLS_MINOR_VERSION}.${CNTOOLS_PATCH_VERSION}"
 
@@ -25,6 +25,7 @@ if ! mkdir -p "${WALLET_FOLDER}" 2>/dev/null; then myExit 1 "${FG_RED}ERROR${NC}
 if ! mkdir -p "${POOL_FOLDER}" 2>/dev/null; then myExit 1 "${FG_RED}ERROR${NC}: Failed to create pool directory: ${POOL_FOLDER}"; fi
 if ! mkdir -p "${ASSET_FOLDER}" 2>/dev/null; then myExit 1 "${FG_RED}ERROR${NC}: Failed to create asset directory: ${POOL_ASSET}"; fi
 [[ -z ${TIMEOUT_NO_OF_SLOTS} ]] && TIMEOUT_NO_OF_SLOTS=600
+[[ -z ${TX_TTL} ]] && TX_TTL=3600
 [[ -z ${WALLET_SELECTION_FILTER_LIMIT} ]] && WALLET_SELECTION_FILTER_LIMIT=10
 [[ -z ${KES_ALERT_PERIOD} ]] && KES_ALERT_PERIOD=172800 # default 2 days
 [[ -z ${KES_WARNING_PERIOD} ]] && KES_WARNING_PERIOD=604800 # default 7 days
@@ -1119,7 +1120,7 @@ getTTL() {
     fi
     ttl=$(( tip_ref + (ttl_enter/SLOT_LENGTH) ))
   else
-    ttl=$(( tip_ref + (600/SLOT_LENGTH) )) # TTL default: 10min
+    ttl=$(( tip_ref + (TX_TTL/SLOT_LENGTH) )) # TTL default: 10min
   fi
   println LOG "Current slot is ${tip_ref}, setting ttl to ${ttl}"
 }

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -29,6 +29,9 @@ fi
 #KES_ALERT_PERIOD=172800 # default 2 days
 #KES_WARNING_PERIOD=604800 # default 7 days
 
+# Default Transaction TTL (slots after which transaction will expire from queue) to use
+#TX_TTL=3600
+
 # limit for extended wallet selection menu filtering (balance check and delegation status)
 # if more wallets exist than limit set these checks will be disabled to improve performance
 #WALLET_SELECTION_FILTER_LIMIT=10


### PR DESCRIPTION
TTL timings in CNTools used atm are a bit borderline given the chain competitiveness.. and transaction being successful depends on external variables beyond node's [default] control. Hence, bump default TTL expiry (instead of 10 minutes) to 1 hour
