### PR TITLE
/pool_history - Return information about pool stake, block and reward history in a given epoch

### DIFF
--- a/files/grest/apispec/koiosapi.yaml
+++ b/files/grest/apispec/koiosapi.yaml
@@ -862,7 +862,11 @@ paths:
         - $ref: "#/components/parameters/_epoch_no"
       responses:
         "200":
-          $ref: "#/components/responses/OK"
+          description: Array of pool history information
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/pool_history_info"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":
@@ -1325,6 +1329,55 @@ components:
             type: string
             description: Pool ticker
             example: JAZZ
+    pool_history_info:
+      type: array
+      items:
+        type: object
+        properties:
+          epoch_no:
+            type: integer
+            description: Epoch for which the pool history data is shown
+            example: 312
+          active_stake:
+            type: number
+            description: Amount of delegated Ada to this pool at the time of epoch snapshot (lovelaces)
+            example: 31235800000
+          active_stake_pct:
+            type: number
+            description: Active stake for the pool, expressed as a percentage of total active stake on network
+            example: 13.512182543475783
+          saturation_pct:
+            type: number
+            description: Saturation percentage of a pool at the time of snapshot (2 decimals)
+            example: 45.32
+          block_cnt:
+            type: integer
+            description: Number of blocks pool created in that epoch
+            example: 14
+          delegator_cnt:
+            type: integer
+            description: Number of delegators to the pool for that epoch snapshot
+            example: 1432
+          pool_fee_variable:
+            type: number
+            description: Margin (decimal format)
+            example: 0.125
+          pool_fee_fixed:
+            type: number
+            description: Pool fixed cost per epoch (in lovelaces)
+            example: 340000000
+          pool_fees:
+            type: number
+            description: Total amount of fees earned by pool owners in that epoch
+            example: 123.327382
+          deleg_rewards:
+            type: number
+            description: Total amount of rewards earned by delegators in that epoch
+            example: 123456.789123
+          epoch_ros:
+            type: number
+            description: Annualized ROS (return on staking) for delegators for this epoch
+            example: 3.000340466
     pool_info:
       type: array
       items:

--- a/files/grest/apispec/koiosapi.yaml
+++ b/files/grest/apispec/koiosapi.yaml
@@ -1339,9 +1339,9 @@ components:
             description: Epoch for which the pool history data is shown
             example: 312
           active_stake:
-            type: number
+            type: string
             description: Amount of delegated stake to this pool at the time of epoch snapshot (in lovelaces)
-            example: 31235800000
+            example: "31235800000"
           active_stake_pct:
             type: number
             description: Active stake for the pool, expressed as a percentage of total active stake on network
@@ -1358,22 +1358,22 @@ components:
             type: integer
             description: Number of delegators to the pool for that epoch snapshot
             example: 1432
-          pool_fee_variable:
+          margin:
             type: number
             description: Margin (decimal format)
             example: 0.125
-          pool_fee_fixed:
-            type: number
+          fixed_cost:
+            type: string
             description: Pool fixed cost per epoch (in lovelaces)
-            example: 340000000
+            example: "340000000"
           pool_fees:
-            type: number
+            type: string
             description: Total amount of fees earned by pool owners in that epoch (in lovelaces)
-            example: 123327382
+            example: "123327382"
           deleg_rewards:
-            type: number
+            type: string
             description: Total amount of rewards earned by delegators in that epoch (in lovelaces)
-            example: 123456789123
+            example: "123456789123"
           epoch_ros:
             type: number
             description: Annualized ROS (return on staking) for delegators for this epoch

--- a/files/grest/apispec/koiosapi.yaml
+++ b/files/grest/apispec/koiosapi.yaml
@@ -852,6 +852,24 @@ paths:
       description: >-
         Return information about blocks minted by a given pool in current epoch
         (or _epoch_no if provided)
+  /pool_history: #RPC
+    get:
+      tags:
+        - Pool
+      parameters:
+        - $ref: "#/components/parameters/_pool_bech32"
+        - $ref: "#/components/parameters/_epoch_no"
+      responses:
+        "200":
+          $ref: "#/components/responses/OK"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+      summary: Pool Stake, Block and Reward History
+      description: >-
+        Return information about pool stake, block and reward history in a given epoch _epoch_no
+        (or all epochs that pool existed for, in descending order if no _epoch_no was provided)        
   /pool_updates: #RPC
     get:
       tags:

--- a/files/grest/apispec/koiosapi.yaml
+++ b/files/grest/apispec/koiosapi.yaml
@@ -1340,7 +1340,7 @@ components:
             example: 312
           active_stake:
             type: number
-            description: Amount of delegated Ada to this pool at the time of epoch snapshot (lovelaces)
+            description: Amount of delegated stake to this pool at the time of epoch snapshot (in lovelaces)
             example: 31235800000
           active_stake_pct:
             type: number
@@ -1368,12 +1368,12 @@ components:
             example: 340000000
           pool_fees:
             type: number
-            description: Total amount of fees earned by pool owners in that epoch
-            example: 123.327382
+            description: Total amount of fees earned by pool owners in that epoch (in lovelaces)
+            example: 123327382
           deleg_rewards:
             type: number
-            description: Total amount of rewards earned by delegators in that epoch
-            example: 123456.789123
+            description: Total amount of rewards earned by delegators in that epoch (in lovelaces)
+            example: 123456789123
           epoch_ros:
             type: number
             description: Annualized ROS (return on staking) for delegators for this epoch

--- a/files/grest/rpc/pool/pool_history.sql
+++ b/files/grest/rpc/pool/pool_history.sql
@@ -1,0 +1,37 @@
+DROP FUNCTION IF EXISTS grest.pool_history (text, uinteger);
+
+CREATE FUNCTION grest.pool_history (_pool_bech32_id text, _epoch_no uinteger DEFAULT NULL)
+  RETURNS TABLE (
+    epoch_no bigint,
+    active_stake public.lovelace,
+    active_stake_pct numeric,
+    saturation_pct numeric,
+    block_cnt bigint,
+    delegator_cnt bigint,
+    pool_fee_variable double precision,
+    pool_fee_fixed public.lovelace,
+    pool_fees double precision,
+    deleg_rewards double precision,
+    epoch_ros numeric
+  )
+  LANGUAGE plpgsql
+  AS $$
+  #variable_conflict use_column
+DECLARE
+
+BEGIN
+
+  RETURN QUERY
+  SELECT    epoch_no, active_stake, active_stake_pct, saturation_pct, block_cnt,
+            delegator_cnt, pool_fee_variable, pool_fee_fixed, pool_fees,
+            deleg_rewards, epoch_ros
+  FROM grest.pool_history_cache phc
+  WHERE phc.pool_id = _pool_bech32_id and 
+    (_epoch_no is null or 
+        phc.epoch_no = _epoch_no)
+   ORDER by phc.epoch_no desc;
+
+END;
+$$;
+
+COMMENT ON FUNCTION grest.pool_history IS 'Pool block production and reward history for a given epoch (or all epochs if not specified)';

--- a/files/grest/rpc/pool/pool_history.sql
+++ b/files/grest/rpc/pool/pool_history.sql
@@ -3,15 +3,15 @@ DROP FUNCTION IF EXISTS grest.pool_history (text, uinteger);
 CREATE FUNCTION grest.pool_history (_pool_bech32_id text, _epoch_no uinteger DEFAULT NULL)
   RETURNS TABLE (
     epoch_no bigint,
-    active_stake public.lovelace,
+    active_stake text,
     active_stake_pct numeric,
     saturation_pct numeric,
     block_cnt bigint,
     delegator_cnt bigint,
-    pool_fee_variable double precision,
-    pool_fee_fixed public.lovelace,
-    pool_fees double precision,
-    deleg_rewards double precision,
+    margin double precision,
+    fixed_cost text,
+    pool_fees text,
+    deleg_rewards text,
     epoch_ros numeric
   )
   LANGUAGE plpgsql
@@ -22,9 +22,9 @@ DECLARE
 BEGIN
 
   RETURN QUERY
-  SELECT    epoch_no, active_stake, active_stake_pct, saturation_pct, block_cnt,
-            delegator_cnt, pool_fee_variable, pool_fee_fixed, pool_fees,
-            deleg_rewards, epoch_ros
+  SELECT    epoch_no, active_stake::text, active_stake_pct, saturation_pct, block_cnt,
+            delegator_cnt, pool_fee_variable as margin, pool_fee_fixed::text as fixed_cost, pool_fees::text,
+            deleg_rewards::text, epoch_ros
   FROM grest.pool_history_cache phc
   WHERE phc.pool_id = _pool_bech32_id and 
     (_epoch_no is null or 


### PR DESCRIPTION
First cut of the simplistic pool history endpoint. Decided not to return just everything since returning pool id seemed a bit weird/redundant, let me know if there's anything else that catches your eye (I searched guild operators alpha branch check-out for references to another small endpoint and came up with just koiosapi.yaml reference and the rcp sql file that were modified).