### PR TITLE
Move tx_metalabels to use loose indexscan

### DIFF
--- a/files/grest/rpc/transactions/tx_metalabels.sql
+++ b/files/grest/rpc/transactions/tx_metalabels.sql
@@ -1,0 +1,21 @@
+DROP FUNCTION IF EXISTS grest.tx_metalabels;
+
+CREATE FUNCTION grest.tx_metalabels()
+  RETURNS TABLE (key word64type)
+  LANGUAGE PLPGSQL
+  AS $$
+BEGIN
+  RETURN QUERY
+  WITH RECURSIVE t AS (
+    (SELECT tm.key FROM public.tx_metadata tm ORDER BY key LIMIT 1) 
+    UNION ALL
+    SELECT (SELECT tm.key FROM tx_metadata tm WHERE tm.key > t.key ORDER BY key LIMIT 1)
+    FROM t
+      WHERE t.key IS NOT NULL
+  )
+  SELECT t.key FROM t WHERE t.key IS NOT NULL;
+END;
+$$;
+
+COMMENT ON FUNCTION grest.tx_metalabels IS 'Get a list of all transaction metalabels';
+

--- a/files/grest/rpc/views/tx_metalabels.sql
+++ b/files/grest/rpc/views/tx_metalabels.sql
@@ -1,9 +1,0 @@
-DROP VIEW IF EXISTS grest.tx_metalabels;
-
-CREATE VIEW grest.tx_metalabels AS SELECT DISTINCT
-  key::text as metalabel
-FROM
-  public.tx_metadata;
-
-COMMENT ON VIEW grest.tx_metalabels IS 'Get a list of all transaction metalabels';
-


### PR DESCRIPTION
## Description

As found/suggested by @Scitz0 in #1470 , tx_metalabels view was not usable anymore as on some instances it took ~14-32s. Using the suggestion, it's down to ~10-15ms (only difference being it's now pre-sorted)