### PR TITLE
Add new Vasil data to tx_info

### DIFF
--- a/files/grest/rpc/transactions/tx_info.sql
+++ b/files/grest/rpc/transactions/tx_info.sql
@@ -14,15 +14,17 @@ CREATE FUNCTION grest.tx_info (_tx_hashes text[])
     deposit text,
     invalid_before word64type,
     invalid_after word64type,
-    collaterals json,
-    inputs json,
-    outputs json,
-    withdrawals json,
-    assets_minted json,
-    metadata json,
-    certificates json,
-    native_scripts json,
-    plutus_contracts json
+    collateral_inputs jsonb,
+    collateral_outputs jsonb,
+    reference_inputs jsonb,
+    inputs jsonb,
+    outputs jsonb,
+    withdrawals jsonb,
+    assets_minted jsonb,
+    metadata jsonb,
+    certificates jsonb,
+    native_scripts jsonb,
+    plutus_contracts jsonb
   )
   LANGUAGE PLPGSQL
   AS $$
@@ -57,20 +59,20 @@ BEGIN
       _all_tx AS (
         SELECT
           tx.id,
-          tx.hash as tx_hash,
-          b.hash as block_hash,
-          b.block_no AS block_height,
-          b.epoch_no AS epoch,
-          b.epoch_slot_no AS epoch_slot,
-          b.slot_no AS absolute_slot,
-          b.time AS tx_timestamp,
-          tx.block_index AS tx_block_index,
-          tx.size AS tx_size,
-          tx.out_sum AS total_output,
+          tx.hash               AS tx_hash,
+          b.hash                AS block_hash,
+          b.block_no            AS block_height,
+          b.epoch_no            AS epoch,
+          b.epoch_slot_no       AS epoch_slot,
+          b.slot_no             AS absolute_slot,
+          b.time                AS tx_timestamp,
+          tx.block_index        AS tx_block_index,
+          tx.size               AS tx_size,
+          tx.out_sum            AS total_output,
           tx.fee,
           tx.deposit,
           tx.invalid_before,
-          tx.invalid_hereafter AS invalid_after
+          tx.invalid_hereafter  AS invalid_after
         FROM
           tx
           INNER JOIN block b ON tx.block_id = b.id
@@ -79,22 +81,43 @@ BEGIN
 
       _all_collateral_inputs AS (
         SELECT
-          collateral_tx_in.tx_in_id AS tx_id,
-          tx_out.address AS payment_addr_bech32,
-          ENCODE(tx_out.payment_cred, 'hex') AS payment_addr_cred,
-          SA.view AS stake_addr,
-          ENCODE(tx.hash, 'hex') AS tx_hash,
-          tx_out.index AS tx_index,
-          tx_out.value::text AS value,
+          collateral_tx_in.tx_in_id           AS tx_id,
+          tx_out.address                      AS payment_addr_bech32,
+          ENCODE(tx_out.payment_cred, 'hex')  AS payment_addr_cred,
+          SA.view                             AS stake_addr,
+          ENCODE(tx.hash, 'hex')              AS tx_hash,
+          tx_out.index                        AS tx_index,
+          tx_out.value::text                  AS value,
+          ENCODE(tx_out.data_hash, 'hex')     AS datum_hash,
           ( CASE WHEN MA.policy IS NULL THEN NULL
             ELSE
-              JSON_BUILD_OBJECT(
+              JSONB_BUILD_OBJECT(
                 'policy_id', ENCODE(MA.policy, 'hex'),
                 'asset_name', ENCODE(MA.name, 'hex'),
+                'fingerprint', MA.fingerprint,
                 'quantity', MTO.quantity::text
               )
             END
-          ) AS asset_list
+          )                                   AS asset_list,
+          ( CASE WHEN tx_out.inline_datum_id IS NULL THEN NULL
+            ELSE
+              JSONB_BUILD_OBJECT(
+                'bytes', ENCODE(datum.bytes, 'hex'),
+                'value', datum.value
+              )
+            END
+          )                                   AS inline_datum,
+          ( CASE WHEN tx_out.reference_script_id IS NULL THEN NULL
+            ELSE
+              JSONB_BUILD_OBJECT(
+                'hash', ENCODE(script.hash, 'hex'),
+                'bytes', ENCODE(script.bytes, 'hex'),
+                'value', script.json,
+                'type', script.type::text,
+                'size', script.serialised_size
+              )
+            END
+          )                                   AS reference_script
         FROM
           collateral_tx_in
           INNER JOIN tx_out ON tx_out.tx_id = collateral_tx_in.tx_out_id
@@ -103,28 +126,104 @@ BEGIN
           LEFT JOIN stake_address SA ON tx_out.stake_address_id = SA.id
           LEFT JOIN ma_tx_out MTO ON MTO.tx_out_id = tx_out.id
           LEFT JOIN multi_asset MA ON MA.id = MTO.ident
+          LEFT JOIN datum ON datum.id = tx_out.inline_datum_id
+          LEFT JOIN script ON script.id = tx_out.reference_script_id
         WHERE 
           collateral_tx_in.tx_in_id = ANY (_tx_id_list)
       ),
 
-      _all_inputs AS (
+      _all_reference_inputs AS (
         SELECT
-          tx_in.tx_in_id AS tx_id,
-          tx_out.address AS payment_addr_bech32,
-          ENCODE(tx_out.payment_cred, 'hex') AS payment_addr_cred,
-          SA.view AS stake_addr,
-          ENCODE(tx.hash, 'hex') AS tx_hash,
-          tx_out.index AS tx_index,
-          tx_out.value::text AS value,
+          reference_tx_in.tx_in_id            AS tx_id,
+          tx_out.address                      AS payment_addr_bech32,
+          ENCODE(tx_out.payment_cred, 'hex')  AS payment_addr_cred,
+          SA.view                             AS stake_addr,
+          ENCODE(tx.hash, 'hex')              AS tx_hash,
+          tx_out.index                        AS tx_index,
+          tx_out.value::text                  AS value,
+          ENCODE(tx_out.data_hash, 'hex')     AS datum_hash,
           ( CASE WHEN MA.policy IS NULL THEN NULL
             ELSE
-              JSON_BUILD_OBJECT(
+              JSONB_BUILD_OBJECT(
                 'policy_id', ENCODE(MA.policy, 'hex'),
                 'asset_name', ENCODE(MA.name, 'hex'),
+                'fingerprint', MA.fingerprint,
                 'quantity', MTO.quantity::text
               )
             END
-          ) AS asset_list
+          )                                   AS asset_list,
+          ( CASE WHEN tx_out.inline_datum_id IS NULL THEN NULL
+            ELSE
+              JSONB_BUILD_OBJECT(
+                'bytes', ENCODE(datum.bytes, 'hex'),
+                'value', datum.value
+              )
+            END
+          )                                   AS inline_datum,
+          ( CASE WHEN tx_out.reference_script_id IS NULL THEN NULL
+            ELSE
+              JSONB_BUILD_OBJECT(
+                'hash', ENCODE(script.hash, 'hex'),
+                'bytes', ENCODE(script.bytes, 'hex'),
+                'value', script.json,
+                'type', script.type::text,
+                'size', script.serialised_size
+              )
+            END
+          )                                   AS reference_script
+        FROM
+          reference_tx_in
+          INNER JOIN tx_out ON tx_out.tx_id = reference_tx_in.tx_out_id
+            AND tx_out.index = reference_tx_in.tx_out_index
+          INNER JOIN tx ON tx_out.tx_id = tx.id
+          LEFT JOIN stake_address SA ON tx_out.stake_address_id = SA.id
+          LEFT JOIN ma_tx_out MTO ON MTO.tx_out_id = tx_out.id
+          LEFT JOIN multi_asset MA ON MA.id = MTO.ident
+          LEFT JOIN datum ON datum.id = tx_out.inline_datum_id
+          LEFT JOIN script ON script.id = tx_out.reference_script_id
+        WHERE 
+          reference_tx_in.tx_in_id = ANY (_tx_id_list)
+      ),
+
+      _all_inputs AS (
+        SELECT
+          tx_in.tx_in_id                      AS tx_id,
+          tx_out.address                      AS payment_addr_bech32,
+          ENCODE(tx_out.payment_cred, 'hex')  AS payment_addr_cred,
+          SA.view                             AS stake_addr,
+          ENCODE(tx.hash, 'hex')              AS tx_hash,
+          tx_out.index                        AS tx_index,
+          tx_out.value::text                  AS value,
+          ENCODE(tx_out.data_hash, 'hex')     AS datum_hash,
+          ( CASE WHEN MA.policy IS NULL THEN NULL
+            ELSE
+              JSONB_BUILD_OBJECT(
+                'policy_id', ENCODE(MA.policy, 'hex'),
+                'asset_name', ENCODE(MA.name, 'hex'),
+                'fingerprint', MA.fingerprint,
+                'quantity', MTO.quantity::text
+              )
+            END
+          )                                   AS asset_list,
+          ( CASE WHEN tx_out.inline_datum_id IS NULL THEN NULL
+            ELSE
+              JSONB_BUILD_OBJECT(
+                'bytes', ENCODE(datum.bytes, 'hex'),
+                'value', datum.value
+              )
+            END
+          )                                   AS inline_datum,
+          ( CASE WHEN tx_out.reference_script_id IS NULL THEN NULL
+            ELSE
+              JSONB_BUILD_OBJECT(
+                'hash', ENCODE(script.hash, 'hex'),
+                'bytes', ENCODE(script.bytes, 'hex'),
+                'value', script.json,
+                'type', script.type::text,
+                'size', script.serialised_size
+              )
+            END
+          )                                   AS reference_script
         FROM
           tx_in
           INNER JOIN tx_out ON tx_out.tx_id = tx_in.tx_out_id
@@ -133,34 +232,110 @@ BEGIN
           LEFT JOIN stake_address SA ON tx_out.stake_address_id = SA.id
           LEFT JOIN ma_tx_out MTO ON MTO.tx_out_id = tx_out.id
           LEFT JOIN multi_asset MA ON MA.id = MTO.ident
+          LEFT JOIN datum ON datum.id = tx_out.inline_datum_id
+          LEFT JOIN script ON script.id = tx_out.reference_script_id
         WHERE 
           tx_in.tx_in_id = ANY (_tx_id_list)
+      ),
+
+      _all_collateral_outputs AS (
+        SELECT
+          tx_out.tx_id,
+          tx_out.address                      AS payment_addr_bech32,
+          ENCODE(tx_out.payment_cred, 'hex')  AS payment_addr_cred,
+          SA.view                             AS stake_addr,
+          ENCODE(tx.hash, 'hex')              AS tx_hash,
+          tx_out.index                        AS tx_index,
+          tx_out.value::text                  AS value,
+          ENCODE(tx_out.data_hash, 'hex')     AS datum_hash,
+          ( CASE WHEN MA.policy IS NULL THEN NULL
+            ELSE
+              JSONB_BUILD_OBJECT(
+                'policy_id', ENCODE(MA.policy, 'hex'),
+                'asset_name', ENCODE(MA.name, 'hex'),
+                'fingerprint', MA.fingerprint,
+                'quantity', MTO.quantity::text
+              )
+            END
+          )                                   AS asset_list,
+          ( CASE WHEN tx_out.inline_datum_id IS NULL THEN NULL
+            ELSE
+              JSONB_BUILD_OBJECT(
+                'bytes', ENCODE(datum.bytes, 'hex'),
+                'value', datum.value
+              )
+            END
+          )                                   AS inline_datum,
+          ( CASE WHEN tx_out.reference_script_id IS NULL THEN NULL
+            ELSE
+              JSONB_BUILD_OBJECT(
+                'hash', ENCODE(script.hash, 'hex'),
+                'bytes', ENCODE(script.bytes, 'hex'),
+                'value', script.json,
+                'type', script.type::text,
+                'size', script.serialised_size
+              )
+            END
+          )                                   AS reference_script
+        FROM
+          collateral_tx_out tx_out
+          INNER JOIN tx on tx_out.tx_id = tx.id
+          LEFT JOIN stake_address SA ON tx_out.stake_address_id = SA.id
+          LEFT JOIN ma_tx_out MTO ON MTO.tx_out_id = tx_out.id
+          LEFT JOIN multi_asset MA ON MA.id = MTO.ident
+          LEFT JOIN datum ON datum.id = tx_out.inline_datum_id
+          LEFT JOIN script ON script.id = tx_out.reference_script_id
+        WHERE 
+          tx_out.tx_id = ANY (_tx_id_list)
       ),
 
       _all_outputs AS (
         SELECT
           tx_out.tx_id,
-          tx_out.address AS payment_addr_bech32,
-          ENCODE(tx_out.payment_cred, 'hex') AS payment_addr_cred,
-          SA.view AS stake_addr,
-          ENCODE(tx.hash, 'hex') AS tx_hash,
-          tx_out.index AS tx_index,
-          tx_out.value::text AS value,
+          tx_out.address                      AS payment_addr_bech32,
+          ENCODE(tx_out.payment_cred, 'hex')  AS payment_addr_cred,
+          SA.view                             AS stake_addr,
+          ENCODE(tx.hash, 'hex')              AS tx_hash,
+          tx_out.index                        AS tx_index,
+          tx_out.value::text                  AS value,
+          ENCODE(tx_out.data_hash, 'hex')     AS datum_hash,
           ( CASE WHEN MA.policy IS NULL THEN NULL
             ELSE
-              JSON_BUILD_OBJECT(
+              JSONB_BUILD_OBJECT(
                 'policy_id', ENCODE(MA.policy, 'hex'),
                 'asset_name', ENCODE(MA.name, 'hex'),
+                'fingerprint', MA.fingerprint,
                 'quantity', MTO.quantity::text
               )
             END
-          ) AS asset_list
+          )                                   AS asset_list,
+          ( CASE WHEN tx_out.inline_datum_id IS NULL THEN NULL
+            ELSE
+              JSONB_BUILD_OBJECT(
+                'bytes', ENCODE(datum.bytes, 'hex'),
+                'value', datum.value
+              )
+            END
+          )                                   AS inline_datum,
+          ( CASE WHEN tx_out.reference_script_id IS NULL THEN NULL
+            ELSE
+              JSONB_BUILD_OBJECT(
+                'hash', ENCODE(script.hash, 'hex'),
+                'bytes', ENCODE(script.bytes, 'hex'),
+                'value', script.json,
+                'type', script.type::text,
+                'size', script.serialised_size
+              )
+            END
+          )                                   AS reference_script
         FROM
           tx_out
           INNER JOIN tx ON tx_out.tx_id = tx.id
           LEFT JOIN stake_address SA ON tx_out.stake_address_id = SA.id
           LEFT JOIN ma_tx_out MTO ON MTO.tx_out_id = tx_out.id
           LEFT JOIN multi_asset MA ON MA.id = MTO.ident
+          LEFT JOIN datum ON datum.id = tx_out.inline_datum_id
+          LEFT JOIN script ON script.id = tx_out.reference_script_id
         WHERE 
           tx_out.tx_id = ANY (_tx_id_list)
       ),
@@ -168,11 +343,11 @@ BEGIN
       _all_withdrawals AS (
         SELECT
           tx_id,
-          JSON_AGG(data) AS list
+          JSONB_AGG(data) AS list
         FROM (
           SELECT
             W.tx_id,
-            JSON_BUILD_OBJECT(
+            JSONB_BUILD_OBJECT(
               'amount', W.amount::text,
               'stake_addr', SA.view
             ) AS data
@@ -189,11 +364,11 @@ BEGIN
       _all_mints AS (
         SELECT
           tx_id,
-          JSON_AGG(data) AS list
+          JSONB_AGG(data) AS list
         FROM (
           SELECT
             MTM.tx_id,
-            JSON_BUILD_OBJECT(
+            JSONB_BUILD_OBJECT(
               'policy_id', ENCODE(MA.policy, 'hex'),
               'asset_name', ENCODE(MA.name, 'hex'),
               'quantity', MTM.quantity::text
@@ -211,11 +386,11 @@ BEGIN
       _all_metadata AS (
         SELECT
           tx_id,
-          JSON_AGG(data) AS list
+          JSONB_AGG(data) AS list
         FROM (
           SELECT
             TM.tx_id,
-            JSON_BUILD_OBJECT(
+            JSONB_BUILD_OBJECT(
               'key', TM.key::text,
               'json', TM.json
             ) AS data
@@ -231,14 +406,14 @@ BEGIN
       _all_certs AS (
         SELECT
           tx_id,
-          JSON_AGG(data) AS list
+          JSONB_AGG(data) AS list
         FROM (
           SELECT
             SR.tx_id,
-            JSON_BUILD_OBJECT(
+            JSONB_BUILD_OBJECT(
               'index', SR.cert_index,
               'type', 'stake_registration',
-              'info', JSON_BUILD_OBJECT(
+              'info', JSONB_BUILD_OBJECT(
                 'stake_address', SA.view
               )
             ) AS data
@@ -252,10 +427,10 @@ BEGIN
           --
           SELECT
             SD.tx_id,
-            JSON_BUILD_OBJECT(
+            JSONB_BUILD_OBJECT(
               'index', SD.cert_index,
               'type', 'stake_deregistration',
-              'info', JSON_BUILD_OBJECT(
+              'info', JSONB_BUILD_OBJECT(
                 'stake_address', SA.view
               )
             ) AS data
@@ -269,10 +444,10 @@ BEGIN
           --
           SELECT
             D.tx_id,
-            JSON_BUILD_OBJECT(
+            JSONB_BUILD_OBJECT(
               'index', D.cert_index,
               'type', 'delegation',
-              'info', JSON_BUILD_OBJECT(
+              'info', JSONB_BUILD_OBJECT(
                 'stake_address', SA.view, 
                 'pool_id_bech32', PH.view,
                 'pool_id_hex', ENCODE(PH.hash_raw, 'hex')
@@ -289,10 +464,10 @@ BEGIN
           --
           SELECT
             T.tx_id,
-            JSON_BUILD_OBJECT(
+            JSONB_BUILD_OBJECT(
               'index', T.cert_index,
               'type', 'treasury_MIR',
-              'info', JSON_BUILD_OBJECT(
+              'info', JSONB_BUILD_OBJECT(
                 'stake_address', SA.view, 
                 'amount', T.amount::text
               )
@@ -307,10 +482,10 @@ BEGIN
           --
           SELECT
             R.tx_id,
-            JSON_BUILD_OBJECT(
+            JSONB_BUILD_OBJECT(
               'index', R.cert_index,
               'type', 'reserve_MIR',
-              'info', JSON_BUILD_OBJECT(
+              'info', JSONB_BUILD_OBJECT(
                 'stake_address', SA.view, 
                 'amount', R.amount::text
               )
@@ -325,10 +500,10 @@ BEGIN
           --
           SELECT
             PT.tx_id,
-            JSON_BUILD_OBJECT(
+            JSONB_BUILD_OBJECT(
               'index', PT.cert_index,
               'type', 'pot_transfer',
-              'info', JSON_BUILD_OBJECT(
+              'info', JSONB_BUILD_OBJECT(
                 'treasury', PT.treasury::text,
                 'reserves', PT.reserves::text
               )
@@ -343,10 +518,10 @@ BEGIN
           SELECT
             -- SELECT DISTINCT below because there are multiple entries for each signing key of a given transaction
             DISTINCT ON (PP.registered_tx_id) PP.registered_tx_id AS tx_id,
-            JSON_BUILD_OBJECT(
+            JSONB_BUILD_OBJECT(
               'index', null, -- cert_index not stored in param_proposal table
               'type', 'param_proposal',
-              'info', JSON_STRIP_NULLS(JSON_BUILD_OBJECT(
+              'info', JSONB_STRIP_NULLS(JSONB_BUILD_OBJECT(
                 'min_fee_a', PP.min_fee_a,
                 'min_fee_b', PP.min_fee_b,
                 'max_block_size', PP.max_block_size,
@@ -387,10 +562,10 @@ BEGIN
           --
           SELECT
             PR.announced_tx_id AS tx_id,
-            JSON_BUILD_OBJECT(
+            JSONB_BUILD_OBJECT(
               'index', PR.cert_index,
               'type', 'pool_retire',
-              'info', JSON_BUILD_OBJECT(
+              'info', JSONB_BUILD_OBJECT(
                 'pool_id_bech32', PH.view,
                 'pool_id_hex', ENCODE(PH.hash_raw, 'hex'),
                 'retiring epoch', PR.retiring_epoch
@@ -406,10 +581,10 @@ BEGIN
           --
           SELECT
             PIC.tx_id,
-            JSON_BUILD_OBJECT(
+            JSONB_BUILD_OBJECT(
               'index', PU.cert_index,
               'type', 'pool_update',
-              'info', JSON_BUILD_OBJECT(
+              'info', JSONB_BUILD_OBJECT(
                 'pool_id_bech32', PIC.pool_id_bech32,
                 'pool_id_hex', PIC.pool_id_hex,
                 'active_epoch_no', PIC.active_epoch_no,
@@ -437,11 +612,11 @@ BEGIN
       _all_native_scripts AS (
         SELECT
           tx_id,
-          JSON_AGG(data) AS list
+          JSONB_AGG(data) AS list
         FROM (
           SELECT
             script.tx_id,
-            JSON_BUILD_OBJECT(
+            JSONB_BUILD_OBJECT(
               'script_hash', ENCODE(script.hash, 'hex'),
               'script_json', script.json
             ) AS data
@@ -459,37 +634,37 @@ BEGIN
       _all_plutus_contracts AS (
         SELECT
           tx_id,
-          JSON_AGG(data) AS list
+          JSONB_AGG(data) AS list
         FROM (
           SELECT
             redeemer.tx_id,
-            JSON_BUILD_OBJECT(
+            JSONB_BUILD_OBJECT(
               'address', INUTXO.address,
               'script_hash', ENCODE(script.hash, 'hex'),
               'bytecode', ENCODE(script.bytes, 'hex'),
               'size', script.serialised_size,
               'valid_contract', tx.valid_contract,
-              'input', JSON_BUILD_OBJECT(
-                'redeemer', JSON_BUILD_OBJECT(
+              'input', JSONB_BUILD_OBJECT(
+                'redeemer', JSONB_BUILD_OBJECT(
                   'purpose', redeemer.purpose,
                   'fee', redeemer.fee::text,
-                  'unit', JSON_BUILD_OBJECT(
+                  'unit', JSONB_BUILD_OBJECT(
                     'steps', redeemer.unit_steps::text,
                     'mem', redeemer.unit_mem::text
                   ),
-                  'datum', JSON_BUILD_OBJECT(
+                  'datum', JSONB_BUILD_OBJECT(
                     'hash', ENCODE(rd.hash, 'hex'),
                     'value', rd.value
                   )
                 ),
-                'datum', JSON_BUILD_OBJECT(
+                'datum', JSONB_BUILD_OBJECT(
                   'hash', ENCODE(ind.hash, 'hex'),
                   'value', ind.value
                 )
               ),
               'output', CASE WHEN outd.hash IS NULL THEN NULL
                         ELSE
-                          JSON_BUILD_OBJECT(
+                          JSONB_BUILD_OBJECT(
                             'hash', ENCODE(outd.hash, 'hex'),
                             'value', outd.value
                           )
@@ -499,7 +674,7 @@ BEGIN
             redeemer
             INNER JOIN tx ON redeemer.tx_id = tx.id
             INNER JOIN redeemer_data RD ON RD.id = redeemer.redeemer_data_id
-            INNER JOIN script ON redeemer.script_hash = script.hash -- perhaps we should join on tx.reference_script_id here?
+            INNER JOIN script ON redeemer.script_hash = script.hash
             INNER JOIN tx_in ON tx_in.redeemer_id = redeemer.id
             INNER JOIN tx_out INUTXO ON INUTXO.tx_id = tx_in.tx_out_id AND INUTXO.index = tx_in.tx_out_index
             INNER JOIN datum IND ON IND.hash = INUTXO.data_hash
@@ -528,11 +703,11 @@ BEGIN
       ATX.invalid_before,
       ATX.invalid_after,
       COALESCE((
-        SELECT JSON_AGG(tx_collateral)
+        SELECT JSONB_AGG(tx_collateral_inputs)
         FROM (
           SELECT
-            JSON_BUILD_OBJECT(
-              'payment_addr', JSON_BUILD_OBJECT(
+            JSONB_BUILD_OBJECT(
+              'payment_addr', JSONB_BUILD_OBJECT(
                 'bech32', payment_addr_bech32,
                 'cred', payment_addr_cred
               ),
@@ -540,19 +715,68 @@ BEGIN
               'tx_hash', ACI.tx_hash,
               'tx_index', tx_index,
               'value', value,
-              'asset_list', COALESCE(JSON_AGG(asset_list) FILTER (WHERE asset_list IS NOT NULL), JSON_BUILD_ARRAY())
-            ) AS tx_collateral
+              'datum_hash', datum_hash,
+              'inline_datum', inline_datum,
+              'reference_script', reference_script,
+              'asset_list', COALESCE(JSONB_AGG(asset_list) FILTER (WHERE asset_list IS NOT NULL), JSONB_BUILD_ARRAY())
+            ) AS tx_collateral_inputs
           FROM _all_collateral_inputs ACI
           WHERE ACI.tx_id = ATX.id
-          GROUP BY payment_addr_bech32, payment_addr_cred, stake_addr, ACI.tx_hash, tx_index, value
+          GROUP BY payment_addr_bech32, payment_addr_cred, stake_addr, ACI.tx_hash, tx_index, value, datum_hash, inline_datum, reference_script
         ) AS tmp
-      ), JSON_BUILD_ARRAY()),
+      ), JSONB_BUILD_ARRAY()),
       COALESCE((
-        SELECT JSON_AGG(tx_inputs)
+        SELECT JSONB_AGG(tx_collateral_outputs)
         FROM (
           SELECT
-            JSON_BUILD_OBJECT(
-              'payment_addr', JSON_BUILD_OBJECT(
+            JSONB_BUILD_OBJECT(
+              'payment_addr', JSONB_BUILD_OBJECT(
+                'bech32', payment_addr_bech32,
+                'cred', payment_addr_cred
+              ),
+              'stake_addr', stake_addr,
+              'tx_hash', ACO.tx_hash,
+              'tx_index', tx_index,
+              'value', value,
+              'datum_hash', datum_hash,
+              'inline_datum', inline_datum,
+              'reference_script', reference_script,
+              'asset_list', COALESCE(JSONB_AGG(asset_list) FILTER (WHERE asset_list IS NOT NULL), JSONB_BUILD_ARRAY())
+            ) AS tx_collateral_outputs
+          FROM _all_collateral_outputs ACO
+          WHERE ACO.tx_id = ATX.id
+          GROUP BY payment_addr_bech32, payment_addr_cred, stake_addr, ACO.tx_hash, tx_index, value, datum_hash, inline_datum, reference_script
+        ) AS tmp
+      ), JSONB_BUILD_ARRAY()),
+      COALESCE((
+        SELECT JSONB_AGG(tx_reference_inputs)
+        FROM (
+          SELECT
+            JSONB_BUILD_OBJECT(
+              'payment_addr', JSONB_BUILD_OBJECT(
+                'bech32', payment_addr_bech32,
+                'cred', payment_addr_cred
+              ),
+              'stake_addr', stake_addr,
+              'tx_hash', ARI.tx_hash,
+              'tx_index', tx_index,
+              'value', value,
+              'datum_hash', datum_hash,
+              'inline_datum', inline_datum,
+              'reference_script', reference_script,
+              'asset_list', COALESCE(JSONB_AGG(asset_list) FILTER (WHERE asset_list IS NOT NULL), JSONB_BUILD_ARRAY())
+            ) AS tx_reference_inputs
+          FROM _all_reference_inputs ARI
+          WHERE ARI.tx_id = ATX.id
+          GROUP BY payment_addr_bech32, payment_addr_cred, stake_addr, ARI.tx_hash, tx_index, value, datum_hash, inline_datum, reference_script
+        ) AS tmp
+      ), JSONB_BUILD_ARRAY()),
+      COALESCE((
+        SELECT JSONB_AGG(tx_inputs)
+        FROM (
+          SELECT
+            JSONB_BUILD_OBJECT(
+              'payment_addr', JSONB_BUILD_OBJECT(
                 'bech32', payment_addr_bech32,
                 'cred', payment_addr_cred
               ),
@@ -560,19 +784,22 @@ BEGIN
               'tx_hash', AI.tx_hash,
               'tx_index', tx_index,
               'value', value,
-              'asset_list', COALESCE(JSON_AGG(asset_list) FILTER (WHERE asset_list IS NOT NULL), JSON_BUILD_ARRAY())
+              'datum_hash', datum_hash,
+              'inline_datum', inline_datum,
+              'reference_script', reference_script,
+              'asset_list', COALESCE(JSONB_AGG(asset_list) FILTER (WHERE asset_list IS NOT NULL), JSONB_BUILD_ARRAY())
             ) AS tx_inputs
           FROM _all_inputs AI
           WHERE AI.tx_id = ATX.id
-          GROUP BY payment_addr_bech32, payment_addr_cred, stake_addr, AI.tx_hash, tx_index, value
+          GROUP BY payment_addr_bech32, payment_addr_cred, stake_addr, AI.tx_hash, tx_index, value, datum_hash, inline_datum, reference_script
         ) AS tmp
-      ), JSON_BUILD_ARRAY()),
+      ), JSONB_BUILD_ARRAY()),
       COALESCE((
-        SELECT JSON_AGG(tx_outputs)
+        SELECT JSONB_AGG(tx_outputs)
         FROM (
           SELECT
-            JSON_BUILD_OBJECT(
-              'payment_addr', JSON_BUILD_OBJECT(
+            JSONB_BUILD_OBJECT(
+              'payment_addr', JSONB_BUILD_OBJECT(
                 'bech32', payment_addr_bech32,
                 'cred', payment_addr_cred
               ),
@@ -580,19 +807,22 @@ BEGIN
               'tx_hash', AO.tx_hash,
               'tx_index', tx_index,
               'value', value,
-              'asset_list', COALESCE(JSON_AGG(asset_list) FILTER (WHERE asset_list IS NOT NULL), JSON_BUILD_ARRAY())
+              'datum_hash', datum_hash,
+              'inline_datum', inline_datum,
+              'reference_script', reference_script,
+              'asset_list', COALESCE(JSONB_AGG(asset_list) FILTER (WHERE asset_list IS NOT NULL), JSONB_BUILD_ARRAY())
             ) AS tx_outputs
           FROM _all_outputs AO
           WHERE AO.tx_id = ATX.id
-          GROUP BY payment_addr_bech32, payment_addr_cred, stake_addr, AO.tx_hash, tx_index, value
+          GROUP BY payment_addr_bech32, payment_addr_cred, stake_addr, AO.tx_hash, tx_index, value, datum_hash, inline_datum, reference_script
         ) AS tmp
-      ), JSON_BUILD_ARRAY()),
-      COALESCE((SELECT AW.list  FROM _all_withdrawals AW        WHERE AW.tx_id  = ATX.id), JSON_BUILD_ARRAY()),
-      COALESCE((SELECT AMI.list FROM _all_mints AMI             WHERE AMI.tx_id = ATX.id), JSON_BUILD_ARRAY()),
-      COALESCE((SELECT AME.list FROM _all_metadata AME          WHERE AME.tx_id = ATX.id), JSON_BUILD_ARRAY()),
-      COALESCE((SELECT AC.list  FROM _all_certs AC              WHERE AC.tx_id  = ATX.id), JSON_BUILD_ARRAY()),
-      COALESCE((SELECT ANS.list FROM _all_native_scripts ANS    WHERE ANS.tx_id = ATX.id), JSON_BUILD_ARRAY()),
-      COALESCE((SELECT APC.list FROM _all_plutus_contracts APC  WHERE APC.tx_id = ATX.id), JSON_BUILD_ARRAY())
+      ), JSONB_BUILD_ARRAY()),
+      COALESCE((SELECT AW.list  FROM _all_withdrawals AW        WHERE AW.tx_id  = ATX.id), JSONB_BUILD_ARRAY()),
+      COALESCE((SELECT AMI.list FROM _all_mints AMI             WHERE AMI.tx_id = ATX.id), JSONB_BUILD_ARRAY()),
+      COALESCE((SELECT AME.list FROM _all_metadata AME          WHERE AME.tx_id = ATX.id), JSONB_BUILD_ARRAY()),
+      COALESCE((SELECT AC.list  FROM _all_certs AC              WHERE AC.tx_id  = ATX.id), JSONB_BUILD_ARRAY()),
+      COALESCE((SELECT ANS.list FROM _all_native_scripts ANS    WHERE ANS.tx_id = ATX.id), JSONB_BUILD_ARRAY()),
+      COALESCE((SELECT APC.list FROM _all_plutus_contracts APC  WHERE APC.tx_id = ATX.id), JSONB_BUILD_ARRAY())
     FROM
       _all_tx ATX
     WHERE ATX.tx_hash = ANY (_tx_hashes_bytea)

--- a/files/grest/rpc/transactions/tx_info.sql
+++ b/files/grest/rpc/transactions/tx_info.sql
@@ -540,7 +540,7 @@ BEGIN
                 'protocol_minor', PP.protocol_minor,
                 'min_utxo_value', PP.min_utxo_value,
                 'min_pool_cost', PP.min_pool_cost,
-                'cost_model_id', PP.cost_model_id,
+                'cost_model', CM.costs,
                 'price_mem', PP.price_mem,
                 'price_step', PP.price_step,
                 'max_tx_ex_mem', PP.max_tx_ex_mem,
@@ -555,6 +555,7 @@ BEGIN
             ) AS data
           FROM 
             public.param_proposal PP
+            INNER JOIN cost_model CM ON CM.id = PP.cost_model_id
           WHERE
             PP.registered_tx_id = ANY (_tx_id_list)
           --


### PR DESCRIPTION
## Description
- Use jsonb instead of json due to 'could not identify an equality operator for type json' issue.
- collateral_outputs and reference_inputs added.
- collaterals renamed to collateral_inputs.
- datum_hash, inline_datum & reference_script added to collateral inputs/outputs, reference inputs & inputs/outputs json.

## Where should the reviewer start?

## Motivation and context
Changes due to Vasil HF

## Which issue it fixes?

## How has this been tested?
Tested that it runs without errors and returns data for new fields. 

## TODO

- [ ] more tests to confirm correctness
- [ ] add new fields to koios-artifacts
- [ ] performance regression testing
