### PR TITLE
tx_utxos update

### DIFF
--- a/files/grest/rpc/transactions/tx_utxos.sql
+++ b/files/grest/rpc/transactions/tx_utxos.sql
@@ -42,100 +42,110 @@ BEGIN
         WHERE tx.id = ANY (_tx_id_list)
       ),
 
-      _all_outputs AS (
-        SELECT
-          tx_id,
-          JSON_AGG(t_outputs) AS list
-        FROM (
-          SELECT 
-            tx_out.tx_id,
-            JSON_BUILD_OBJECT(
-              'payment_addr', JSON_BUILD_OBJECT(
-                'bech32', tx_out.address,
-                'cred', ENCODE(tx_out.payment_cred, 'hex')
-              ),
-              'stake_addr', SA.view,
-              'tx_hash', ENCODE(_all_tx.tx_hash, 'hex'),
-              'tx_index', tx_out.index,
-              'value', tx_out.value::text,
-              'asset_list', COALESCE((
-                SELECT
-                  JSON_AGG(JSON_BUILD_OBJECT(
-                    'policy_id', ENCODE(MA.policy, 'hex'),
-                    'asset_name', ENCODE(MA.name, 'hex'),
-                    'quantity', MTX.quantity::text
-                  ))
-                FROM 
-                  ma_tx_out MTX
-                  INNER JOIN MULTI_ASSET MA ON MA.id = MTX.ident
-                WHERE 
-                  MTX.tx_out_id = tx_out.id
-              ), JSON_BUILD_ARRAY())
-            ) AS t_outputs
-          FROM
-            tx_out
-            INNER JOIN _all_tx ON tx_out.tx_id = _all_tx.tx_id
-            LEFT JOIN stake_address SA on tx_out.stake_address_id = SA.id
-          WHERE 
-            tx_out.tx_id = ANY (_tx_id_list)
-        ) AS tmp
-
-        GROUP BY tx_id
-        ORDER BY tx_id
-      ),
-
       _all_inputs AS (
         SELECT
-          tx_id,
-          JSON_AGG(t_inputs) AS list
-        FROM (
-          SELECT 
-            tx_in.tx_in_id AS tx_id,
-            JSON_BUILD_OBJECT(
-              'payment_addr', JSON_BUILD_OBJECT(
-                'bech32', tx_out.address,
-                'cred', ENCODE(tx_out.payment_cred, 'hex')
-              ),
-              'stake_addr', SA.view,
-              'tx_hash', ENCODE(tx.hash, 'hex'),
-              'tx_index', tx_out.index,
-              'value', tx_out.value::text,
-              'asset_list', COALESCE((
-                SELECT 
-                  JSON_AGG(JSON_BUILD_OBJECT(
-                    'policy_id', ENCODE(MA.policy, 'hex'),
-                    'asset_name', ENCODE(MA.name, 'hex'),
-                    'quantity', MTX.quantity::text
-                  ))
-                FROM 
-                  ma_tx_out MTX
-                  INNER JOIN MULTI_ASSET MA ON MA.id = MTX.ident
-                WHERE 
-                  MTX.tx_out_id = tx_out.id
-              ), JSON_BUILD_ARRAY())
-            ) AS t_inputs
-          FROM
-            tx_in
-            INNER JOIN tx_out ON tx_out.tx_id = tx_in.tx_out_id
-              AND tx_out.index = tx_in.tx_out_index
-            INNER JOIN tx on tx_out.tx_id = tx.id
-            LEFT JOIN stake_address SA on tx_out.stake_address_id = SA.id
-          WHERE 
-            tx_in.tx_in_id = ANY (_tx_id_list)
-        ) AS tmp
+          tx_in.tx_in_id                      AS tx_id,
+          tx_out.address                      AS payment_addr_bech32,
+          ENCODE(tx_out.payment_cred, 'hex')  AS payment_addr_cred,
+          SA.view                             AS stake_addr,
+          ENCODE(tx.hash, 'hex')              AS tx_hash,
+          tx_out.index                        AS tx_index,
+          tx_out.value::text                  AS value,
+          ( CASE WHEN MA.policy IS NULL THEN NULL
+            ELSE
+              JSON_BUILD_OBJECT(
+                'policy_id', ENCODE(MA.policy, 'hex'),
+                'asset_name', ENCODE(MA.name, 'hex'),
+                'fingerprint', MA.fingerprint,
+                'quantity', MTO.quantity::text
+              )
+            END
+          )                                   AS asset_list
+        FROM
+          tx_in
+          INNER JOIN tx_out ON tx_out.tx_id = tx_in.tx_out_id
+            AND tx_out.index = tx_in.tx_out_index
+          INNER JOIN tx on tx_out.tx_id = tx.id
+          LEFT JOIN stake_address SA ON tx_out.stake_address_id = SA.id
+          LEFT JOIN ma_tx_out MTO ON MTO.tx_out_id = tx_out.id
+          LEFT JOIN multi_asset MA ON MA.id = MTO.ident
+        WHERE 
+          tx_in.tx_in_id = ANY (_tx_id_list)
+      ),
 
-        GROUP BY tx_id
-        ORDER BY tx_id
+      _all_outputs AS (
+        SELECT
+          tx_out.tx_id,
+          tx_out.address                      AS payment_addr_bech32,
+          ENCODE(tx_out.payment_cred, 'hex')  AS payment_addr_cred,
+          SA.view                             AS stake_addr,
+          ENCODE(tx.hash, 'hex')              AS tx_hash,
+          tx_out.index                        AS tx_index,
+          tx_out.value::text                  AS value,
+          ( CASE WHEN MA.policy IS NULL THEN NULL
+            ELSE
+              JSON_BUILD_OBJECT(
+                'policy_id', ENCODE(MA.policy, 'hex'),
+                'asset_name', ENCODE(MA.name, 'hex'),
+                'fingerprint', MA.fingerprint,
+                'quantity', MTO.quantity::text
+              )
+            END
+          )                                   AS asset_list
+        FROM
+          tx_out
+          INNER JOIN tx ON tx_out.tx_id = tx.id
+          LEFT JOIN stake_address SA ON tx_out.stake_address_id = SA.id
+          LEFT JOIN ma_tx_out MTO ON MTO.tx_out_id = tx_out.id
+          LEFT JOIN multi_asset MA ON MA.id = MTO.ident
+        WHERE 
+          tx_out.tx_id = ANY (_tx_id_list)
       )
 
     SELECT
-      ENCODE(ATX.tx_hash, 'hex'),
-      COALESCE(AI.list, JSON_BUILD_ARRAY()),
-      COALESCE(AO.list, JSON_BUILD_ARRAY())
+      ENCODE(ATX.tx_hash, 'hex'),      
+      COALESCE((
+        SELECT JSON_AGG(tx_inputs)
+        FROM (
+          SELECT
+            JSON_BUILD_OBJECT(
+              'payment_addr', JSON_BUILD_OBJECT(
+                'bech32', payment_addr_bech32,
+                'cred', payment_addr_cred
+              ),
+              'stake_addr', stake_addr,
+              'tx_hash', AI.tx_hash,
+              'tx_index', tx_index,
+              'value', value,
+              'asset_list', COALESCE(JSON_AGG(asset_list) FILTER (WHERE asset_list IS NOT NULL), JSON_BUILD_ARRAY())
+            ) AS tx_inputs
+          FROM _all_inputs AI
+          WHERE AI.tx_id = ATX.tx_id
+          GROUP BY payment_addr_bech32, payment_addr_cred, stake_addr, AI.tx_hash, tx_index, value
+        ) AS tmp
+      ), JSON_BUILD_ARRAY()),
+      COALESCE((
+        SELECT JSON_AGG(tx_outputs)
+        FROM (
+          SELECT
+            JSON_BUILD_OBJECT(
+              'payment_addr', JSON_BUILD_OBJECT(
+                'bech32', payment_addr_bech32,
+                'cred', payment_addr_cred
+              ),
+              'stake_addr', stake_addr,
+              'tx_hash', AO.tx_hash,
+              'tx_index', tx_index,
+              'value', value,
+              'asset_list', COALESCE(JSON_AGG(asset_list) FILTER (WHERE asset_list IS NOT NULL), JSON_BUILD_ARRAY())
+            ) AS tx_outputs
+          FROM _all_outputs AO
+          WHERE AO.tx_id = ATX.tx_id
+          GROUP BY payment_addr_bech32, payment_addr_cred, stake_addr, AO.tx_hash, tx_index, value
+        ) AS tmp
+      ), JSON_BUILD_ARRAY())
     FROM
       _all_tx ATX
-      LEFT JOIN _all_inputs AI ON AI.tx_id = ATX.tx_id
-      LEFT JOIN _all_outputs AO ON AO.tx_id = ATX.tx_id
     WHERE ATX.tx_hash = ANY (_tx_hashes_bytea)
 );
 


### PR DESCRIPTION
## Description
Update tx_utxos to include optimizations from tx_info + asset fingerpint. Note that this is a simplified version of tx_info that does not include inline datums, or reference scripts. It only returns normal output and input utxo's. For collateral inputs/outputs and reference inputs, please use tx_info endpoint instead.  

## Where should the reviewer start?
-

## Motivation and context
Improve speed and align with tx_info.

## Which issue it fixes?
-

## How has this been tested?
It has been tested on testnet.
