### PR TITLE
CNTools update fix + env return code 2 on checkUpdate() curl error.

### DIFF
--- a/docs/Scripts/cntools-changelog.md
+++ b/docs/Scripts/cntools-changelog.md
@@ -6,6 +6,10 @@ All notable changes to this tool will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.0.5] - 2022-02-16
+#### Fixed
+- Script update code fixed to better handle in-app update. Would sometimes update but not source library correctly.
+
 ## [9.0.4] - 2022-02-14
 #### Fixed
 - Update request for pool_info endpoint from Koios

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -11,7 +11,7 @@ CNTOOLS_MAJOR_VERSION=9
 # Minor: Changes and features of minor character that can be applied without breaking existing functionality or workflow
 CNTOOLS_MINOR_VERSION=0
 # Patch: Backwards compatible bug fixes. No additional functionality or major changes
-CNTOOLS_PATCH_VERSION=4
+CNTOOLS_PATCH_VERSION=5
 
 CNTOOLS_VERSION="${CNTOOLS_MAJOR_VERSION}.${CNTOOLS_MINOR_VERSION}.${CNTOOLS_PATCH_VERSION}"
 

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -174,8 +174,8 @@ if [[ ${CNTOOLS_MODE} = "CONNECTED" ]]; then
       1) checkUpdate cntools.sh Y
          if [[ $? = 2 ]]; then
            echo -e "\n${FG_RED}ERROR${NC}: Update check of cntools.sh against GitHub failed!"
-           waitToProceed 
          fi
+         waitToProceed
          $0 "$@" "-u"; myExit 0 ;; # re-launch script with same args skipping update check
       2) echo -e "\n${FG_RED}ERROR${NC}: Update check of cntools.library against GitHub failed!"
          waitToProceed ;;

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -172,12 +172,13 @@ if [[ ${CNTOOLS_MODE} = "CONNECTED" ]]; then
     checkUpdate cntools.library "${ENV_UPDATED}" Y N
     case $? in
       1) checkUpdate cntools.sh Y
-         case $? in
-           1) $0 "$@" "-u"; myExit 0 ;; # re-launch script with same args skipping update check
-           2) exit 1 ;;
-         esac
-         ;;
-      2) exit 1 ;;
+         if [[ $? = 2 ]]; then
+           echo -e "\n${FG_RED}ERROR${NC}: Update check of cntools.sh against GitHub failed!"
+           waitToProceed 
+         fi
+         $0 "$@" "-u"; myExit 0 ;; # re-launch script with same args skipping update check
+      2) echo -e "\n${FG_RED}ERROR${NC}: Update check of cntools.library against GitHub failed!"
+         waitToProceed ;;
     esac
     
     # check if CNTools was recently updated, if so show whats new

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -208,6 +208,9 @@ checkUpdate() {
         return 1
       fi
     fi
+  else
+    # curl failed, return error code 2
+    return 2
   fi
   rm -f "${dname}/${fname}".tmp
   return 0


### PR DESCRIPTION
## Description
- CNTools update code fix.
- checkUpdate() in env updated to return error code 2 on curl download error from GitHub. 

## How has this been tested?
No tests done as of yet. 
