### PR TITLE
[RPC] Cast metadata keys to strings

### DIFF
--- a/files/grest/rpc/assets/asset_info.sql
+++ b/files/grest/rpc/assets/asset_info.sql
@@ -48,7 +48,7 @@ BEGIN
     (
       SELECT
         JSON_BUILD_OBJECT(
-          'key', TM.key,
+          'key', TM.key::text,
           'json', TM.json
         )
       FROM

--- a/files/grest/rpc/assets/asset_policy_info.sql
+++ b/files/grest/rpc/assets/asset_policy_info.sql
@@ -18,7 +18,7 @@ BEGIN
         SELECT DISTINCT ON (MTM.ident)
           MTM.ident,
           JSON_BUILD_OBJECT(
-            'key', TM.key,
+            'key', TM.key::text,
             'json', TM.json
           ) AS metadata
         FROM

--- a/files/grest/rpc/transactions/tx_info.sql
+++ b/files/grest/rpc/transactions/tx_info.sql
@@ -216,7 +216,7 @@ BEGIN
           SELECT
             TM.tx_id,
             JSON_BUILD_OBJECT(
-              'key', TM.key,
+              'key', TM.key::text,
               'json', TM.json
             ) AS data
           FROM 

--- a/files/grest/rpc/transactions/tx_metadata.sql
+++ b/files/grest/rpc/transactions/tx_metadata.sql
@@ -23,7 +23,10 @@ BEGIN
           UNNEST(_tx_hashes) AS hashes)) T1
   LEFT JOIN LATERAL (
     SELECT
-      JSON_OBJECT_AGG(tx_metadata.key, tx_metadata.json) as metadata
+      JSON_OBJECT_AGG(
+        tx_metadata.key::text,
+        tx_metadata.json
+      ) as metadata
     FROM
       tx_metadata
     WHERE

--- a/files/grest/rpc/views/tx_metalabels.sql
+++ b/files/grest/rpc/views/tx_metalabels.sql
@@ -1,7 +1,7 @@
 DROP VIEW IF EXISTS grest.tx_metalabels;
 
 CREATE VIEW grest.tx_metalabels AS SELECT DISTINCT
-  key as metalabel
+  key::text as metalabel
 FROM
   public.tx_metadata;
 


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Endpoints returning metadata keys will now return their values as strings instead of integers.

Associated schema update PR: https://github.com/cardano-community/koios-artifacts/pull/19

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
Easier client-side handling.

## How has this been tested?
<!--- Describe how you tested changes -->
Check that the changed endpoint returns the key value as a string.