### PR TITLE
Various minor cleanups

### DIFF
--- a/docs/Scripts/cntools-changelog.md
+++ b/docs/Scripts/cntools-changelog.md
@@ -6,6 +6,11 @@ All notable changes to this tool will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.0.8] - 2022-03-07
+#### Changed
+- Remove HASH_IDENTIFIER variable references (Ddz issue which required this seperation was resolved a while ago)
+- Replace NETWORKID check with NWMAGIC variable
+
 ## [9.0.7] - 2022-03-02
 #### Fixed
 - Call Test Koios function at start of CNTools, instead of calling by default every time env is sourced

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -11,7 +11,7 @@ CNTOOLS_MAJOR_VERSION=9
 # Minor: Changes and features of minor character that can be applied without breaking existing functionality or workflow
 CNTOOLS_MINOR_VERSION=0
 # Patch: Backwards compatible bug fixes. No additional functionality or major changes
-CNTOOLS_PATCH_VERSION=7
+CNTOOLS_PATCH_VERSION=8
 
 CNTOOLS_VERSION="${CNTOOLS_MAJOR_VERSION}.${CNTOOLS_MINOR_VERSION}.${CNTOOLS_PATCH_VERSION}"
 
@@ -806,8 +806,8 @@ getPayAddress() {
   [[ -f ${payment_addr_file} ]] && pay_addr=$(cat "${payment_addr_file}") && return 0
   pay_addr=""
   if [[ -f "${payment_vk_file}" ]]; then
-    println ACTION "${CCLI} address build --payment-verification-key-file ${payment_vk_file} --out-file ${payment_addr_file} ${HASH_IDENTIFIER}"
-    if ${CCLI} address build --payment-verification-key-file "${payment_vk_file}" --out-file "${payment_addr_file}" ${HASH_IDENTIFIER} 2>/dev/null; then
+    println ACTION "${CCLI} address build --payment-verification-key-file ${payment_vk_file} --out-file ${payment_addr_file} ${NETWORK_IDENTIFIER}"
+    if ${CCLI} address build --payment-verification-key-file "${payment_vk_file}" --out-file "${payment_addr_file}" ${NETWORK_IDENTIFIER} 2>/dev/null; then
       pay_addr=$(cat "${payment_addr_file}")
       return 0
     fi
@@ -826,14 +826,14 @@ getBaseAddress() {
   [[ -f ${base_addr_file} ]] && base_addr=$(cat "${base_addr_file}") && return 0
   base_addr=""
   if [[ -f "${payment_vk_file}" && -f "${stake_vk_file}" ]]; then
-    println ACTION "${CCLI} address build --payment-verification-key-file ${payment_vk_file} --stake-verification-key-file ${stake_vk_file} --out-file ${base_addr_file} ${HASH_IDENTIFIER}"
-    if ${CCLI} address build --payment-verification-key-file "${payment_vk_file}" --stake-verification-key-file "${stake_vk_file}" --out-file "${base_addr_file}" ${HASH_IDENTIFIER} 2>/dev/null; then
+    println ACTION "${CCLI} address build --payment-verification-key-file ${payment_vk_file} --stake-verification-key-file ${stake_vk_file} --out-file ${base_addr_file} ${NETWORK_IDENTIFIER}"
+    if ${CCLI} address build --payment-verification-key-file "${payment_vk_file}" --stake-verification-key-file "${stake_vk_file}" --out-file "${base_addr_file}" ${NETWORK_IDENTIFIER} 2>/dev/null; then
       base_addr=$(cat "${base_addr_file}")
       return 0
     fi
   elif [[ $# -eq 2 && -f "${1}" && -f "${2}" ]]; then
-    println ACTION "${CCLI} address build --payment-verification-key-file ${1} --stake-verification-key-file ${2} ${HASH_IDENTIFIER}"
-    base_addr=$(${CCLI} address build --payment-verification-key-file "${1}" --stake-verification-key-file "${2}" ${HASH_IDENTIFIER} 2>/dev/null)
+    println ACTION "${CCLI} address build --payment-verification-key-file ${1} --stake-verification-key-file ${2} ${NETWORK_IDENTIFIER}"
+    base_addr=$(${CCLI} address build --payment-verification-key-file "${1}" --stake-verification-key-file "${2}" ${NETWORK_IDENTIFIER} 2>/dev/null)
   fi
   return 1
 }
@@ -848,14 +848,14 @@ getRewardAddress() {
   [[ -f ${stake_addr_file} ]] && reward_addr=$(cat "${stake_addr_file}") && return 0
   reward_addr=""
   if [[ -f "${stake_vk_file}" ]]; then
-    println ACTION "${CCLI} stake-address build --stake-verification-key-file ${stake_vk_file} --out-file ${stake_addr_file} ${HASH_IDENTIFIER}"
-    if ${CCLI} stake-address build --stake-verification-key-file "${stake_vk_file}" --out-file "${stake_addr_file}" ${HASH_IDENTIFIER} 2>/dev/null; then
+    println ACTION "${CCLI} stake-address build --stake-verification-key-file ${stake_vk_file} --out-file ${stake_addr_file} ${NETWORK_IDENTIFIER}"
+    if ${CCLI} stake-address build --stake-verification-key-file "${stake_vk_file}" --out-file "${stake_addr_file}" ${NETWORK_IDENTIFIER} 2>/dev/null; then
       reward_addr=$(cat "${stake_addr_file}")
       return 0
     fi
   elif [[ -f "${1}" ]]; then
-    println ACTION "${CCLI} stake-address build --stake-verification-key-file ${1} ${HASH_IDENTIFIER}"
-    reward_addr=$(${CCLI} stake-address build --stake-verification-key-file "${1}" ${HASH_IDENTIFIER} 2>/dev/null)
+    println ACTION "${CCLI} stake-address build --stake-verification-key-file ${1} ${NETWORK_IDENTIFIER}"
+    reward_addr=$(${CCLI} stake-address build --stake-verification-key-file "${1}" ${NETWORK_IDENTIFIER} 2>/dev/null)
   fi
   return 1
 }
@@ -865,8 +865,8 @@ getRewardAddress() {
 # Parameters  : stake key  >  path to stake.vkey file
 # Return      : populates ${reward_addr}
 getRewardAddressFromKey() {
-  println ACTION "${CCLI} stake-address build --stake-verification-key-file ${1} ${HASH_IDENTIFIER}"
-  reward_addr=$(${CCLI} stake-address build --stake-verification-key-file "${1}" ${HASH_IDENTIFIER} 2>/dev/null)
+  println ACTION "${CCLI} stake-address build --stake-verification-key-file ${1} ${NETWORK_IDENTIFIER}"
+  reward_addr=$(${CCLI} stake-address build --stake-verification-key-file "${1}" ${NETWORK_IDENTIFIER} 2>/dev/null)
 }
 
 # Command     : getAddressInfo [address]

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -473,9 +473,9 @@ function main {
                     stake_xprv=$(cardano-address key child 1852H/1815H/0H/2/0 <<< ${root_prv})
                     payment_xpub=$(cardano-address key public ${caddr_arg} <<< ${payment_xprv})
                     stake_xpub=$(cardano-address key public ${caddr_arg} <<< ${stake_xprv})
-                    [[ "${NETWORKID}" = "Mainnet" ]] && network_tag=1 || network_tag=0
+                    [[ "${NWMAGIC}" == "764824073" ]] && network_tag=1 || network_tag=0
                     base_addr_candidate=$(cardano-address address delegation ${stake_xpub} <<< "$(cardano-address address payment --network-tag ${network_tag} <<< ${payment_xpub})")
-                    if [[ "${caddr_v}" == 2* ]] && [[ "${NETWORKID}" = "Testnet" ]]; then
+                    if [[ "${caddr_v}" == 2* ]] && [[ "${NWMAGIC}" != "764824073" ]]; then
                       println LOG "TestNet, converting address to 'addr_test'"
                       base_addr_candidate=$(bech32 addr_test <<< ${base_addr_candidate})
                     fi

--- a/scripts/cnode-helper-scripts/dbsync.sh
+++ b/scripts/cnode-helper-scripts/dbsync.sh
@@ -58,13 +58,11 @@ check_defaults() {
 }
 
 check_config_sanity() {
-  read -ra genfiles <<<"$(jq -r '[ .ByronGenesisFile, .ShelleyGenesisFile, .AlonzoGenesisFile] | @tsv' "${CONFIG}")"
-  [[ -z "${genfiles[1]}" ]] || [[ -z "${genfiles[2]}" ]] && err_exit "Could not find Shelley/Alonzo Genesis Files in ${CONFIG}! Please re-run prereqs.sh with right arguments!" && exit 1
-  BYGENHASH=$(cardano-cli byron genesis print-genesis-hash --genesis-json "${genfiles[0]}" 2>/dev/null)
+  BYGENHASH=$(cardano-cli byron genesis print-genesis-hash --genesis-json "${BYRON_GENESIS_JSON}" 2>/dev/null)
   BYGENHASHCFG=$(jq '.ByronGenesisHash' <"${CONFIG}" 2>/dev/null)
-  SHGENHASH=$(cardano-cli genesis hash --genesis "${genfiles[1]}" 2>/dev/null)
+  SHGENHASH=$(cardano-cli genesis hash --genesis "${GENESIS_JSON}" 2>/dev/null)
   SHGENHASHCFG=$(jq '.ShelleyGenesisHash' <"${CONFIG}" 2>/dev/null)
-  ALGENHASH=$(cardano-cli genesis hash --genesis "${genfiles[2]}" 2>/dev/null)
+  ALGENHASH=$(cardano-cli genesis hash --genesis "${ALONZO_GENESIS_JSON}" 2>/dev/null)
   ALGENHASHCFG=$(jq '.AlonzoGenesisHash' <"${CONFIG}" 2>/dev/null)
   # If hash are missing/do not match, add that to the end of config. We could have sorted it based on logic, but that would mess up sdiff comparison outputs
   if [[ "${BYGENHASH}" != "${BYGENHASHCFG}" ]] || [[ "${SHGENHASH}" != "${SHGENHASHCFG}" ]] || [[ "${ALGENHASH}" != "${ALGENHASHCFG}" ]]; then

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -881,12 +881,23 @@ if ! command -v "jq" &>/dev/null; then
   return 1
 fi
 
-if ! jq -r . "${CONFIG}" >/dev/null 2>&1; then
-  echo "Could not parse ${CONFIG} file in JSON format, please double-check the syntax of your config, or simply download it from guild-operators repository!"
+read -ra CONFIG_CONTENTS <<<"$(jq -r '[ .AlonzoGenesisFile, .ByronGenesisFile, .ShelleyGenesisFile, .Protocol, .TraceChainDb]| @tsv' "${CONFIG}" 2>/dev/null)"
+if [[ -z "${CONFIG_CONTENTS[4]}" ]]; then
+  echo "Could not find TraceChainDb when attempting to parse ${CONFIG} file in JSON format, please double-check the syntax of your config, or simply download it from guild-operators repository!"
   return 1
-elif [[ "$(jq -r .TraceChainDb ${CONFIG})" != "true" ]]; then
-  echo "The ${CONFIG} file suggests that you have set TraceChainDb parameter to false. Please change it to true, as it is required to extract statistics from node."
-  return 1
+else
+  ALONZO_GENESIS_JSON="${CONFIG_CONTENTS[0]}"
+  BYRON_GENESIS_JSON="${CONFIG_CONTENTS[1]}"
+  GENESIS_JSON="${CONFIG_CONTENTS[2]}"
+  # if relative path is used, assume same parent dir as config
+  [[ ! ${ALONZO_GENESIS_JSON} =~ ^/ ]] && ALONZO_GENESIS_JSON="$(dirname "${CONFIG}")/${ALONZO_GENESIS_JSON}"
+  [[ ! ${BYRON_GENESIS_JSON} =~ ^/ ]] && BYRON_GENESIS_JSON="$(dirname "${CONFIG}")/${BYRON_GENESIS_JSON}"
+  [[ ! ${GENESIS_JSON} =~ ^/ ]] && GENESIS_JSON="$(dirname "${CONFIG}")/${GENESIS_JSON}"
+  # if genesis files not found, exit with rc 1
+  [[ ! -f "${ALONZO_GENESIS_JSON}" ]] && echo "Byron genesis file not found: ${ALONZO_GENESIS_JSON}" && return 1
+  [[ ! -f "${BYRON_GENESIS_JSON}" ]] && echo "Byron genesis file not found: ${BYRON_GENESIS_JSON}" && return 1
+  [[ ! -f "${GENESIS_JSON}" ]] && echo "Shelley genesis file not found: ${GENESIS_JSON}" && return 1
+  PROTOCOL="${CONFIG_CONTENTS[3]}"
 fi
 
 [[ -z ${EKG_TIMEOUT} ]] && EKG_TIMEOUT=3
@@ -938,24 +949,6 @@ elif [[ ! ${PROM_PORT} =~ ^[0-9]+$ ]]; then
   return 1
 fi
 
-if ! GENESIS_JSON=$(jq -er '.ShelleyGenesisFile' "${CONFIG}" 2>/dev/null); then
-  echo "Could not get 'ShelleyGenesisFile' in ${CONFIG}"
-  return 1
-else
-  # if relative path is used, assume same parent dir as config
-  [[ ! ${GENESIS_JSON} =~ ^/ ]] && GENESIS_JSON="$(dirname "${CONFIG}")/${GENESIS_JSON}"
-  [[ ! -f "${GENESIS_JSON}" ]] && echo "Shelley genesis file not found: ${GENESIS_JSON}" && return 1
-fi
-
-if ! BYRON_GENESIS_JSON=$(jq -er '.ByronGenesisFile' "${CONFIG}" 2>/dev/null); then
-  echo "Could not get 'ByronGenesisFile' specified in ${CONFIG}"
-  return 1
-else
-  # if relative path is used, assume same parent dir as config
-  [[ ! ${BYRON_GENESIS_JSON} =~ ^/ ]] && BYRON_GENESIS_JSON="$(dirname "${CONFIG}")/${BYRON_GENESIS_JSON}"
-  [[ ! -f "${BYRON_GENESIS_JSON}" ]] && echo "Byron genesis file not found: ${BYRON_GENESIS_JSON}" && return 1
-fi
-
 [[ -z ${BLOCKLOG_DIR} ]] && BLOCKLOG_DIR="${CNODE_HOME}/guild-db/blocklog"
 BLOCKLOG_DB="${BLOCKLOG_DIR}/blocklog.db"
 [[ -z ${BLOCKLOG_TZ} ]] && BLOCKLOG_TZ="UTC"
@@ -985,35 +978,44 @@ if ! versionCheck "1.32.1" "${node_version}"; then
   return 1
 fi
 
-PROTOCOL=$(jq -r .Protocol "${CONFIG}")
-NETWORKID=$(jq -r .networkId ${GENESIS_JSON})
-MAGIC=$(jq -r .protocolMagicId < ${GENESIS_JSON})
-NWMAGIC=$(jq -r .networkMagic < ${GENESIS_JSON})
-[[ ${NETWORKID} = "Mainnet" ]] && HASH_IDENTIFIER="--mainnet" || HASH_IDENTIFIER="--testnet-magic ${NWMAGIC}"
+read_genesis() {
+  read -ra SHGENESIS <<< "$(jq -r '[ .networkMagic, .systemStart, .epochLength, .slotLength, .activeSlotsCoeff, .slotsPerKESPeriod, .maxKESEvolutions ] |@tsv' < ${GENESIS_JSON})"
+  read -ra BYGENESIS <<< "$(jq -r '[ .startTime, .protocolConsts.k, .blockVersionData.slotDuration ] |@tsv' < ${BYRON_GENESIS_JSON})"
+  NWMAGIC=${SHGENESIS[0]}
+  SHELLEY_GENESIS_START_SEC=$(date --date="${SHGENESIS[1]}" +%s)
+  EPOCH_LENGTH=${SHGENESIS[2]}
+  SLOT_LENGTH=${SHGENESIS[3]}
+  ACTIVE_SLOTS_COEFF=${SHGENESIS[4]}
+  SLOTS_PER_KES_PERIOD=${SHGENESIS[5]}
+  MAX_KES_EVOLUTIONS=${SHGENESIS[6]}
+  BYRON_GENESIS_START_SEC=${BYGENESIS[0]}
+  BYRON_K=${BYGENESIS[1]}
+  BYRON_SLOT_LENGTH=${BYGENESIS[2]}
+  BYRON_EPOCH_LENGTH=$(( 10 * BYRON_K ))
+}
+
+read_genesis
+
+[[ ${NWMAGIC} == "764824073" ]] && NETWORK_IDENTIFIER="--mainnet" || NETWORK_IDENTIFIER="--testnet-magic ${NWMAGIC}"
 case ${NWMAGIC} in
   764824073) 
     NETWORK_NAME="Mainnet"
-    [[ -z ${SHELLEY_TRANS_EPOCH} ]] && SHELLEY_TRANS_EPOCH=208
-    NETWORK_IDENTIFIER="--mainnet"
+    SHELLEY_TRANS_EPOCH=208
     [[ -z ${KOIOS_API} ]] && KOIOS_API="https://api.koios.rest/api/v0" ;;
   1097911063) 
     NETWORK_NAME="Testnet"
-    [[ -z ${SHELLEY_TRANS_EPOCH} ]] && SHELLEY_TRANS_EPOCH=74
-    NETWORK_IDENTIFIER="--testnet-magic ${NWMAGIC}"
+    SHELLEY_TRANS_EPOCH=74
     [[ -z ${KOIOS_API} ]] && KOIOS_API="https://testnet.koios.rest/api/v0" ;;
   633343913) 
     NETWORK_NAME="Staging"
-    [[ -z ${SHELLEY_TRANS_EPOCH} ]] && SHELLEY_TRANS_EPOCH=208
-    NETWORK_IDENTIFIER="--testnet-magic ${NWMAGIC}" ;;
+    SHELLEY_TRANS_EPOCH=208 ;;
   141) 
     NETWORK_NAME="Guild"
-    [[ -z ${SHELLEY_TRANS_EPOCH} ]] && SHELLEY_TRANS_EPOCH=2
-    NETWORK_IDENTIFIER="--testnet-magic ${NWMAGIC}"
+    SHELLEY_TRANS_EPOCH=2
     [[ -z ${KOIOS_API} ]] && KOIOS_API="https://guild.koios.rest/api/v0" ;;
   *) 
     NETWORK_NAME="Custom"
     [[ -z ${SHELLEY_TRANS_EPOCH} ]] && SHELLEY_TRANS_EPOCH=0
-    NETWORK_IDENTIFIER="--testnet-magic ${NWMAGIC}" ;;
 esac
 
 test_koios() {
@@ -1021,20 +1023,9 @@ test_koios() {
   [[ ${ENABLE_KOIOS} = 'Y' && -n ${KOIOS_API} && $(curl -Isf -m 5 ${KOIOS_API}/tip | head -1) = *"200 OK"* ]] || unset KOIOS_API
 }
 
-SHELLEY_GENESIS_START_SEC=$(date --date="$(jq -r .systemStart "${GENESIS_JSON}")" +%s)
-EPOCH_LENGTH=$(jq -r .epochLength "${GENESIS_JSON}")
-SLOT_LENGTH=$(jq -r .slotLength "${GENESIS_JSON}")
-ACTIVE_SLOTS_COEFF=$(jq -r .activeSlotsCoeff "${GENESIS_JSON}")
-SLOTS_PER_KES_PERIOD=$(jq -r .slotsPerKESPeriod "${GENESIS_JSON}")
-MAX_KES_EVOLUTIONS=$(jq -r .maxKESEvolutions "${GENESIS_JSON}")
-BYRON_GENESIS_START_SEC=$(jq -r .startTime "${BYRON_GENESIS_JSON}")
-BYRON_K=$(jq -r .protocolConsts.k "${BYRON_GENESIS_JSON}")
-BYRON_SLOT_LENGTH=$(( $(jq -r .blockVersionData.slotDuration "${BYRON_GENESIS_JSON}") ))
-BYRON_EPOCH_LENGTH=$(( 10 * BYRON_K ))
+[[ ${OFFLINE_MODE} = "N" && ${SHELLEY_TRANS_EPOCH} -eq -1 ]] && getNodeMetrics && getShelleyTransitionEpoch
 
 # Return code 2 is used for scripts that want to source env but not fail due to a starting node
-
-[[ ${OFFLINE_MODE} = "N" && ${SHELLEY_TRANS_EPOCH} -eq -1 ]] && getNodeMetrics && getShelleyTransitionEpoch
 
 if [[ ${OFFLINE_MODE} = "N" && ! -S ${CARDANO_NODE_SOCKET_PATH} ]]; then
   echo -e "${FG_RED}Looks like cardano-node is running with socket-path as ${FG_LBLUE}${CARDANO_NODE_SOCKET_PATH}${FG_RED}, but the actual socket file does not exist."

--- a/scripts/cnode-helper-scripts/prereqs.sh
+++ b/scripts/cnode-helper-scripts/prereqs.sh
@@ -480,7 +480,7 @@ curl -s -f -m ${CURL_TIMEOUT} -o cntools.sh ${URL_RAW}/scripts/cnode-helper-scri
 curl -s -f -m ${CURL_TIMEOUT} -o cntools.library ${URL_RAW}/scripts/cnode-helper-scripts/cntools.library
 curl -s -f -m ${CURL_TIMEOUT} -o logMonitor.sh.tmp ${URL_RAW}/scripts/cnode-helper-scripts/logMonitor.sh
 curl -s -f -m ${CURL_TIMEOUT} -o setup_mon.sh ${URL_RAW}/scripts/cnode-helper-scripts/setup_mon.sh
-curl -s -f -m ${CURL_TIMEOUT} -o setup-grest.sh ${URL_RAW}/scripts/grest-helper-scripts/setup-grest.sh
+curl -s -f -m ${CURL_TIMEOUT} -o setup-grest.sh.tmp ${URL_RAW}/scripts/grest-helper-scripts/setup-grest.sh
 curl -s -f -m ${CURL_TIMEOUT} -o topologyUpdater.sh.tmp ${URL_RAW}/scripts/cnode-helper-scripts/topologyUpdater.sh
 curl -s -f -m ${CURL_TIMEOUT} -o cabal-build-all.sh ${URL_RAW}/scripts/cnode-helper-scripts/cabal-build-all.sh
 curl -s -f -m ${CURL_TIMEOUT} -o submitapi.sh.tmp ${URL_RAW}/scripts/cnode-helper-scripts/submitapi.sh

--- a/scripts/cnode-helper-scripts/prereqs.sh
+++ b/scripts/cnode-helper-scripts/prereqs.sh
@@ -530,6 +530,7 @@ updateWithCustomConfig "topologyUpdater.sh"
 updateWithCustomConfig "logMonitor.sh"
 updateWithCustomConfig "cncli.sh"
 updateWithCustomConfig "blockPerf.sh"
+updateWithCustomConfig "setup-grest.sh"
 
 find "${CNODE_HOME}/scripts" -name '*.sh' -exec chmod 755 {} \; 2>/dev/null
 chmod -R 700 "${CNODE_HOME}"/priv 2>/dev/null

--- a/scripts/grest-helper-scripts/getmetrics.sh
+++ b/scripts/grest-helper-scripts/getmetrics.sh
@@ -2,8 +2,6 @@
 #shellcheck disable=SC2005,SC2046,SC2154,SC2155,SC2034,SC2086
 #shellcheck source=/dev/null
 
-. "$(dirname $0)"/env offline
-
 ######################################
 # User Variables - Change as desired #
 # Common variables set in env file   #
@@ -54,7 +52,7 @@ function get-metrics() {
   export METRIC_dbsynctipref=$(( currslottip - $( echo "${tip}" | jq .[0].abs_slot) ))
   export METRIC_nodetipref=$(( currslottip - slotnum ))
   export METRIC_uptime="${uptimes}"
-  export METRIC_dbsyncBlockHeight=$(curl -s http://${RESTAPI_HOST}:${RESTAPI_PORT}/rpc/tip | jq .[0].block_no)
+  export METRIC_dbsyncBlockHeight=$(echo "${tip}" | jq .[0].block_no)
   export METRIC_nodeBlockHeight=${blocknum}
   export METRIC_dbsyncQueueLength=$(( METRIC_nodeBlockHeight - METRIC_dbsyncBlockHeight ))
   export METRIC_memtotal="${memtotal}"

--- a/scripts/grest-helper-scripts/setup-grest.sh
+++ b/scripts/grest-helper-scripts/setup-grest.sh
@@ -260,7 +260,6 @@
   #             : Note: Given the Plutus schema is far from finalized, we expect changes as SC layer matures and PAB gets into real networks.
   #             :       For now, a compressed jq will be inserted as a shell escaped json data blob.
   populate_genesis_table() {
-    read -ra genfiles <<<$(jq -r '[ .ByronGenesisFile, .ShelleyGenesisFile, .AlonzoGenesisFile] | @tsv' "${CONFIG}")
     read -ra SHGENESIS <<<$(jq -r '[
       .activeSlotsCoeff,
       .updateQuorum,
@@ -273,8 +272,8 @@
       .slotLength,
       .maxKESEvolutions,
       .securityParam
-      ] | @tsv' <"${genfiles[1]}")
-    ALGENESIS="$(jq -c . <${genfiles[2]})"
+      ] | @tsv' <"${GENESIS_JSON}")
+    ALGENESIS="$(jq -c . <"${ALONZO_GENESIS_JSON}")"
 
     insert_genesis_table_data "${ALGENESIS}" "${SHGENESIS[@]}"
   }


### PR DESCRIPTION
### env:
- Reduce jq calls for parsing config and genesis files - for options that will always be present
- For mainnet/testnet/staging/guild networks, dont need to check for SHELLEY_TRANS_EPOCH variable to pre-exist as they're constant
- NETWORKID is no longer used for environments, can use NWMAGIC instead

### prereqs.sh:
- Add updateWithCustomConfig for setup-grest.sh

### getmetrics.sh:
- Remove duplicate reference for env
- Use tip from variable already available

### cntools.library:
- Remove HASH_IDENTIFIER (Ddz issue which required this seperation was resolved a while ago)

### cntools.sh:
- Replace NETWORKID check with NWMAGIC

### setup-grest.sh/dbsync.sh:
- Use genesis json variables already present in env instead of parsing config again