### PR TITLE
Fix for pool_info, meta_json being null for some pools

### DIFF
--- a/files/grest/rpc/pool/pool_info.sql
+++ b/files/grest/rpc/pool/pool_info.sql
@@ -1,3 +1,4 @@
+DROP FUNCTION IF EXISTS grest.pool_info;
 CREATE FUNCTION grest.pool_info (_pool_bech32_ids text[])
   RETURNS TABLE (
     pool_id_bech32 character varying,
@@ -67,7 +68,7 @@ BEGIN
   FROM
     grest.pool_info_cache AS pic
   LEFT JOIN
-    public.pool_offline_data AS pod ON pod.pmr_id = pic.meta_id
+    public.pool_offline_data AS pod ON pic.pool_hash_id = pod.pool_id
   LEFT JOIN LATERAL (
     SELECT
       SUM(COUNT(b.id)) OVER () AS cnt,
@@ -118,7 +119,7 @@ BEGIN
     pic.pool_id_bech32 = ANY(SELECT UNNEST(_pool_bech32_ids))
   ORDER BY
     pic.pool_id_bech32,
-    pic.tx_id DESC;
+    pic.tx_id, pod.pmr_id DESC;
 END;
 $$;
 


### PR DESCRIPTION
pmr_id in pod may not always exist, given the size of pod - best to use latest entry instead