### PR TITLE
Add epoch_no to tx list endpoints, and simplify asset_txs

### DIFF
--- a/docs/Build/grest.md
+++ b/docs/Build/grest.md
@@ -7,6 +7,9 @@
 
 gRest is an open source implementation of a `query layer built over dbsync using PostgREST and HAProxy`. The package is built as part of [Koios](https://www.koios.rest) team's efforts to unite community individual stream of work together and give back a more aligned structure to query dbsync and adopt standardisation to queries utilising open-source tooling as well as collaboration. In addition to these, there are also accessibility features to deploy rules for failover, do healthchecks, set up priorities, have ability to prevent DDoS attacks, provide timeouts, report tips for analysis over a longer period, etc - which can prove to be really useful when performing any analysis for instances.
 
+!!! warning ""
+    Note that the scripts below do allow for provisioning ogmios integration too, but Ogmios does not provide advanced session management for a server-client architecture in absence of a middleware. The availability for ogmios from monitoring instance is restricted to avoid ability to DDoS an instance.
+
 ### Components
 
 1. [PostgREST](https://postgrest.org/en/latest):  
@@ -63,9 +66,9 @@ Similarly - if instead, you'd like to re-install all components as well as force
 ./setup-grest.sh -f -i prmcd -q
 ```
 
-Another example could be to preserve your config, but only update queries using an alternate branch (eg: `alpha`). To do so, you may run:
+Another example could be to preserve your config, but only update queries using an alternate branch (eg: let's say you want to try the tag `koios-1.0.0rc1`). To do so, you may run:
 ``` bash
-./setup-grest.sh -q -b alpha
+./setup-grest.sh -q -b koios-1.0.0rc1
 ```
 
 Please ensure to follow the on-screen instructions, if any (for example restarting deployed services, or updating configs to specify correct target postgres URLs/enable TLS/add peers etc in `${CNODE_HOME}/priv/grest.conf` and `${CNODE_HOME}/files/haproxy.cfg`).

--- a/files/grest/rpc/address/address_txs.sql
+++ b/files/grest/rpc/address/address_txs.sql
@@ -44,7 +44,9 @@ BEGIN
       INNER JOIN public.block ON block.id = tx.block_id
     WHERE
       tx.id = ANY (_tx_id_list)
-      AND block.block_no >= _after_block_height;
+      AND block.block_no >= _after_block_height
+    ORDER BY
+      block.block_no DESC;
 END;
 $$;
 

--- a/files/grest/rpc/address/address_txs.sql
+++ b/files/grest/rpc/address/address_txs.sql
@@ -1,6 +1,7 @@
 CREATE FUNCTION grest.address_txs (_addresses text[], _after_block_height integer DEFAULT 0)
   RETURNS TABLE (
     tx_hash text,
+    epoch_no uinteger,
     block_height uinteger,
     block_time timestamp
   )
@@ -35,6 +36,7 @@ BEGIN
   RETURN QUERY
     SELECT
       DISTINCT(ENCODE(tx.hash, 'hex')) as tx_hash,
+      block.epoch_no,
       block.block_no,
       block.time
     FROM

--- a/files/grest/rpc/address/credential_txs.sql
+++ b/files/grest/rpc/address/credential_txs.sql
@@ -54,7 +54,9 @@ BEGIN
       INNER JOIN public.block ON block.id = tx.block_id
     WHERE
       tx.id = ANY (_tx_id_list)
-      AND block.block_no >= _after_block_height;
+      AND block.block_no >= _after_block_height
+    ORDER BY
+      block.block_no DESC;
 END;
 $$;
 

--- a/files/grest/rpc/address/credential_txs.sql
+++ b/files/grest/rpc/address/credential_txs.sql
@@ -1,6 +1,7 @@
 CREATE FUNCTION grest.credential_txs (_payment_credentials text[], _after_block_height integer DEFAULT 0)
   RETURNS TABLE (
     tx_hash text,
+    epoch_no uinteger,
     block_height uinteger,
     block_time timestamp
   )
@@ -45,6 +46,7 @@ BEGIN
   RETURN QUERY
     SELECT
       DISTINCT(ENCODE(tx.hash, 'hex')) as tx_hash,
+      block.epoch_no,
       block.block_no,
       block.time
     FROM

--- a/files/grest/rpc/assets/asset_txs.sql
+++ b/files/grest/rpc/assets/asset_txs.sql
@@ -31,25 +31,24 @@ BEGIN
       tx_hashes.time
     FROM (
       SELECT DISTINCT ON (tx.hash)
-        tx.id,
         tx.hash,
-	block.epoch_no,
-	block.block_no,
-	block.time
+        block.epoch_no,
+        block.block_no,
+        block.time
       FROM
         ma_tx_out MTO
         INNER JOIN tx_out TXO ON TXO.id = MTO.tx_out_id
         INNER JOIN tx ON tx.id = TXO.tx_id
-	INNER JOIN block ON block.id = tx.block_id
+        INNER JOIN block ON block.id = tx.block_id
       WHERE
         MTO.ident = _asset_id
       GROUP BY
         ident,
-        tx.id,
-	block.epoch_no,
-	block.block_no,
-	block.time
-    ) tx_hashes ORDER BY tx_hashes.id DESC;
+        tx.hash,
+        block.epoch_no,
+        block.block_no,
+        block.time
+    ) tx_hashes ORDER BY tx_hashes.block_no DESC;
 END;
 $$;
 

--- a/scripts/grest-helper-scripts/setup-grest.sh
+++ b/scripts/grest-helper-scripts/setup-grest.sh
@@ -16,7 +16,7 @@
 # Do NOT modify code below           #
 ######################################
 
-SGVERSION=1.0.0rc
+SGVERSION=1.0.0rc1
 
 ######## Functions ########
   usage() {


### PR DESCRIPTION
- Avoid tx array by removing redundant asset/policy info in `/asset_txs` (allows for leveraging native PostgREST filtering)
- Add epoch_no, block_no & block_time to `/address_txs`, `/credential_txs` and `/asset_txs`

PS: Also check corresponding changes to output schema on [koios-artifacts#35](https://github.com/cardano-community/koios-artifacts/pull/35)