### PR TITLE
Update CNODE_HOME to CNODE_PORT in kill command for cnode.sh

### DIFF
--- a/docs/Build/node-cli.md
+++ b/docs/Build/node-cli.md
@@ -52,7 +52,7 @@ POOL_NAME="GUILD"
 ```
 
 !!! important
-    POOL_NAME is the name of folder that you will use when registering pools and starting node in core mode. This folder would typically contain your `hot.skey`,`vrf.skey` and `op.cert` files required. If the mentioned files are absent, the node will automatically start in a passive mode.
+    POOL_NAME is the name of folder that you will use when registering pools and starting node in core mode. This folder would typically contain your `hot.skey`,`vrf.skey` and `op.cert` files required. If the mentioned files are absent, the node will automatically start in a passive mode. Note that in case CNODE_PORT is changed, you'd want to re-do the deployment of systemd service as mentioned later in the guide
 
 #### Start the node
 

--- a/scripts/cnode-helper-scripts/cnode.sh
+++ b/scripts/cnode-helper-scripts/cnode.sh
@@ -76,7 +76,7 @@ deploy_systemd() {
 	LimitNOFILE=1048576
 	WorkingDirectory=${CNODE_HOME}/scripts
 	ExecStart=/bin/bash -l -c \"exec ${CNODE_HOME}/scripts/cnode.sh\"
-	ExecStop=/bin/bash -l -c \"exec kill -2 \$(ps -ef | grep ${CNODEBIN}.*.${CNODE_HOME}/ | tr -s ' ' | cut -d ' ' -f2) &>/dev/null\"
+	ExecStop=/bin/bash -l -c \"exec kill -2 \$(ps -ef | grep ${CNODEBIN}.*.--port\\ ${CNODE_PORT} | tr -s ' ' | cut -d ' ' -f2) &>/dev/null\"
 	KillSignal=SIGINT
 	SuccessExitStatus=143
 	StandardOutput=syslog


### PR DESCRIPTION
## Description
In cases where folks may have more than one node running under CNODE_HOME, having that variable to kill would not be appropriate. Instead , using CNODE_PORT ensures that the PID that comes back is unique (as you should - under no circumstances - be ending up with two cardano-node processes sharing same port)