### PR TITLE
gLiveView 1.27.1

### DIFF
--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -57,7 +57,7 @@ setTheme() {
 # Do NOT modify code below           #
 ######################################
 
-GLV_VERSION=v1.27.0
+GLV_VERSION=v1.27.1
 
 PARENT="$(dirname $0)"
 
@@ -629,6 +629,8 @@ tlines=$(tput lines) # set initial terminal lines
 tcols=$(tput cols)   # set initial terminal columns
 printf "${NC}"       # reset and set default color
 
+unset cpu_now cpu_last
+
 #####################################
 # MAIN LOOP                         #
 #####################################
@@ -696,13 +698,24 @@ while true; do
       fi
     fi
 
-    read -ra proc_data <<<"$(ps -q ${CNODE_PID} -o pcpu= -o rss=)"
-    if [[ ${#proc_data[@]} -eq 2 ]]; then
-      proc_cpu=${proc_data[0]}
-      mem_rss=${proc_data[1]}
+    mem_rss="$(ps -q ${CNODE_PID} -o rss=)"
+    read -ra cpu_now <<< "$(awk '/cpu /{print $2+$4,$2+$4+$5}' /proc/stat)"
+    if [[ ${#cpu_now[@]} -eq 2 ]]; then
+      if [[ ${#cpu_last[@]} -eq 2 ]]; then
+        cpu_util=$(bc -l <<< "100*((${cpu_now[0]}-${cpu_last[0]})/(${cpu_now[1]}-${cpu_last[1]}))")
+        if [[ ${cpu_util%.*} -gt 99 ]]; then
+          cpu_util=$(printf "%.0f" "${cpu_util}")
+        elif [[ ${cpu_util%.*} -gt 9 ]]; then
+          cpu_util=$(printf "%.1f" "${cpu_util}")
+        else
+          cpu_util=$(printf "%.2f" "${cpu_util}")
+        fi
+      else
+        cpu_util="0.0"
+      fi
+      cpu_last=("${cpu_now[@]}")
     else
-      proc_cpu="0.0"
-      mem_rss=0
+      cpu_util="0.0"
     fi
     if [[ ${about_to_lead} -gt 0 ]]; then
       [[ ${nodemode} != "Core" ]] && clrScreen && nodemode="Core"
@@ -1032,7 +1045,7 @@ while true; do
     echo "${resourcesdivider}" && ((line++))
 
     # row 1
-    printf "${VL} CPU node   : ${style_values_1}%s${NC}%-$((three_col_1_value_width - ${#proc_cpu}))s" "${proc_cpu}" "%"
+    printf "${VL} CPU (sys)  : ${style_values_1}%s${NC}%-$((three_col_1_value_width - ${#cpu_util}))s" "${cpu_util}" "%"
     mvThreeSecond
     printf -v mem_live_gb "%.1f" "$(bc -l <<<"(${mem_live}/1073741824)")"
     printf "Mem (Live) : ${style_values_1}%s${NC}%-$((three_col_3_value_width - ${#mem_live_gb}))s" "${mem_live_gb}" "G"


### PR DESCRIPTION
## Description
CPU utilization showed an average value since process start. This isn't that useful. This is now replaced by grabbing stats from /proc/stat instead. This is a system metric, not a node metric. But there are no good alternatives to grab just the process cpu utilization. top could be parsed but its a very heavy endpoint to parse. For now I think this is the best option.

## Where should the reviewer start?

## Motivation and context

## Which issue it fixes?

## How has this been tested?
Tested locally to give a correct value
