### PR TITLE
Updates to cnode.sh startup script and systemd

### DIFF
--- a/scripts/cnode-helper-scripts/cnode.sh
+++ b/scripts/cnode-helper-scripts/cnode.sh
@@ -29,6 +29,7 @@ usage() {
 		
 		Cardano Node wrapper script !!
 		-d    Deploy cnode as a systemd service
+		-s    Stop cnode using SIGINT
 		
 		EOF
   exit 1
@@ -60,6 +61,13 @@ pre_startup_sanity() {
   [[ $(find "${LOG_DIR}"/node*.json 2>/dev/null | wc -l) -gt 0 ]] && mv "${LOG_DIR}"/node*.json "${LOG_DIR}"/archive/
 }
 
+stop_node() {
+  CNODE_PID=$(pgrep -fn "$(basename ${CNODEBIN}).*.--port ${CNODE_PORT}" 2>/dev/null) # env was only called in offline mode
+  kill -2 ${CNODE_PID} 2>/dev/null
+  # touch clean "${CNODE_HOME}"/db/clean # Disabled as it's a bit hacky, but only runs when SIGINT is passed to node process. Should not be needed if node does it's job
+  exit 0
+}
+
 deploy_systemd() {
   echo "Deploying ${CNODE_VNAME} as systemd service.."
   sudo bash -c "cat <<-'EOF' > /etc/systemd/system/${CNODE_VNAME}.service
@@ -67,20 +75,20 @@ deploy_systemd() {
 	Description=Cardano Node
 	Wants=network-online.target
 	After=network-online.target
+	StartLimitIntervalSec=600
+	StartLimitBurst=5
 	
 	[Service]
 	Type=simple
-	Restart=always
+	Restart=on-failure
 	RestartSec=60
 	User=${USER}
 	LimitNOFILE=1048576
 	WorkingDirectory=${CNODE_HOME}/scripts
 	ExecStart=/bin/bash -l -c \"exec ${CNODE_HOME}/scripts/cnode.sh\"
-	ExecStop=/bin/bash -l -c \"exec kill -2 \$(ps -ef | grep ${CNODEBIN}.*.--port\\ ${CNODE_PORT} | tr -s ' ' | cut -d ' ' -f2) &>/dev/null\"
+	ExecStop=/bin/bash -l -c \"exec ${CNODE_HOME}/scripts.cnode.sh -s\"
 	KillSignal=SIGINT
 	SuccessExitStatus=143
-	StandardOutput=syslog
-	StandardError=syslog
 	SyslogIdentifier=${CNODE_VNAME}
 	TimeoutStopSec=60
 	
@@ -94,9 +102,10 @@ deploy_systemd() {
 ###################
 
 # Parse command line options
-while getopts :d opt; do
+while getopts :ds opt; do
   case ${opt} in
     d ) DEPLOY_SYSTEMD="Y" ;;
+    s ) STOP_NODE="Y" ;;
     \? ) usage ;;
   esac
 done
@@ -108,6 +117,8 @@ case $? in
   1) echo -e "ERROR: Failed to load common env file\nPlease verify set values in 'User Variables' section in env file or log an issue on GitHub" && exit 1;;
   2) clear ;;
 esac
+
+[[ "${STOP_NODE}" == "Y" ]] && stop_node
 
 # Set defaults and do basic sanity checks
 set_defaults

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -481,7 +481,7 @@ createDistanceToBottom() {
 # Description : Query cardano-node for current metrics
 getNodeMetrics() {
   CNODE_PID=$(pgrep -fn "$(basename ${CNODEBIN}).*.--port ${CNODE_PORT}") # Define again - as node could be restarted since last attempt of sourcing env
-  [[ -n ${CNODE_PID} ]] && uptimes=$(ps -p ${CNODE_PID} -o etimes=) || uptimes=0
+  [[ -n ${CNODE_PID} ]] && uptimes=$(( $(date +%s) - $(date -d "$(TZ=UTC ps -p ${CNODE_PID} -o lstart | tail -1)" +%s) )) || uptimes=0
   if [[ ${USE_EKG} = 'Y' ]]; then
     node_metrics=$(curl -s -m ${EKG_TIMEOUT} -H 'Accept: application/json' "http://${EKG_HOST}:${EKG_PORT}/" 2>/dev/null)
     node_metrics_tsv=$(jq -r '[


### PR DESCRIPTION
## Description

Updates to cnode.sh startup script and systemd
- Add -s to cnode.sh to handle shutdown via SIGINT
- Update systemd creation script to not `cnode.sh -s` for shutdown to add burst limit for startup attempts, remove stdout/stderr redirection.

(PS: This will not resolve/workaround bug from 1.35.0 for incorrect shutdown)