### PR TITLE
fix(cncli): replace hardcoded cncliSync host

### DIFF
--- a/scripts/cnode-helper-scripts/cncli.sh
+++ b/scripts/cnode-helper-scripts/cncli.sh
@@ -207,7 +207,7 @@ cncliInit() {
 #################################
 
 cncliSync() {
-  ${CNCLI} sync --host 127.0.0.1 --network-magic "${NWMAGIC}" --port "${CNODE_PORT}" --db "${CNCLI_DB}"
+  ${CNCLI} sync --host "${PT_HOST}" --network-magic "${NWMAGIC}" --port "${CNODE_PORT}" --db "${CNCLI_DB}"
 }
 
 #################################


### PR DESCRIPTION
Use env $PT_HOST from User Variables instead of hardcoded value.
defaults to 127.0.0.1

## Description
<!--- Describe your changes -->

## Where should the reviewer start?
<!--- Describe where reviewer should start testing -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->

## Which issue it fixes?
<!--- Link to issue: Closes #issue-number -->

## How has this been tested?
<!--- Describe how you tested changes -->
