### PR TITLE
Bump shutdown time for cnode.sh to 60s

### DIFF
--- a/scripts/cnode-helper-scripts/cnode.sh
+++ b/scripts/cnode-helper-scripts/cnode.sh
@@ -71,7 +71,7 @@ deploy_systemd() {
 	[Service]
 	Type=simple
 	Restart=always
-	RestartSec=5
+	RestartSec=60
 	User=${USER}
 	LimitNOFILE=1048576
 	WorkingDirectory=${CNODE_HOME}/scripts
@@ -82,7 +82,7 @@ deploy_systemd() {
 	StandardOutput=syslog
 	StandardError=syslog
 	SyslogIdentifier=${CNODE_VNAME}
-	TimeoutStopSec=5
+	TimeoutStopSec=60
 	KillMode=mixed
 	
 	[Install]


### PR DESCRIPTION
There is not scientifically proven theory around that shutdown in 5s causes node to not go down clean enough, and 30s works better (personally, I've found that when at times doing SIGINT at terminal , and letting it take it's time still resulted in wierd shutdown state, but assuming the experience of others is true, 5s is possibly too short)