### PR TITLE
[SDC] Clean up de-registered accounts

### DIFF
--- a/files/grest/rpc/01_cached_tables/stake_distribution_cache.sql
+++ b/files/grest/rpc/01_cached_tables/stake_distribution_cache.sql
@@ -40,7 +40,8 @@ BEGIN
         WHERE
           NOT EXISTS (
             SELECT TRUE FROM DELEGATION D
-              WHERE D.ADDR_ID = DELEGATION.ADDR_ID AND D.ID > DELEGATION.ID
+              WHERE D.ADDR_ID = DELEGATION.ADDR_ID
+                AND D.ID > DELEGATION.ID
           )
           AND NOT EXISTS (
             SELECT TRUE FROM STAKE_DEREGISTRATION
@@ -48,7 +49,6 @@ BEGIN
                 AND STAKE_DEREGISTRATION.TX_ID > DELEGATION.TX_ID
           )
           -- Account must be present in epoch_stake table for the last validated epoch
-          -- Up for discussion whether this should be switched to _latest_epoch
           AND EXISTS (
             SELECT TRUE FROM EPOCH_STAKE
               WHERE EPOCH_STAKE.EPOCH_NO = (

--- a/files/grest/rpc/01_cached_tables/stake_distribution_new_accounts.sql
+++ b/files/grest/rpc/01_cached_tables/stake_distribution_new_accounts.sql
@@ -64,5 +64,19 @@ BEGIN
           REWARDS = EXCLUDED.rewards,
           WITHDRAWALS = EXCLUDED.withdrawals,
           REWARDS_AVAILABLE = EXCLUDED.rewards_available;
+
+    -- Clean up de-registered accounts
+    DELETE FROM grest.stake_distribution_cache
+      WHERE stake_address IN (
+        SELECT DISTINCT ON (SA.id)
+          SA.view
+        FROM STAKE_ADDRESS SA
+        INNER JOIN STAKE_DEREGISTRATION SD ON SA.ID = SD.ADDR_ID
+          WHERE NOT EXISTS (
+            SELECT TRUE FROM STAKE_REGISTRATION SR
+              WHERE SR.ADDR_ID = SD.ADDR_ID
+                AND SR.TX_ID > SD.TX_ID
+          )
+      );
 END;
 $$;

--- a/files/grest/rpc/pool/pool_delegators.sql
+++ b/files/grest/rpc/pool/pool_delegators.sql
@@ -16,7 +16,12 @@ BEGIN
     RETURN QUERY
       SELECT
         stake_address,
-        total_balance::text,
+        (
+          CASE WHEN total_balance >= 0
+            THEN total_balance
+            ELSE 0
+          END
+        )::text,
         (SELECT MAX(no) FROM public.epoch)::uinteger
       FROM
         grest.stake_distribution_cache AS sdc

--- a/files/grest/rpc/pool/pool_info.sql
+++ b/files/grest/rpc/pool/pool_info.sql
@@ -1,4 +1,3 @@
-DROP FUNCTION IF EXISTS grest.pool_info;
 CREATE FUNCTION grest.pool_info (_pool_bech32_ids text[])
   RETURNS TABLE (
     pool_id_bech32 character varying,
@@ -102,7 +101,12 @@ BEGIN
       CASE WHEN pic.pool_status = 'retired'
         THEN NULL
       ELSE
-        SUM (total_balance)::lovelace
+        SUM (
+          CASE WHEN total_balance >= 0
+            THEN total_balance
+            ELSE 0
+          END
+        )::lovelace
       END AS stake,
       COUNT (stake_address) AS delegators,
       CASE WHEN pic.pool_status = 'retired'


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Every 6 hours, we will clean up the SDC table to remove any accounts that are currently deregistered.

Added a safeguard against summing negative balances in `pool_info`/`pool_delegators` endpoints.