### PR TITLE
Lighten grest.account_active_stake_cache

### DIFF
--- a/files/grest/cron/jobs/active-stake-cache-update.sh
+++ b/files/grest/cron/jobs/active-stake-cache-update.sh
@@ -17,13 +17,13 @@ last_epoch_stakes_log=$(grep -r 'Inserted.*.EpochStake for EpochNo ' "$(dirname 
 logs_last_epoch_stakes_count=$(echo "${last_epoch_stakes_log}" | cut -d\  -f1)
 logs_last_epoch_no=$(echo "${last_epoch_stakes_log}" | cut -d\  -f3)
 
-db_last_epoch_no=$(psql ${DB_NAME} -qbt -c "SELECT grest.get_current_epoch();" | tr -cd '[:alnum:]')
+db_last_epoch_no=$(psql ${DB_NAME} -qbt -c "SELECT MAX(NO) from EPOCH;" | tr -cd '[:alnum:]')
 [[ "${db_last_epoch_no}" != "${logs_last_epoch_no}" ]] &&
   echo "Mismatch between last epoch in logs and database, exiting..." &&
   exit 1
 
 # Count current epoch entries processed by db-sync
-db_epoch_stakes_count=$(psql ${DB_NAME} -qbt -c "SELECT grest.get_epoch_stakes_count(${db_last_epoch_no});" | tr -cd '[:alnum:]')
+db_epoch_stakes_count=$(psql ${DB_NAME} -qbt -c "SELECT COUNT(1) FROM EPOCH_STAKE WHERE epoch_no = ${db_last_epoch_no};" | tr -cd '[:alnum:]')
 
 # Check if db-sync completed handling stakes
 [[ "${db_epoch_stakes_count}" != "${logs_last_epoch_stakes_count}" ]] &&

--- a/files/grest/rpc/account/account_history.sql
+++ b/files/grest/rpc/account/account_history.sql
@@ -33,27 +33,31 @@ $$
     THEN
       RETURN QUERY
         SELECT
-          ACCOUNT_ACTIVE_STAKE_CACHE.stake_address,
-          ACCOUNT_ACTIVE_STAKE_CACHE.pool_id,
-          ACCOUNT_ACTIVE_STAKE_CACHE.epoch_no,
-          ACCOUNT_ACTIVE_STAKE_CACHE.amount::text as active_stake
+          sa.view as stake_address,
+          ph.view as pool_id,
+          es.epoch_no::bigint,
+          es.amount::text as active_stake
         FROM
-          GREST.ACCOUNT_ACTIVE_STAKE_CACHE
+          EPOCH_STAKE es
+        LEFT JOIN stake_address sa ON sa.id = es.addr_id
+        LEFT JOIN pool_hash ph ON ph.id = es.pool_id
         WHERE
-          ACCOUNT_ACTIVE_STAKE_CACHE.epoch_no = _epoch_no
+          es.epoch_no = _epoch_no
             AND
-          ACCOUNT_ACTIVE_STAKE_CACHE.stake_address = _address;
+          sa.view = _address;
     ELSE
       RETURN QUERY
         SELECT
-          ACCOUNT_ACTIVE_STAKE_CACHE.stake_address,
-          ACCOUNT_ACTIVE_STAKE_CACHE.pool_id,
-          ACCOUNT_ACTIVE_STAKE_CACHE.epoch_no,
-          ACCOUNT_ACTIVE_STAKE_CACHE.amount::text as active_stake
+          sa.view as stake_address,
+          ph.view as pool_id,
+          es.epoch_no::bigint,
+          es.amount::text as active_stake
         FROM
-          GREST.ACCOUNT_ACTIVE_STAKE_CACHE
+          EPOCH_STAKE es
+        LEFT JOIN stake_address sa ON sa.id = es.addr_id
+        LEFT JOIN pool_hash ph ON ph.id = es.pool_id
         WHERE
-          ACCOUNT_ACTIVE_STAKE_CACHE.stake_address = _address;
+          sa.view = _address;
     END IF;
   END;
 $$;

--- a/scripts/cnode-helper-scripts/dbsync.sh
+++ b/scripts/cnode-helper-scripts/dbsync.sh
@@ -68,7 +68,7 @@ check_config_sanity() {
   if [[ "${BYGENHASH}" != "${BYGENHASHCFG}" ]] || [[ "${SHGENHASH}" != "${SHGENHASHCFG}" ]] || [[ "${ALGENHASH}" != "${ALGENHASHCFG}" ]]; then
     cp "${CONFIG}" "${CONFIG}".tmp
     jq --arg BYGENHASH ${BYGENHASH} --arg SHGENHASH ${SHGENHASH} --arg ALGENHASH ${ALGENHASH} '.ByronGenesisHash = $BYGENHASH | .ShelleyGenesisHash = $SHGENHASH | .AlonzoGenesisHash = $ALGENHASH' <"${CONFIG}" >"${CONFIG}".tmp
-    mv -f "${CONFIG}".tmp "${CONFIG}"
+    [[ -s "${CONFIG}".tmp ]] && mv -f "${CONFIG}".tmp "${CONFIG}"
   fi
 }
 

--- a/scripts/grest-helper-scripts/db-scripts/basics.sql
+++ b/scripts/grest-helper-scripts/db-scripts/basics.sql
@@ -138,37 +138,6 @@ BEGIN
 END;
 $$;
 
-CREATE FUNCTION grest.get_current_epoch ()
-  RETURNS integer
-  LANGUAGE plpgsql
-  AS 
-$$
-  BEGIN
-    RETURN (
-      SELECT MAX(no) FROM public.epoch
-    );
-  END;
-$$;
-
-CREATE FUNCTION grest.get_epoch_stakes_count (_epoch_no integer)
-  RETURNS integer
-  LANGUAGE plpgsql
-  AS
-$$
-  BEGIN
-    RETURN (
-      SELECT
-        count(*)
-      FROM
-        public.epoch_stake
-      WHERE
-        epoch_no = _epoch_no
-      GROUP BY
-        epoch_no
-    );
-  END;
-$$;
-
 CREATE FUNCTION grest.update_control_table (_key text, _last_value text, _artifacts text default null)
   RETURNS void
   LANGUAGE plpgsql

--- a/scripts/grest-helper-scripts/grest-poll.sh
+++ b/scripts/grest-helper-scripts/grest-poll.sh
@@ -106,7 +106,7 @@ function chk_tip() {
   currtip=$(date +%s)
   [[ ${tip[4]} =~ ^[0-9.]+$ ]] && dbtip=$(cut -d. -f1 <<< "${tip[4]}") || dbtip=$(date --date "${tip[4]}+0" +%s)
   if [[ -z "${dbtip}" ]] || [[ $(( currtip - dbtip )) -gt ${TIP_DIFF} ]] ; then
-    log_err "${URLRPC}/tip endpoint did not provide a timestamp that's within ${TIP_DIFF} seconds - Tip: ${currtip}, DB Tip: ${dbtip}, Difference: $(( $(date -d "${currtip}" +%s) - $(date -d "${dbtip}" +%s) ))"
+    log_err "${URLRPC}/tip endpoint did not provide a timestamp that's within ${TIP_DIFF} seconds - Tip: ${currtip}, DB Tip: ${dbtip}, Difference: $(( currtip - dbtip ))"
     optexit
   else
     epoch=${tip[0]}


### PR DESCRIPTION
## Description

- [x] Update grest.account_history to remove dependency on grest.account_active_stake_cache
- [x] Retire minimalistic (single-table) functions used in active_stake_cache SQL that are only used once
- [x] Delete historical view (beyond 4 epochs) for grest.account_active_stake_cache, in most cases - only 3 is sufficient, except on a new sync instance when epoch_stake will not be populated and you may need 4th
- [x] Minor bug-fixes in grest-poll.sh (echo for dbtip/currtip logging) and dbsync.sh (ensure \${CONFIG}.tmp file is not empty)


Closes cardano-community/koios-artifacts#52