### PR TITLE
gRest BugFix: /pool_info => wrong metadata sort

### DIFF
--- a/docs/Build/grest-changelog.md
+++ b/docs/Build/grest-changelog.md
@@ -1,0 +1,26 @@
+# Koios gRest Changelog
+
+## [1.0.0-rc1]
+
+### Changes for API
+
+#### Data Output Changes
+- Improve: Add `epoch_no`, `block_no` to `/address_txs`, `/credential_txs` and `/asset_txs` endpoints. [#1409](https://github.com/cardano-community/guild-operators/pull/1403)
+- Fix: Remove redundant policy_info for `/asset_txs`, returning transactions as an array - allows for leveraging native PostgREST filtering. [#1409](https://github.com/cardano-community/guild-operators/pull/1403)
+- Fix: Pool Metadata sorting was incorrect for `/pool_info`. [#1414](https://github.com/cardano-community/guild-operators/pull/1414)
+
+#### Input Parameter Changes
+- None
+
+### Changes for Instance Providers
+
+#### Added
+- Add setup-grest.sh versioning. When running setup-grest.sh against a branch/tag, it will now populate the version information on control table, the health checks will be able to use this versioning for downstream connections. [#1403](https://github.com/cardano-community/guild-operators/pull/1403)
+
+#### Fixed
+- Delete token token-registry folder when running `setup-grest.sh` with `-r` (reset flag), as the delta registry records to insert depends on file (POSIX) timestamps. [#1410]https://github.com/cardano-community/guild-operators/pull/1410)
+- Remove duplicate tip check in `grest-poll.sh`. 
+
+## [1.0.0-rc0] - 2022-04-29
+
+- Initial Release Candidate for Koios gRest API layer with 43 endpoints to query the chain.

--- a/docs/Build/wallet.md
+++ b/docs/Build/wallet.md
@@ -22,14 +22,12 @@ You can use the instructions below to build the latest release of [cardano-walle
 
 !> - Note that the latest release of `cardano-wallet` may not work with the latest release of `cardano-node`. Please check the compatibility of each `cardano-wallet` release yourself in the official docs, e.g. https://github.com/input-output-hk/cardano-wallet/releases/latest.
 
-> The cardano-wallet repo does not work yet with `cabal`, hence the alternative for now is building with `stack`
-
 ``` bash
 git fetch --tags --all
 git pull
 # Replace tag against checkout if you do not want to build the latest released version
 git checkout $(curl -s https://api.github.com/repos/input-output-hk/cardano-wallet/releases/latest | jq -r .tag_name)
-$CNODE_HOME/scripts/stack-build.sh
+$CNODE_HOME/scripts/cabal-build-all.sh
 ```
 
 The above would copy the binaries into `~/.cabal/bin` folder.

--- a/files/grest/rpc/pool/pool_info.sql
+++ b/files/grest/rpc/pool/pool_info.sql
@@ -67,7 +67,7 @@ BEGIN
   FROM
     grest.pool_info_cache AS pic
   LEFT JOIN
-    public.pool_offline_data AS pod ON pic.pool_hash_id = pod.pool_id
+    public.pool_offline_data AS pod ON pic.pool_hash_id = pod.pool_id AND pic.meta_id = pod.pmr_id
   LEFT JOIN LATERAL (
     SELECT
       SUM(COUNT(b.id)) OVER () AS cnt,
@@ -122,8 +122,7 @@ BEGIN
   WHERE
     pic.pool_id_bech32 = ANY(SELECT UNNEST(_pool_bech32_ids))
   ORDER BY
-    pic.pool_id_bech32,
-    pod.pmr_id, pic.tx_id DESC;
+    pic.pool_id_bech32,pic.meta_id DESC, pic.tx_id DESC;
 END;
 $$;
 


### PR DESCRIPTION
## Description

1. Join for pool_offline_data and pool_info_cache based on hash_id match was slightly vague, as you can end up having a mismatch of meta and pmr ID (can be troublesome later for ordering)
2. ordering of meta_id should be descending

The above could result in invalid metadata for those who may have updated their pool metadata