### PR TITLE
Add setting to filter peers based on uniqueness of ip or ip:port

### DIFF
--- a/docs/Scripts/cntools-changelog.md
+++ b/docs/Scripts/cntools-changelog.md
@@ -6,6 +6,10 @@ All notable changes to this tool will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.0.9] - 2022-03-14
+#### Changed
+- Add version (-v) argument to cntools script to print current version
+
 ## [9.0.8] - 2022-03-07
 #### Changed
 - Remove HASH_IDENTIFIER variable references (Ddz issue which required this seperation was resolved a while ago)

--- a/scripts/cnode-helper-scripts/cncli.sh
+++ b/scripts/cnode-helper-scripts/cncli.sh
@@ -35,7 +35,7 @@ usage() {
 		Usage: $(basename "$0") [operation <sub arg>]
 		Script to run CNCLI, best launched through systemd deployed by 'deploy-as-systemd.sh'
 		
-    -u          Skip script update check overriding UPDATE_CHECK value in env (must be first argument to script)
+		-u          Skip script update check overriding UPDATE_CHECK value in env (must be first argument to script)
 
 		sync        Start CNCLI chainsync process that connects to cardano-node to sync blocks stored in SQLite DB (deployed as service)
 		leaderlog   One-time leader schedule calculation for current epoch, then continously monitors and calculates schedule for coming epochs, 1.5 days before epoch boundary on MainNet (deployed as service)

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -11,7 +11,7 @@ CNTOOLS_MAJOR_VERSION=9
 # Minor: Changes and features of minor character that can be applied without breaking existing functionality or workflow
 CNTOOLS_MINOR_VERSION=0
 # Patch: Backwards compatible bug fixes. No additional functionality or major changes
-CNTOOLS_PATCH_VERSION=8
+CNTOOLS_PATCH_VERSION=9
 
 CNTOOLS_VERSION="${CNTOOLS_MAJOR_VERSION}.${CNTOOLS_MINOR_VERSION}.${CNTOOLS_PATCH_VERSION}"
 

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -79,14 +79,14 @@ myExit() {
 
 usage() {
   cat <<-EOF
-		Usage: $(basename "$0") [-o] [-a] [-b <branch name>]
+		Usage: $(basename "$0") [-o] [-a] [-b <branch name>] [-v]
 		CNTools - The Cardano SPOs best friend
 		
 		-o    Activate offline mode - run CNTools in offline mode without node access, a limited set of functions available
 		-a    Enable advanced/developer features like metadata transactions, multi-asset management etc (not needed for SPO usage)
-    -u    Skip script update check overriding UPDATE_CHECK value in env
+		-u    Skip script update check overriding UPDATE_CHECK value in env
 		-b    Run CNTools and look for updates on alternate branch instead of master of guild repository (only for testing/development purposes)
-    -v    Print CNTools version
+		-v    Print CNTools version
 		
 		EOF
 }

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -86,6 +86,7 @@ usage() {
 		-a    Enable advanced/developer features like metadata transactions, multi-asset management etc (not needed for SPO usage)
     -u    Skip script update check overriding UPDATE_CHECK value in env
 		-b    Run CNTools and look for updates on alternate branch instead of master of guild repository (only for testing/development purposes)
+    -v    Print CNTools version
 		
 		EOF
 }
@@ -93,6 +94,7 @@ usage() {
 CNTOOLS_MODE="CONNECTED"
 ADVANCED_MODE="false"
 SKIP_UPDATE=N
+PRINT_VERSION="false"
 PARENT="$(dirname $0)"
 [[ -f "${PARENT}"/.env_branch ]] && BRANCH="$(cat "${PARENT}"/.env_branch)" || BRANCH="master"
 
@@ -102,6 +104,7 @@ while getopts :oaub: opt; do
     a ) ADVANCED_MODE="true" ;;
     u ) SKIP_UPDATE=Y ;;
     b ) echo "${OPTARG}" > "${PARENT}"/.env_branch ;;
+    v ) PRINT_VERSION="true" ;;
     \? ) myExit 1 "$(usage)" ;;
     esac
 done
@@ -127,6 +130,8 @@ fi
 
 # get helper functions from library file
 ! . "${PARENT}"/cntools.library && myExit 1
+
+[[ ${PRINT_VERSION} = "true" ]] && echo -e "\nCNTools v${CNTOOLS_VERSION} (branch: $([[ -f "${PARENT}"/.env_branch ]] && cat "${PARENT}"/.env_branch || echo "master"))\n" && exit 0
 
 archiveLog # archive current log and cleanup log archive folder
 

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -238,11 +238,8 @@ if [[ ${CHECK_KES} = true ]]; then
 
   while IFS= read -r -d '' pool; do
     unset pool_kes_start
-    if [[ ${CNTOOLS_MODE} = "CONNECTED" ]]; then
-      getNodeMetrics
-    else
-      [[ -f "${pool}/${POOL_CURRENT_KES_START}" ]] && pool_kes_start="$(cat "${pool}/${POOL_CURRENT_KES_START}")"
-    fi
+    [[ ${CNTOOLS_MODE} = "CONNECTED" ]] && getNodeMetrics
+    [[ (-z ${remaining_kes_periods} || ${remaining_kes_periods} -eq 0) && -f "${pool}/${POOL_CURRENT_KES_START}" ]] && pool_kes_start="$(cat "${pool}/${POOL_CURRENT_KES_START}")"  
   
     if ! kesExpiration ${pool_kes_start}; then println ERROR "${FG_RED}ERROR${NC}: failure during KES calculation for ${FG_GREEN}$(basename ${pool})${NC}" && waitForInput && continue; fi
 

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -98,7 +98,7 @@ PRINT_VERSION="false"
 PARENT="$(dirname $0)"
 [[ -f "${PARENT}"/.env_branch ]] && BRANCH="$(cat "${PARENT}"/.env_branch)" || BRANCH="master"
 
-while getopts :oaub: opt; do
+while getopts :oaub:v opt; do
   case ${opt} in
     o ) CNTOOLS_MODE="OFFLINE" ;;
     a ) ADVANCED_MODE="true" ;;

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -131,7 +131,7 @@ fi
 # get helper functions from library file
 ! . "${PARENT}"/cntools.library && myExit 1
 
-[[ ${PRINT_VERSION} = "true" ]] && echo -e "\nCNTools v${CNTOOLS_VERSION} (branch: $([[ -f "${PARENT}"/.env_branch ]] && cat "${PARENT}"/.env_branch || echo "master"))\n" && exit 0
+[[ ${PRINT_VERSION} = "true" ]] && myExit 0 "CNTools v${CNTOOLS_VERSION} (branch: $([[ -f "${PARENT}"/.env_branch ]] && cat "${PARENT}"/.env_branch || echo "master"))"
 
 archiveLog # archive current log and cleanup log archive folder
 
@@ -239,7 +239,7 @@ if [[ ${CHECK_KES} = true ]]; then
   while IFS= read -r -d '' pool; do
     unset pool_kes_start
     [[ ${CNTOOLS_MODE} = "CONNECTED" ]] && getNodeMetrics
-    [[ (-z ${remaining_kes_periods} || ${remaining_kes_periods} -eq 0) && -f "${pool}/${POOL_CURRENT_KES_START}" ]] && pool_kes_start="$(cat "${pool}/${POOL_CURRENT_KES_START}")"  
+    [[ (-z ${remaining_kes_periods} || ${remaining_kes_periods} -eq 0) && -f "${pool}/${POOL_CURRENT_KES_START}" ]] && unset remaining_kes_periods && pool_kes_start="$(cat "${pool}/${POOL_CURRENT_KES_START}")"  
   
     if ! kesExpiration ${pool_kes_start}; then println ERROR "${FG_RED}ERROR${NC}: failure during KES calculation for ${FG_GREEN}$(basename ${pool})${NC}" && waitForInput && continue; fi
 

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -179,8 +179,8 @@ if [[ ${CNTOOLS_MODE} = "CONNECTED" ]]; then
       1) checkUpdate "${PARENT}"/cntools.sh Y
          if [[ $? = 2 ]]; then
            echo -e "\n${FG_RED}ERROR${NC}: Update check of cntools.sh against GitHub failed!"
+           waitToProceed
          fi
-         waitToProceed
          $0 "$@" "-u"; myExit 0 ;; # re-launch script with same args skipping update check
       2) echo -e "\n${FG_RED}ERROR${NC}: Update check of cntools.library against GitHub failed!"
          waitToProceed ;;

--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -17,7 +17,7 @@ THEME="dark"                              # dark  = suited for terminals with a 
 #ENABLE_IP_GEOLOCATION="Y"                # Enable IP geolocation on outgoing and incoming connections using ip-api.com (default: Y)
 #LATENCY_TOOLS="cncli|ss|tcptraceroute|ping" # Preferred latency check tool order, valid entries: cncli|ss|tcptraceroute|ping (must be separated by |)
 #CNCLI_CONNECT_ONLY=false                 # By default cncli measure full connect handshake duration. If set to false, only connect is measured similar to other tools
-#HIDE_DUPLICATE_IPS="N"                   # If set to 'Y', duplicate IP's will be filtered out in peer analysis, else unique ip:port entries are shown (default: N)
+#HIDE_DUPLICATE_IPS="Y"                   # If set to 'Y', duplicate IP's will be filtered out in peer analysis, else unique ip:port entries are shown (default: Y)
 
 #####################################
 # Themes                            #
@@ -176,6 +176,8 @@ declare -gA geoIP=()
 [[ -z ${LATENCY_TOOLS} ]] && LATENCY_TOOLS="cncli|ss|tcptraceroute|ping"
 
 [[ -z ${CNCLI_CONNECT_ONLY} ]] && CNCLI_CONNECT_ONLY=false
+
+[[ -z ${HIDE_DUPLICATE_IPS} ]] && HIDE_DUPLICATE_IPS=Y
 
 #######################################################
 # Style / UI                                          #
@@ -486,11 +488,14 @@ checkPeers() {
       continue
     fi
 
-    [[ ${HIDE_DUPLICATE_IPS} = 'Y' ]] && matchStr="${peerIP};" || matchStr="${peerIP};${peerPORT};"
-    local peerIndex=$(getArrayIndex "${matchStr}" "${peersFiltered[@]}")
-    if [[ ${peerIndex} -ge 0 ]]; then
-      if [[ ${peersFiltered[$peerIndex]} != *o ]]; then
-        peersFiltered[$peerIndex]="${peerIP};${peerPORT};i+o"
+    if [[ ${HIDE_DUPLICATE_IPS} = 'Y' ]]; then
+      local peerIndex=$(getArrayIndex "${peerIP};" "${peersFiltered[@]}")
+      if [[ ${peerIndex} -ge 0 ]]; then
+        if [[ ${peersFiltered[$peerIndex]} != *o ]]; then
+          peersFiltered[$peerIndex]="${peerIP};${peerPORT};i+o"
+        fi
+      else
+        peersFiltered+=("${peerIP};${peerPORT};o")
       fi
     else
       peersFiltered+=("${peerIP};${peerPORT};o")

--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -17,7 +17,7 @@ THEME="dark"                              # dark  = suited for terminals with a 
 #ENABLE_IP_GEOLOCATION="Y"                # Enable IP geolocation on outgoing and incoming connections using ip-api.com (default: Y)
 #LATENCY_TOOLS="cncli|ss|tcptraceroute|ping" # Preferred latency check tool order, valid entries: cncli|ss|tcptraceroute|ping (must be separated by |)
 #CNCLI_CONNECT_ONLY=false                 # By default cncli measure full connect handshake duration. If set to false, only connect is measured similar to other tools
-#HIDE_DUPLICATE_IPS="Y"                   # If set to 'Y', duplicate IP's will be filtered out in peer analysis, else unique ip:port entries are shown (default: Y)
+#HIDE_DUPLICATE_IPS="N"                   # If set to 'Y', duplicate IP's will be filtered out in peer analysis, else unique ip:port entries are shown (default: N)
 
 #####################################
 # Themes                            #
@@ -177,7 +177,7 @@ declare -gA geoIP=()
 
 [[ -z ${CNCLI_CONNECT_ONLY} ]] && CNCLI_CONNECT_ONLY=false
 
-[[ -z ${HIDE_DUPLICATE_IPS} ]] && HIDE_DUPLICATE_IPS=Y
+[[ -z ${HIDE_DUPLICATE_IPS} ]] && HIDE_DUPLICATE_IPS=N
 
 #######################################################
 # Style / UI                                          #

--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -70,9 +70,9 @@ usage() {
 		Guild LiveView - An alternative cardano-node LiveView
 
 		-l    Activate legacy mode - standard ASCII characters instead of box-drawing characters
-    -u    Skip script update check overriding UPDATE_CHECK value in env
+		-u    Skip script update check overriding UPDATE_CHECK value in env
 		-b    Use alternate branch to check for updates - only for testing/development (Default: Master)
-    -v    Print Guild LiveView version
+		-v    Print Guild LiveView version
 		EOF
   exit 1
 }

--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -424,8 +424,8 @@ getArrayIndex () {
   local match=$1
   shift
   arr=("$@")
-  for i in "${!arr[@]}"; do [[ $e = ${arr[$i]} ]] && return $i; done
-  return -1
+  for i in "${!arr[@]}"; do [[ ${arr[$i]} = *"${match}"* ]] && echo $i && return; done
+  echo -1
 }
 
 # Command    : checkPeers

--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -72,17 +72,19 @@ usage() {
 		-l    Activate legacy mode - standard ASCII characters instead of box-drawing characters
     -u    Skip script update check overriding UPDATE_CHECK value in env
 		-b    Use alternate branch to check for updates - only for testing/development (Default: Master)
+    -v    Print Guild LiveView version
 		EOF
   exit 1
 }
 
 SKIP_UPDATE=N
 
-while getopts :lub: opt; do
+while getopts :lub:v opt; do
   case ${opt} in
     l ) LEGACY_MODE="true" ;;
     u ) SKIP_UPDATE=Y ;;
     b ) echo "${OPTARG}" > "${PARENT}"/.env_branch ;;
+    v ) echo -e "\nGuild LiveView ${GLV_VERSION} (branch: $([[ -f "${PARENT}"/.env_branch ]] && cat "${PARENT}"/.env_branch || echo "master"))\n"; exit 0 ;;
     \? ) usage ;;
   esac
 done

--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -66,7 +66,7 @@ PARENT="$(dirname $0)"
 
 usage() {
   cat <<-EOF
-		Usage: $(basename "$0") [-l] [-p] [-b <branch name>]
+		Usage: $(basename "$0") [-l] [-p] [-b <branch name>] [-v]
 		Guild LiveView - An alternative cardano-node LiveView
 
 		-l    Activate legacy mode - standard ASCII characters instead of box-drawing characters

--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -17,7 +17,7 @@ THEME="dark"                              # dark  = suited for terminals with a 
 #ENABLE_IP_GEOLOCATION="Y"                # Enable IP geolocation on outgoing and incoming connections using ip-api.com (default: Y)
 #LATENCY_TOOLS="cncli|ss|tcptraceroute|ping" # Preferred latency check tool order, valid entries: cncli|ss|tcptraceroute|ping (must be separated by |)
 #CNCLI_CONNECT_ONLY=false                 # By default cncli measure full connect handshake duration. If set to false, only connect is measured similar to other tools
-#HIDE_DUPLICATE_IPS="N"                   # If set to 'Y', duplicate IP's will be filtered out in peer analysis, else unique ip:port entries are shown (default: N)
+#HIDE_DUPLICATE_IPS="N"                   # If set to 'Y', duplicate and local IP's will be filtered out in peer analysis, else all connected peers are shown (default: N)
 
 #####################################
 # Themes                            #
@@ -463,7 +463,7 @@ checkPeers() {
       peerPORT=$(cut -d: -f2 <<< "${peer}")
     fi
 
-    if [[ -z ${peerIP} || -z ${peerPORT} || ${peerIP} = 127.0.0.1 || (${peerIP} = ${ext_ip_resolve} && ${peerPORT} = ${CNODE_PORT}) ]]; then
+    if [[ -z ${peerIP} || -z ${peerPORT} || (${HIDE_DUPLICATE_IPS} = 'Y' && ${peerIP} = 127.0.0.1) || (${HIDE_DUPLICATE_IPS} = 'Y' && ${peerIP} = ${ext_ip_resolve} && ${peerPORT} = ${CNODE_PORT}) ]]; then
       continue
     fi
 
@@ -484,7 +484,7 @@ checkPeers() {
       peerPORT=$(cut -d: -f2 <<< "${peer}")
     fi
 
-    if [[ -z ${peerIP} || -z ${peerPORT} || ${peerIP} = 127.0.0.1 || (${peerIP} = ${ext_ip_resolve} && ${peerPORT} = ${CNODE_PORT}) ]]; then
+    if [[ -z ${peerIP} || -z ${peerPORT} || (${HIDE_DUPLICATE_IPS} = 'Y' && ${peerIP} = 127.0.0.1) || (${HIDE_DUPLICATE_IPS} = 'Y' && ${peerIP} = ${ext_ip_resolve} && ${peerPORT} = ${CNODE_PORT}) ]]; then
       continue
     fi
 

--- a/scripts/cnode-helper-scripts/topologyUpdater.sh
+++ b/scripts/cnode-helper-scripts/topologyUpdater.sh
@@ -30,7 +30,7 @@ usage() {
 
 		-f    Disable fetch of a fresh topology file
 		-p    Disable node alive push to Topology Updater API
-    -u    Skip script update check overriding UPDATE_CHECK value in env
+		-u    Skip script update check overriding UPDATE_CHECK value in env
 		-b    Use alternate branch to check for updates - only for testing/development (Default: master)
 		
 		EOF


### PR DESCRIPTION
## Description
It was requested by users to not filter peers in peer analysis by the uniqueness of IP, and instead, show all connected peers, even if multiple from same IP or local. A new setting is added(default `N`) called `HIDE_DUPLICATE_IPS` which, if set to Y, is the old behavior filtering out all duplicates of the same IP as well as local connections. 