### PR TITLE
[RPC] Asset endpoints update

### DIFF
--- a/files/grest/rpc/assets/asset_address_list.sql
+++ b/files/grest/rpc/assets/asset_address_list.sql
@@ -1,4 +1,4 @@
-CREATE FUNCTION grest.asset_address_list (_asset_policy text, _asset_name text)
+CREATE FUNCTION grest.asset_address_list (_asset_policy text, _asset_name text default '')
   RETURNS TABLE (
     payment_address varchar,
     quantity text
@@ -10,7 +10,14 @@ DECLARE
   _asset_id int;
 BEGIN
   SELECT DECODE(_asset_policy, 'hex') INTO _asset_policy_decoded;
-  SELECT DECODE(_asset_name, 'hex') INTO _asset_name_decoded;
+  SELECT DECODE(
+    CASE WHEN _asset_name IS NULL
+      THEN ''
+    ELSE
+      _asset_name
+    END,
+    'hex'
+  ) INTO _asset_name_decoded;
   SELECT id INTO _asset_id FROM multi_asset MA WHERE MA.policy = _asset_policy_decoded AND MA.name = _asset_name_decoded;
 
   RETURN QUERY

--- a/files/grest/rpc/assets/asset_history.sql
+++ b/files/grest/rpc/assets/asset_history.sql
@@ -1,4 +1,4 @@
-CREATE FUNCTION grest.asset_history (_asset_policy text, _asset_name text)
+CREATE FUNCTION grest.asset_history (_asset_policy text, _asset_name text default '')
   RETURNS TABLE (
     policy_id text,
     asset_name text,
@@ -12,7 +12,14 @@ DECLARE
   _asset_id int;
 BEGIN
   SELECT DECODE(_asset_policy, 'hex') INTO _asset_policy_decoded;
-  SELECT DECODE(_asset_name, 'hex') INTO _asset_name_decoded;
+  SELECT DECODE(
+    CASE WHEN _asset_name IS NULL
+      THEN ''
+    ELSE
+      _asset_name
+    END,
+    'hex'
+  ) INTO _asset_name_decoded;
   SELECT
     id
   INTO

--- a/files/grest/rpc/assets/asset_info.sql
+++ b/files/grest/rpc/assets/asset_info.sql
@@ -1,4 +1,4 @@
-CREATE FUNCTION grest.asset_info (_asset_policy text, _asset_name text)
+CREATE FUNCTION grest.asset_info (_asset_policy text, _asset_name text default '')
   RETURNS TABLE (
     policy_id text,
     asset_name text,
@@ -20,7 +20,14 @@ DECLARE
   _asset_id int;
 BEGIN
   SELECT DECODE(_asset_policy, 'hex') INTO _asset_policy_decoded;
-  SELECT DECODE(_asset_name, 'hex') INTO _asset_name_decoded;
+  SELECT DECODE(
+    CASE WHEN _asset_name IS NULL
+      THEN ''
+    ELSE
+      _asset_name
+    END,
+    'hex'
+  ) INTO _asset_name_decoded;
   SELECT id INTO _asset_id FROM multi_asset MA WHERE MA.policy = _asset_policy_decoded AND MA.name = _asset_name_decoded;
 
   RETURN QUERY

--- a/files/grest/rpc/assets/asset_summary.sql
+++ b/files/grest/rpc/assets/asset_summary.sql
@@ -1,4 +1,4 @@
-CREATE FUNCTION grest.asset_summary (_asset_policy text, _asset_name text)
+CREATE FUNCTION grest.asset_summary (_asset_policy text, _asset_name text default '')
   RETURNS TABLE (
     policy_id text,
     asset_name text,
@@ -14,7 +14,14 @@ DECLARE
   _asset_id int;
 BEGIN
   SELECT DECODE(_asset_policy, 'hex') INTO _asset_policy_decoded;
-  SELECT DECODE(_asset_name, 'hex') INTO _asset_name_decoded;
+  SELECT DECODE(
+    CASE WHEN _asset_name IS NULL
+      THEN ''
+    ELSE
+      _asset_name
+    END,
+    'hex'
+  ) INTO _asset_name_decoded;
   SELECT id INTO _asset_id FROM multi_asset MA WHERE MA.policy = _asset_policy_decoded AND MA.name = _asset_name_decoded;
 
 RETURN QUERY

--- a/files/grest/rpc/assets/asset_txs.sql
+++ b/files/grest/rpc/assets/asset_txs.sql
@@ -1,4 +1,4 @@
-CREATE FUNCTION grest.asset_txs (_asset_policy text, _asset_name text)
+CREATE FUNCTION grest.asset_txs (_asset_policy text, _asset_name text default '')
   RETURNS TABLE (
     policy_id text,
     asset_name text,
@@ -12,7 +12,14 @@ DECLARE
   _asset_id int;
 BEGIN
   SELECT DECODE(_asset_policy, 'hex') INTO _asset_policy_decoded;
-  SELECT DECODE(_asset_name, 'hex') INTO _asset_name_decoded;
+  SELECT DECODE(
+    CASE WHEN _asset_name IS NULL
+      THEN ''
+    ELSE
+      _asset_name
+    END,
+    'hex'
+  ) INTO _asset_name_decoded;
   SELECT id INTO _asset_id FROM multi_asset MA WHERE MA.policy = _asset_policy_decoded AND MA.name = _asset_name_decoded;
 
   RETURN QUERY


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
1. All asset endpoints now apply a default empty string for the `_asset_name` parameter if not provided. If `NULL` is provided, it is also defaulted to empty string. Passing in an empty string `''` was working before and is working now.

2. `/asset_policy_info` now returns a table of assets which means that postgREST features like pagination and horizontal/vertical filtering can now be applied to this endpoint.

## Where should the reviewer start? 
<!--- Describe where reviewer should start testing -->
Check the 3 cases for empty string: `NULL`, not specified, and `''` return correct values for asset endpoints.

Check that `/asset_policy_info` returns new schema that supports postgREST features.

## Which issue it fixes?
<!--- Link to issue: Closes #issue-number -->
1. Closes [#31](https://github.com/cardano-community/koios-artifacts/issues/31)
2. Closes [#32](https://github.com/cardano-community/koios-artifacts/issues/32)

## How has this been tested?
<!--- Describe how you tested changes -->
Changes were tested on guildnet.


Note: this PR brings API schema changes which need to be updated on the [koios-artifacts repo](https://github.com/cardano-community/koios-artifacts)

Schema update PR: https://github.com/cardano-community/koios-artifacts/pull/33