### PR TITLE
[Issue #1423] Pre-merge track containerfiles

### DIFF
--- a/.github/workflows/premerge_amazonlinux2.yml
+++ b/.github/workflows/premerge_amazonlinux2.yml
@@ -7,6 +7,8 @@ on:
       - scripts/cnode-helper-scripts/prereqs.sh
       - scripts/cnode-helper-scripts/cabal-build-all.sh
       - files/cabal.project.local
+      - files/tests/amazonlinux2_prereqs.sh.containerfile
+      - files/tests/amazonlinux2_prereqs.sh_-l.containerfile
 
 jobs:
   prerequisites:

--- a/.github/workflows/premerge_rockylinux8.yml
+++ b/.github/workflows/premerge_rockylinux8.yml
@@ -7,6 +7,8 @@ on:
       - scripts/cnode-helper-scripts/prereqs.sh
       - scripts/cnode-helper-scripts/cabal-build-all.sh
       - files/cabal.project.local
+      - files/tests/rockylinux8_prereqs.sh.containerfile
+      - files/tests/rockylinux8_prereqs.sh_-l.containerfile
 
 jobs:
   prerequisites:

--- a/.github/workflows/premerge_ubuntu20.yml
+++ b/.github/workflows/premerge_ubuntu20.yml
@@ -7,6 +7,8 @@ on:
       - scripts/cnode-helper-scripts/prereqs.sh
       - scripts/cnode-helper-scripts/cabal-build-all.sh
       - files/cabal.project.local
+      - files/tests/ubuntu20_prereqs.sh.containerfile
+      - files/tests/ubuntu20_prereqs.sh_-l.containerfile
 
 jobs:
   prerequisites:


### PR DESCRIPTION
## Description
include containerfiles for the paths monitored by `workflow_dispatch:pull_request:paths`

## Where should the reviewer start?
Any commit to `*_prereqs.*.containerfile` that is part of a PR will kick off the premerge workflow to test the changes.

## Motivation and context
Allows automated testing of containerfile changes which otherwise go untested before being merged. Does not address the Run Workflow button does not identify the branch as a source branch of a PR, will be tracked in a separate issue.

## Which issue it fixes?
#1423 

## How has this been tested?
#1422 contained the changes only for Debian and showed the expected results of testing premerge automatically.
