### PR TITLE
Add _pool_bech32_id argument for /rpc/pool_metadata endpoint

### DIFF
--- a/files/grest/rpc/pool/pool_metadata.sql
+++ b/files/grest/rpc/pool/pool_metadata.sql
@@ -1,4 +1,4 @@
-CREATE FUNCTION grest.pool_metadata ()
+CREATE FUNCTION grest.pool_metadata (_pool_bech32_ids text[])
     RETURNS TABLE (
         pool_id_bech32 character varying,
         meta_url character varying,
@@ -21,9 +21,12 @@ BEGIN
         public.pool_offline_data AS pod ON pod.pmr_id = pic.meta_id
     WHERE
         pic.pool_status != 'retired'
+        AND
+        pic.pool_id_bech32 = ANY(SELECT UNNEST(_pool_bech32_ids))
     ORDER BY
         pic.pool_id_bech32, pic.tx_id DESC;
 END;
 $$;
+CREATE FUNCTION
 
 COMMENT ON FUNCTION grest.pool_metadata IS 'Metadata(on & off-chain) for all currently registered/retiring (not retired) pools';

--- a/files/grest/rpc/pool/pool_metadata.sql
+++ b/files/grest/rpc/pool/pool_metadata.sql
@@ -1,4 +1,4 @@
-CREATE FUNCTION grest.pool_metadata (_pool_bech32_ids text[])
+CREATE FUNCTION grest.pool_metadata (_pool_bech32_ids text[] DEFAULT null)
     RETURNS TABLE (
         pool_id_bech32 character varying,
         meta_url character varying,
@@ -22,11 +22,13 @@ BEGIN
     WHERE
         pic.pool_status != 'retired'
         AND
-        pic.pool_id_bech32 = ANY(SELECT UNNEST(_pool_bech32_ids))
+        CASE
+            WHEN _pool_bech32_ids IS NULL THEN true
+            WHEN _pool_bech32_ids IS NOT NULL THEN pic.pool_id_bech32 = ANY(SELECT UNNEST(_pool_bech32_ids))
+        END
     ORDER BY
         pic.pool_id_bech32, pic.tx_id DESC;
 END;
 $$;
-CREATE FUNCTION
 
 COMMENT ON FUNCTION grest.pool_metadata IS 'Metadata(on & off-chain) for all currently registered/retiring (not retired) pools';


### PR DESCRIPTION
## Description

I've added support for pool filtering while retrieving metadata [in the same way](https://github.com/cardano-community/guild-operators/blob/alpha/files/grest/rpc/pool/pool_info.sql#L1) it's implemented in the `/rpc/pool_info` endpoint

## Motivation and context

I thought it would be handy :)
