### PR TITLE
Minor patch: Align mem stats for getmetrics with RHEL article

### DIFF
--- a/scripts/grest-helper-scripts/getmetrics.sh
+++ b/scripts/grest-helper-scripts/getmetrics.sh
@@ -40,10 +40,10 @@ function get-metrics() {
   getNodeMetrics
   currslottip=$(getSlotTipRef)
   tip=$(curl -s http://${RESTAPI_HOST}:${RESTAPI_PORT}/rpc/tip)
-  meminf=$(grep "^[MSBC][ewua][mafc]" /proc/meminfo)
+  meminf=$(grep "^Mem" /proc/meminfo)
   load1m=$(( $(awk '{ print $1*100 }' /proc/loadavg) / $(grep -c ^processor /proc/cpuinfo) ))
-  memtotal=$(( $(echo "${meminf}" | grep MemTotal | awk '{print $2}') + $(echo "${meminf}" | grep SwapTotal | awk '{print $2}') ))
-  memused=$(( memtotal + $(echo "${meminf}" | grep Shmem: | awk '{print $2}') - $(echo "${meminf}" | grep MemFree | awk '{print $2}') - $(echo "${meminf}" | grep SwapFree | awk '{print $2}') - $(echo "${meminf}" | grep ^Buffers | awk '{print $2}') - $(echo "${meminf}" | grep ^Cached | awk '{print $2}') ))
+  memtotal=$(( $(echo "${meminf}" | grep MemTotal | awk '{print $2}') ))
+  memused=$(( memtotal - $(echo "${meminf}" | grep MemAvailable | awk '{print $2}') ))
   cpuutil=$(awk -v a="$(awk '/cpu /{print $2+$4,$2+$4+$5}' /proc/stat; sleep 1)" '/cpu /{split(a,b," "); print 100*($2+$4-b[1])/($2+$4+$5-b[2])}'  /proc/stat)
   # in Bytes
   pubschsize=$(psql -d cexplorer -c "SELECT sum(pg_relation_size(quote_ident(schemaname) || '.' || quote_ident(tablename))::bigint) FROM pg_tables WHERE schemaname = 'public'" | awk 'FNR == 3 {print $1 $2}')


### PR DESCRIPTION
Simplify memused calculation as per [article from redhat](https://access.redhat.com/solutions/406773), which also aligns it more accurately with top output