### PR TITLE
Multiple polishing updates for grest pre version release:

### DIFF
--- a/scripts/cnode-helper-scripts/setup_mon.sh
+++ b/scripts/cnode-helper-scripts/setup_mon.sh
@@ -18,8 +18,8 @@ NEXP_PORT=$(( PROM_PORT + 1 ))
 ######################################################################
 ARCHS=("darwin-amd64" "linux-amd64"  "linux-armv6" "linux-arm64" "linux-aarch64")
 TMP_DIR=$(mktemp -d "/tmp/cnode_monitoring.XXXXXXXX")
-PROM_VER=2.33.1
-GRAF_VER=8.3.4
+PROM_VER=2.35.0
+GRAF_VER=8.5.1
 NEXP_VER=1.3.1
 NEXP="node_exporter"
 SKY_DB_URL="https://raw.githubusercontent.com/Oqulent/SkyLight-Pool/master/Haskel_Node_SKY_Relay1_Dash.json"

--- a/scripts/grest-helper-scripts/grest-poll.sh
+++ b/scripts/grest-helper-scripts/grest-poll.sh
@@ -72,7 +72,7 @@ function usage() {
   exit 1
 }
 
-function is_up() {
+function chk_is_up() {
   rc=$(curl -s "${GURL}"/ready -I 2>/dev/null | grep x-failover)
   if [[ "${rc}" != "" ]]; then
     log_err "${GURL}/ready status check failed!!"


### PR DESCRIPTION
- Update haproxy config: Split grest_core into postgrest and failover backends. While this keeps queries compatible with grest_core, it will allow changes upstream on haproxy config of monitoring backends
- Bump prometheus/grafana versions (relevant only for monitoring instances)
- Add upcoming `/ready` endpoint (postgREST internal status endpoint) status check for grest-poll.sh script, absence of the endpoint in v9 for now does not impact availability, as we check the returned header