### PR TITLE
Minor patch for topoUpd and getmetrics scripts

### DIFF
--- a/scripts/cnode-helper-scripts/topologyUpdater.sh
+++ b/scripts/cnode-helper-scripts/topologyUpdater.sh
@@ -135,6 +135,7 @@ if [[ ${TU_FETCH} = "Y" ]]; then
   else
     curl -s -f -6 -o "${TOPOLOGY}".tmp "https://api.clio.one/htopology/v1/fetch/?max=${MAX_PEERS}&magic=${NWMAGIC}&ipv=${IP_VERSION}"
   fi
+  [[ ! -s "${TOPOLOGY}".tmp ]] && echo "ERROR: The downloaded file is empty!" && exit 1
   if [[ -n "${CUSTOM_PEERS}" ]]; then
     topo="$(cat "${TOPOLOGY}".tmp)"
     IFS='|' read -ra cpeers <<< "${CUSTOM_PEERS}"

--- a/scripts/grest-helper-scripts/getmetrics.sh
+++ b/scripts/grest-helper-scripts/getmetrics.sh
@@ -46,8 +46,8 @@ function get-metrics() {
   memused=$(( memtotal - $(echo "${meminf}" | grep MemAvailable | awk '{print $2}') ))
   cpuutil=$(awk -v a="$(awk '/cpu /{print $2+$4,$2+$4+$5}' /proc/stat; sleep 1)" '/cpu /{split(a,b," "); print 100*($2+$4-b[1])/($2+$4+$5-b[2])}'  /proc/stat)
   # in Bytes
-  pubschsize=$(psql -d cexplorer -c "SELECT sum(pg_relation_size(quote_ident(schemaname) || '.' || quote_ident(tablename))::bigint) FROM pg_tables WHERE schemaname = 'public'" | awk 'FNR == 3 {print $1 $2}')
-  grestschsize=$(psql -d cexplorer -c "SELECT sum(pg_relation_size(quote_ident(schemaname) || '.' || quote_ident(tablename))::bigint) FROM pg_tables WHERE schemaname = 'grest'" | awk 'FNR == 3 {print $1 $2}')
+  pubschsize=$(psql -t --csv -d cexplorer -c "SELECT sum(pg_relation_size(quote_ident(schemaname) || '.' || quote_ident(tablename))::bigint) FROM pg_tables WHERE schemaname = 'public'" | grep "^[0-9]")
+  grestschsize=$(psql -t --csv -d cexplorer -c "SELECT sum(pg_relation_size(quote_ident(schemaname) || '.' || quote_ident(tablename))::bigint) FROM pg_tables WHERE schemaname = 'grest'" | grep "^[0-9]")
   dbsize=$(( pubschsize + grestschsize ))
 
   # Metrics


### PR DESCRIPTION
- topologyUpdater.sh: Exit if curl command fails (eg: due to timeout) and CUSTOM_PEERS are not set
- getmetrics.sh: Use tuple CSV to grep numeric output for psql instead of awk filtering (eg: my instance had `\timing` turned on, disrupting psql output filtering for line number)