### PR TITLE
Remove Digital Syndicate Secondary Server

### DIFF
--- a/files/grest/topology-mainnet.json
+++ b/files/grest/topology-mainnet.json
@@ -7,8 +7,7 @@
       { "name": "homer-redoracle", "addr": "194.233.71.104", "port": 8053},
       { "name": "docker", "addr": "92.204.53.48", "port": 8053},
       { "name": "rdlrt2", "addr": "194.36.145.157", "port": 8053},
-      { "name": "HuthS0lo1", "addr": "db-sync1.digitalsyndicate.io", "port": 8053},
-      { "name": "HuthS0lo2", "addr": "db-sync3.digitalsyndicate.io", "port": 8053}
+      { "name": "HuthS0lo1", "addr": "db-sync1.digitalsyndicate.io", "port": 8053}
   ],
   "Consumers": []
 }


### PR DESCRIPTION
Going to change this boxes purpose.  Remaining server is going to be running long term.

## Description
Delete DB-Sync3.digitialsyndicate.io from topology

## Where should the reviewer start?
N/A

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->

## Which issue it fixes?
N/A

## How has this been tested?
N/A