### PR TITLE
Free-up Space

### DIFF
--- a/.github/workflows/docker_stage3.yml
+++ b/.github/workflows/docker_stage3.yml
@@ -10,8 +10,18 @@ jobs:
     - name: docker login
       run: |
         docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
+        # Workaround to provide additional free space for builds.
+        #   https://github.com/actions/virtual-environments/issues/2840
+        sudo apt-get remove -y '^dotnet-.*'
+        sudo apt-get remove -y 'php.*'
+        sudo apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel
+        sudo apt-get autoremove -y
+        sudo apt-get clean
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf "/usr/local/share/boost"
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
     - name: Compiling new node software suite
-      run: |      
+      run: |
         DOCKER_BUILDKIT=1 docker build . --file files/docker/node/dockerfile_stage3 --compress --tag cardanocommunity/cardano-node:stage3
     - name: docker push stage3 and latest
       run: |


### PR DESCRIPTION
The github-hosted runner is populated with a lot of software that are not relevant to this repo.
This results in ~18Gb free space which is no longer enough for cabal build