### PR TITLE
pool_list and API Spec fixes

### DIFF
--- a/files/grest/apispec/koiosapi.yaml
+++ b/files/grest/apispec/koiosapi.yaml
@@ -1987,6 +1987,10 @@ components:
       description: Array of policy IDs and asset names
       items:
         properties:
+          policy_id:
+            type: string
+            description: Asset Policy ID (hex)
+            example: d3501d9531fcc25e3ca4b6429318c2cc374dbdbcf5e99c1c1e5da1ff
           asset_names:
             type: object
             properties:

--- a/files/grest/rpc/pool/pool_list.sql
+++ b/files/grest/rpc/pool/pool_list.sql
@@ -21,8 +21,8 @@ BEGIN
           grest.pool_info_cache AS pic
           LEFT JOIN public.pool_offline_data AS pod ON pod.pmr_id = pic.meta_id
         ORDER BY
-          pool_id_bech32,
-          tx_id DESC
+          pic.pool_id_bech32,
+          pic.tx_id DESC
       )
 
     SELECT


### PR DESCRIPTION
- pool_list : On postgrest v14.1 , missing alias reference on ORDER BY may fail
- API Specs: _policy_id was missing