### PR TITLE
Drop existing function before deployment

### DIFF
--- a/files/grest/rpc/00_blockchain/tip.sql
+++ b/files/grest/rpc/00_blockchain/tip.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.tip ();
-
 CREATE FUNCTION grest.tip ()
   RETURNS TABLE (
     hash text,

--- a/files/grest/rpc/00_blockchain/totals.sql
+++ b/files/grest/rpc/00_blockchain/totals.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.totals (numeric);
-
 CREATE FUNCTION grest.totals (_epoch_no numeric DEFAULT NULL)
   RETURNS TABLE (
     epoch_no uinteger,

--- a/files/grest/rpc/01_cached_tables/active_stake_cache.sql
+++ b/files/grest/rpc/01_cached_tables/active_stake_cache.sql
@@ -22,15 +22,7 @@ CREATE TABLE IF NOT EXISTS GREST.ACCOUNT_ACTIVE_STAKE_CACHE (
   PRIMARY KEY (STAKE_ADDRESS, POOL_ID, EPOCH_NO)
 );
 
--- For easier updates only:
-DROP TRIGGER IF EXISTS POOL_ACTIVE_STAKE_EPOCH_UPDATE_TRIGGER ON PUBLIC.EPOCH_STAKE;
-DROP TRIGGER IF EXISTS EPOCH_ACTIVE_STAKE_EPOCH_UPDATE_TRIGGER ON PUBLIC.EPOCH_STAKE;
-DROP FUNCTION IF EXISTS GREST.POOL_ACTIVE_STAKE_EPOCH_UPDATE;
-DROP FUNCTION IF EXISTS GREST.EPOCH_ACTIVE_STAKE_EPOCH_UPDATE;
---
-
 /* HELPER FUNCTIONS */
-DROP FUNCTION IF EXISTS grest.get_last_active_stake_validated_epoch ();
 
 CREATE FUNCTION grest.get_last_active_stake_validated_epoch ()
   RETURNS INTEGER
@@ -51,8 +43,6 @@ $$;
 
 /* POSSIBLE VALIDATION FOR CACHE (COUNTING ENTRIES) INSTEAD OF JUST DB-SYNC PART (EPOCH_STAKE)
 
-DROP FUNCTION IF EXISTS grest.get_last_active_stake_cache_address_count ();
-
 CREATE FUNCTION grest.get_last_active_stake_cache_address_count ()
   RETURNS INTEGER
   LANGUAGE plpgsql
@@ -64,8 +54,6 @@ CREATE FUNCTION grest.get_last_active_stake_cache_address_count ()
     END;
   $$;
  */
-
-DROP FUNCTION IF EXISTS grest.active_stake_cache_update_check ();
 
 CREATE FUNCTION grest.active_stake_cache_update_check ()
   RETURNS BOOLEAN
@@ -103,8 +91,6 @@ $$;
 
 COMMENT ON FUNCTION grest.active_stake_cache_update_check
   IS 'Internal function to determine whether active stake cache should be updated';
-
-DROP FUNCTION IF EXISTS grest.active_stake_cache_update (integer);
 
 /* UPDATE FUNCTION */
 CREATE FUNCTION grest.active_stake_cache_update (_epoch_no integer)

--- a/files/grest/rpc/01_cached_tables/asset_registry_cache.sql
+++ b/files/grest/rpc/01_cached_tables/asset_registry_cache.sql
@@ -13,8 +13,6 @@ CREATE TABLE grest.asset_registry_cache (
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_asset ON grest.asset_registry_cache (asset_policy, asset_name);
 
-DROP FUNCTION IF EXISTS grest.asset_registry_cache_update CASCADE;
-
 CREATE FUNCTION grest.asset_registry_cache_update (
         _asset_policy text,
         _asset_name text,

--- a/files/grest/rpc/01_cached_tables/epoch_info_cache.sql
+++ b/files/grest/rpc/01_cached_tables/epoch_info_cache.sql
@@ -41,8 +41,6 @@ CREATE TABLE IF NOT EXISTS grest.epoch_info_cache (
 
 COMMENT ON TABLE grest.epoch_info_cache IS 'Contains detailed info for epochs including protocol parameters';
 
-DROP FUNCTION IF EXISTS grest.EPOCH_INFO_CACHE_UPDATE CASCADE;
-
 CREATE FUNCTION grest.EPOCH_INFO_CACHE_UPDATE (
     _epoch_no_to_insert_from bigint default NULL
   )
@@ -167,8 +165,6 @@ END;
 $$;
 
 -- Helper function for updating current epoch data
-DROP FUNCTION IF EXISTS grest.UPDATE_LATEST_EPOCH_INFO_CACHE;
-
 CREATE FUNCTION grest.UPDATE_LATEST_EPOCH_INFO_CACHE (_epoch_no_to_update bigint default NULL)
   RETURNS void
   LANGUAGE plpgsql

--- a/files/grest/rpc/01_cached_tables/pool_history_cache.sql
+++ b/files/grest/rpc/01_cached_tables/pool_history_cache.sql
@@ -18,8 +18,6 @@ CREATE TABLE grest.pool_history_cache (
 
 COMMENT ON TABLE grest.pool_history_cache IS 'A history of pool performance including blocks, delegators, active stake, fees and rewards';
 
-DROP FUNCTION IF EXISTS grest.pool_history_cache_update CASCADE;
-
 create function grest.pool_history_cache_update (_epoch_no_to_insert_from bigint default NULL)
   returns void
   language plpgsql

--- a/files/grest/rpc/01_cached_tables/pool_info_cache.sql
+++ b/files/grest/rpc/01_cached_tables/pool_info_cache.sql
@@ -25,9 +25,6 @@ CREATE TABLE grest.pool_info_cache (
 
 COMMENT ON TABLE grest.pool_info_cache IS 'A summary of all pool parameters and updates';
 
-
-DROP FUNCTION IF EXISTS grest.pool_info_insert CASCADE;
-
 CREATE FUNCTION grest.pool_info_insert (
         _update_id bigint,
         _tx_id bigint,
@@ -133,9 +130,6 @@ $$;
 
 COMMENT ON FUNCTION grest.pool_info_insert IS 'Internal function to insert a single pool update';
 
-
-DROP FUNCTION IF EXISTS grest.pool_info_retire_status CASCADE;
-
 CREATE FUNCTION grest.pool_info_retire_status ()
     RETURNS TRIGGER
     LANGUAGE plpgsql
@@ -153,9 +147,6 @@ END;
 $$;
 
 COMMENT ON FUNCTION grest.pool_info_retire_status IS 'Internal function to update pool_info_cache with new retire status based on epoch switch';
-
-
-DROP FUNCTION IF EXISTS grest.pool_info_retire_update CASCADE;
 
 CREATE FUNCTION grest.pool_info_retire_update ()
     RETURNS TRIGGER
@@ -206,9 +197,6 @@ END;
 $$;
 
 COMMENT ON FUNCTION grest.pool_info_retire_update IS 'Internal function to update pool_info cache table based on insert/delete on pool_retire table';
-
-
-DROP FUNCTION IF EXISTS grest.pool_info_update CASCADE;
 
 CREATE FUNCTION grest.pool_info_update ()
     RETURNS TRIGGER

--- a/files/grest/rpc/01_cached_tables/stake_distribution_cache.sql
+++ b/files/grest/rpc/01_cached_tables/stake_distribution_cache.sql
@@ -9,8 +9,7 @@ CREATE TABLE IF NOT EXISTS GREST.STAKE_DISTRIBUTION_CACHE (
   RESERVES numeric,
   TREASURY numeric
 );
-DROP PROCEDURE IF EXISTS GREST.UPDATE_STAKE_DISTRIBUTION_CACHE ();
-DROP FUNCTION IF EXISTS GREST.UPDATE_STAKE_DISTRIBUTION_CACHE ();
+
 CREATE PROCEDURE GREST.UPDATE_STAKE_DISTRIBUTION_CACHE () LANGUAGE PLPGSQL AS $$
 DECLARE -- Last block height to control future re-runs of the query
   _last_accounted_block_height bigint;
@@ -255,7 +254,6 @@ $$;
  * Determines whether or not the stake distribution cache should be updated
  * based on the time rule (max once in 60 mins), and ensures previous run completed.
  */
-DROP FUNCTION IF EXISTS GREST.STAKE_DISTRIBUTION_CACHE_UPDATE_CHECK;
 CREATE FUNCTION GREST.STAKE_DISTRIBUTION_CACHE_UPDATE_CHECK () RETURNS VOID LANGUAGE PLPGSQL AS $$
 DECLARE _last_update_block_height bigint DEFAULT NULL;
 _current_block_height bigint DEFAULT NULL;

--- a/files/grest/rpc/account/account_addresses.sql
+++ b/files/grest/rpc/account/account_addresses.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.account_addresses (text);
-
 CREATE FUNCTION grest.account_addresses (_address text DEFAULT NULL)
     RETURNS TABLE (
         address varchar)

--- a/files/grest/rpc/account/account_assets.sql
+++ b/files/grest/rpc/account/account_assets.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.account_assets (text);
-
 CREATE FUNCTION grest.account_assets (_address text DEFAULT NULL)
     RETURNS TABLE (
         asset_policy text,

--- a/files/grest/rpc/account/account_history.sql
+++ b/files/grest/rpc/account/account_history.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.account_history (text, integer);
-
 CREATE FUNCTION grest.account_history (
   _address text,
   _epoch_no integer DEFAULT NULL

--- a/files/grest/rpc/account/account_info.sql
+++ b/files/grest/rpc/account/account_info.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.account_info (text);
-
 CREATE FUNCTION grest.account_info (_address text)
   RETURNS TABLE (
     STATUS text,

--- a/files/grest/rpc/account/account_rewards.sql
+++ b/files/grest/rpc/account/account_rewards.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.account_rewards (text, numeric);
-
 CREATE FUNCTION grest.account_rewards (_stake_address text, _epoch_no numeric DEFAULT NULL)
   RETURNS TABLE (
     earned_epoch bigint,

--- a/files/grest/rpc/account/account_updates.sql
+++ b/files/grest/rpc/account/account_updates.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.account_updates (text);
-
 CREATE FUNCTION grest.account_updates (_stake_address text)
   RETURNS TABLE (
     action_type text,

--- a/files/grest/rpc/address/address_assets.sql
+++ b/files/grest/rpc/address/address_assets.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.address_assets (_address text);
-
 CREATE FUNCTION grest.address_assets (_address text)
   RETURNS TABLE (
     policy_id text,

--- a/files/grest/rpc/address/address_info.sql
+++ b/files/grest/rpc/address/address_info.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.address_info (text);
-
 CREATE FUNCTION grest.address_info (_address text DEFAULT NULL)
   RETURNS TABLE (
     balance text,

--- a/files/grest/rpc/address/address_txs.sql
+++ b/files/grest/rpc/address/address_txs.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.address_txs (text[], integer);
-
 CREATE FUNCTION grest.address_txs (_addresses text[], _after_block_height integer DEFAULT 0)
   RETURNS TABLE (
     tx_hash text,

--- a/files/grest/rpc/address/credential_txs.sql
+++ b/files/grest/rpc/address/credential_txs.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.credential_txs (text[], integer);
-
 CREATE FUNCTION grest.credential_txs (_payment_credentials text[], _after_block_height integer DEFAULT 0)
   RETURNS TABLE (
     tx_hash text,

--- a/files/grest/rpc/assets/asset_address_list.sql
+++ b/files/grest/rpc/assets/asset_address_list.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.asset_address_list (text, text);
-
 CREATE FUNCTION grest.asset_address_list (_asset_policy text, _asset_name text)
   RETURNS TABLE (
     payment_address varchar,

--- a/files/grest/rpc/assets/asset_history.sql
+++ b/files/grest/rpc/assets/asset_history.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.asset_history (text, text);
-
 CREATE FUNCTION grest.asset_history (_asset_policy text, _asset_name text)
   RETURNS TABLE (
     policy_id text,

--- a/files/grest/rpc/assets/asset_info.sql
+++ b/files/grest/rpc/assets/asset_info.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.asset_info (text, text);
-
 CREATE FUNCTION grest.asset_info (_asset_policy text, _asset_name text)
   RETURNS TABLE (
     policy_id text,

--- a/files/grest/rpc/assets/asset_policy_info.sql
+++ b/files/grest/rpc/assets/asset_policy_info.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.asset_policy_info (text);
-
 CREATE FUNCTION grest.asset_policy_info (_asset_policy text)
   RETURNS TABLE (
     policy_id text,

--- a/files/grest/rpc/assets/asset_summary.sql
+++ b/files/grest/rpc/assets/asset_summary.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.asset_summary (text, text);
-
 CREATE FUNCTION grest.asset_summary (_asset_policy text, _asset_name text)
   RETURNS TABLE (
     policy_id text,

--- a/files/grest/rpc/assets/asset_txs.sql
+++ b/files/grest/rpc/assets/asset_txs.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.asset_txs (text, text);
-
 CREATE FUNCTION grest.asset_txs (_asset_policy text, _asset_name text)
   RETURNS TABLE (
     policy_id text,

--- a/files/grest/rpc/blocks/block_info.sql
+++ b/files/grest/rpc/blocks/block_info.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.block_info (_block_hashes text[]);
-
 CREATE FUNCTION grest.block_info (_block_hashes text[])
   RETURNS TABLE (
     hash text,

--- a/files/grest/rpc/blocks/block_txs.sql
+++ b/files/grest/rpc/blocks/block_txs.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.block_txs (_block_hash text);
-
 CREATE FUNCTION grest.block_txs (_block_hash text)
     RETURNS TABLE (
         TX_HASH text)

--- a/files/grest/rpc/epoch/epoch_info.sql
+++ b/files/grest/rpc/epoch/epoch_info.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.epoch_info (numeric);
-
 CREATE FUNCTION grest.epoch_info (_epoch_no numeric DEFAULT NULL)
   RETURNS TABLE (
     epoch_no uinteger,

--- a/files/grest/rpc/epoch/epoch_params.sql
+++ b/files/grest/rpc/epoch/epoch_params.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.epoch_params (numeric);
-
 CREATE FUNCTION grest.epoch_params (_epoch_no numeric DEFAULT NULL)
   RETURNS TABLE (
     epoch_no uinteger,

--- a/files/grest/rpc/pool/pool_blocks.sql
+++ b/files/grest/rpc/pool/pool_blocks.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.pool_blocks (text, uinteger);
-
 CREATE FUNCTION grest.pool_blocks (_pool_bech32 text, _epoch_no uinteger DEFAULT NULL)
     RETURNS TABLE (
         epoch_no uinteger,

--- a/files/grest/rpc/pool/pool_delegators.sql
+++ b/files/grest/rpc/pool/pool_delegators.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.pool_delegators (text, uinteger);
-
 CREATE FUNCTION grest.pool_delegators (_pool_bech32 text, _epoch_no uinteger DEFAULT NULL)
   RETURNS TABLE (
     stake_address character varying,

--- a/files/grest/rpc/pool/pool_history.sql
+++ b/files/grest/rpc/pool/pool_history.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.pool_history (text, uinteger);
-
 CREATE FUNCTION grest.pool_history (_pool_bech32 text, _epoch_no uinteger DEFAULT NULL)
   RETURNS TABLE (
     epoch_no bigint,

--- a/files/grest/rpc/pool/pool_info.sql
+++ b/files/grest/rpc/pool/pool_info.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.pool_info (text[]);
-
 CREATE FUNCTION grest.pool_info (_pool_bech32_ids text[])
   RETURNS TABLE (
     pool_id_bech32 character varying,

--- a/files/grest/rpc/pool/pool_list.sql
+++ b/files/grest/rpc/pool/pool_list.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.pool_list ();
-
 CREATE FUNCTION grest.pool_list ()
   RETURNS TABLE (
     pool_id_bech32 character varying,

--- a/files/grest/rpc/pool/pool_metadata.sql
+++ b/files/grest/rpc/pool/pool_metadata.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.pool_metadata ();
-
 CREATE FUNCTION grest.pool_metadata ()
     RETURNS TABLE (
         pool_id_bech32 character varying,

--- a/files/grest/rpc/pool/pool_relays.sql
+++ b/files/grest/rpc/pool/pool_relays.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.pool_relays ();
-
 CREATE FUNCTION grest.pool_relays ()
     RETURNS TABLE (
         pool_id_bech32 character varying,

--- a/files/grest/rpc/pool/pool_updates.sql
+++ b/files/grest/rpc/pool/pool_updates.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.pool_updates (text);
-
 CREATE FUNCTION grest.pool_updates (_pool_bech32 text DEFAULT NULL)
     RETURNS TABLE (
         tx_hash text,

--- a/files/grest/rpc/script/native_script_list.sql
+++ b/files/grest/rpc/script/native_script_list.sql
@@ -1,23 +1,22 @@
-DROP FUNCTION IF EXISTS grest.native_script_list ();
 CREATE FUNCTION grest.native_script_list ()
-RETURNS TABLE (
+  RETURNS TABLE (
     script_hash text,
     creation_tx_hash text,
     type scripttype,
     script jsonb
-)
+  )
 LANGUAGE PLPGSQL AS
 $$
 BEGIN 
-RETURN QUERY
-SELECT 
+  RETURN QUERY
+  SELECT 
     ENCODE(script.hash, 'hex'), 
     ENCODE(tx.hash, 'hex'),
     script.type,
     script.json
-FROM script
+  FROM script
     INNER JOIN tx ON tx.id = script.tx_id
-WHERE script.type IN ('timelock', 'multisig');
+  WHERE script.type IN ('timelock', 'multisig');
 END;
 $$;
 

--- a/files/grest/rpc/script/plutus_script_list.sql
+++ b/files/grest/rpc/script/plutus_script_list.sql
@@ -1,19 +1,18 @@
-DROP FUNCTION IF EXISTS grest.plutus_script_list ();
 CREATE FUNCTION grest.plutus_script_list ()
-RETURNS TABLE (
+  RETURNS TABLE (
     script_hash text,
     creation_tx_hash text
-)
+  )
 LANGUAGE PLPGSQL AS
 $$
 BEGIN 
-RETURN QUERY
-SELECT 
+  RETURN QUERY
+  SELECT 
     ENCODE(script.hash, 'hex') as script_hash, 
     ENCODE(tx.hash, 'hex') as creation_tx_hash
-FROM script
+  FROM script
     INNER JOIN tx ON tx.id = script.tx_id
-WHERE script.type = 'plutus';
+  WHERE script.type = 'plutus';
 END;
 $$;
 

--- a/files/grest/rpc/script/script_redeemers.sql
+++ b/files/grest/rpc/script/script_redeemers.sql
@@ -1,10 +1,8 @@
-DROP FUNCTION IF EXISTS grest.script_redeemers (_script_hash text);
-
 CREATE FUNCTION grest.script_redeemers (_script_hash text) 
-RETURNS TABLE (
+  RETURNS TABLE (
     script_hash text,
     redeemers json
-) 
+  ) 
 LANGUAGE PLPGSQL AS 
 $$
 DECLARE _script_hash_bytea bytea;

--- a/files/grest/rpc/transactions/tx_info.sql
+++ b/files/grest/rpc/transactions/tx_info.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.tx_info (text[]);
-
 CREATE FUNCTION grest.tx_info (_tx_hashes text[])
   RETURNS TABLE (
     tx_hash text,

--- a/files/grest/rpc/transactions/tx_metadata.sql
+++ b/files/grest/rpc/transactions/tx_metadata.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.tx_metadata (text[]);
-
 CREATE FUNCTION grest.tx_metadata (_tx_hashes text[])
   RETURNS TABLE (
     tx_hash text,

--- a/files/grest/rpc/transactions/tx_status.sql
+++ b/files/grest/rpc/transactions/tx_status.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.tx_status (_tx_hashes text[]);
-
 CREATE FUNCTION grest.tx_status (_tx_hashes text[])
     RETURNS TABLE (
         tx_hash text,

--- a/files/grest/rpc/transactions/tx_utxos.sql
+++ b/files/grest/rpc/transactions/tx_utxos.sql
@@ -1,5 +1,3 @@
-DROP FUNCTION IF EXISTS grest.tx_utxos (text[]);
-
 CREATE FUNCTION grest.tx_utxos (_tx_hashes text[])
   RETURNS TABLE (
     tx_hash text,

--- a/scripts/grest-helper-scripts/db-scripts/basics.sql
+++ b/scripts/grest-helper-scripts/db-scripts/basics.sql
@@ -101,8 +101,6 @@ END
 $do$;
 
 -- HELPER FUNCTIONS --
-DROP FUNCTION IF EXISTS grest.get_query_pids_partial_match (_query text);
-
 CREATE FUNCTION grest.get_query_pids_partial_match (_query text)
   RETURNS TABLE (
     pid integer)
@@ -142,8 +140,6 @@ BEGIN
 END;
 $$; */
 
-DROP FUNCTION IF EXISTS grest.get_current_epoch ();
-
 CREATE FUNCTION grest.get_current_epoch ()
   RETURNS integer
   LANGUAGE plpgsql
@@ -155,8 +151,6 @@ $$
     );
   END;
 $$;
-
-DROP FUNCTION IF EXISTS grest.get_epoch_stakes_count (integer);
 
 CREATE FUNCTION grest.get_epoch_stakes_count (_epoch_no integer)
   RETURNS integer
@@ -176,8 +170,6 @@ $$
     );
   END;
 $$;
-
-DROP FUNCTION IF EXISTS grest.update_control_table (text, text, text);
 
 CREATE FUNCTION grest.update_control_table (_key text, _last_value text, _artifacts text default null)
   RETURNS void


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
We want to simplify Koios deployments by not worrying about dropping each RPC function because this causes some issues when deployments include function parameters being added/removed or their types changes.

## Where should the reviewer start?
<!--- Describe where reviewer should start testing -->
The branch is ready to test with a simple `./setup-grest.sh -q`. All functions in `grest` schema will be dropped as part of the `setup_db_basics` step in the script.
The SQL output that will be executed (i.e. the functions that will be dropped) by the added step can be seen by running (with SQL execution commented out for debug):
```
DO
$do$
DECLARE
  _sql text;
BEGIN
  SELECT INTO _sql
    string_agg(
      format(
        'DROP %s %s CASCADE;',
        CASE prokind
            WHEN 'f' THEN 'FUNCTION'
            WHEN 'a' THEN 'AGGREGATE'
            WHEN 'p' THEN 'PROCEDURE'
            WHEN 'w' THEN 'FUNCTION'  -- window function (rarely applicable)
        END,
        oid::regprocedure
      ),
      E'\n'
    )
  FROM
    pg_proc
  WHERE
    pronamespace = 'grest'::regnamespace  -- schema name here
    AND prokind = ANY ('{f,a,p,w}');      -- optionally filter kinds

  IF _sql IS NOT NULL THEN
    RAISE NOTICE '%', _sql; -- debug
    --EXECUTE _sql;
  ELSE
    RAISE NOTICE 'No fuctions found in schema %', quote_ident('grest');
  END IF;
END
$do$;

NOTICE:  DROP FUNCTION grest.plutus_script_list() CASCADE;
DROP FUNCTION grest.get_query_pids_partial_match(text) CASCADE;
DROP FUNCTION grest.get_current_epoch() CASCADE;
DROP FUNCTION grest.get_epoch_stakes_count(integer) CASCADE;
DROP FUNCTION grest.update_control_table(text,text,text) CASCADE;
DROP FUNCTION grest.tx_info(text[]) CASCADE;
DROP FUNCTION grest.get_last_active_stake_validated_epoch() CASCADE;
DROP FUNCTION grest.active_stake_cache_update_check() CASCADE;
DROP FUNCTION grest.active_stake_cache_update(integer) CASCADE;
DROP FUNCTION grest.epoch_info_cache_update(bigint) CASCADE;
DROP FUNCTION grest.update_latest_epoch_info_cache(bigint) CASCADE;
DROP FUNCTION grest.pool_history_cache_update(bigint) CASCADE;
DROP FUNCTION grest.tx_metadata(text[]) CASCADE;
DROP PROCEDURE grest.update_stake_distribution_cache() CASCADE;
DROP FUNCTION grest.stake_distribution_cache_update_check() CASCADE;
DROP FUNCTION grest.tx_status(text[]) CASCADE;
DROP FUNCTION grest.script_redeemers(text) CASCADE;
DROP FUNCTION grest.tip() CASCADE;
DROP FUNCTION grest.totals(numeric) CASCADE;
DROP FUNCTION grest.asset_registry_cache_update(text,text,text,text,text,text,text,uinteger) CASCADE;
DROP FUNCTION grest.pool_info_insert(bigint,bigint,bigint,bigint,hash32type,double precision,lovelace,lovelace,addr29type,bigint) CASCADE;
DROP FUNCTION grest.pool_info_retire_status() CASCADE;
DROP FUNCTION grest.pool_info_retire_update() CASCADE;
DROP FUNCTION grest.credential_txs(text[],integer) CASCADE;
DROP FUNCTION grest.pool_info_update() CASCADE;
DROP FUNCTION grest.account_addresses(text) CASCADE;
DROP FUNCTION grest.account_assets(text) CASCADE;
DROP FUNCTION grest.account_history(text,integer) CASCADE;
DROP FUNCTION grest.asset_address_list(text,text) CASCADE;
DROP FUNCTION grest.account_info(text) CASCADE;
DROP FUNCTION grest.account_rewards(text,numeric) CASCADE;
DROP FUNCTION grest.account_updates(text) CASCADE;
DROP FUNCTION grest.address_assets(text) CASCADE;
DROP FUNCTION grest.address_info(text) CASCADE;
DROP FUNCTION grest.address_txs(text[],integer) CASCADE;
DROP FUNCTION grest.asset_history(text,text) CASCADE;
DROP FUNCTION grest.asset_info(text,text) CASCADE;
DROP FUNCTION grest.asset_policy_info(text) CASCADE;
DROP FUNCTION grest.asset_summary(text,text) CASCADE;
DROP FUNCTION grest.asset_txs(text,text) CASCADE;
DROP FUNCTION grest.pool_relays() CASCADE;
DROP FUNCTION grest.block_info(text[]) CASCADE;
DROP FUNCTION grest.block_txs(text) CASCADE;
DROP FUNCTION grest.epoch_info(numeric) CASCADE;
DROP FUNCTION grest.epoch_params(numeric) CASCADE;
DROP FUNCTION grest.pool_blocks(text,uinteger) CASCADE;
DROP FUNCTION grest.native_script_list() CASCADE;
DROP FUNCTION grest.pool_delegators(text,uinteger) CASCADE;
DROP FUNCTION grest.pool_history(text,uinteger) CASCADE;
DROP FUNCTION grest.pool_info(text[]) CASCADE;
DROP FUNCTION grest.pool_list() CASCADE;
DROP FUNCTION grest.pool_metadata() CASCADE;
DROP FUNCTION grest.pool_updates(text) CASCADE;
DROP FUNCTION grest.tx_utxos(text[]) CASCADE;
DO
```
## Motivation and context
<!--- Why is this change required? What problem does it solve? -->

## Which issue it fixes?
<!--- Link to issue: Closes #issue-number -->
Closes #1349

## How has this been tested?
<!--- Describe how you tested changes -->
Close attention should be paid to database triggers which are also dropped due to `CASCADE`. They are automatically recreated with the `-q` parameter so it should not be a problem. Essentially we were dropping them the same way before, this just removes the need to write each `DROP` statement manually.
Still, attention should be paid to not allow these DROP statements to have unwanted effects, particularly on cache tables. So far I couldn't think of an edge-case scenario where the above would cause issues.