### PR TITLE
[EIC] Only update last_tx_id of previous epoch on epoch transition

### DIFF
--- a/files/grest/rpc/01_cached_tables/epoch_info_cache.sql
+++ b/files/grest/rpc/01_cached_tables/epoch_info_cache.sql
@@ -189,6 +189,7 @@ BEGIN
           INNER JOIN tx ON tx.block_id = b.id
         WHERE
           b.epoch_no = e.no
+          AND b.epoch_no <> _curr_epoch
       ) last_tx ON TRUE
     WHERE
       e.no >= _epoch_no_to_insert_from

--- a/files/grest/rpc/01_cached_tables/epoch_info_cache.sql
+++ b/files/grest/rpc/01_cached_tables/epoch_info_cache.sql
@@ -189,7 +189,6 @@ BEGIN
           INNER JOIN tx ON tx.block_id = b.id
         WHERE
           b.epoch_no = e.no
-          AND b.epoch_no <> _curr_epoch
       ) last_tx ON TRUE
     WHERE
       e.no >= _epoch_no_to_insert_from
@@ -221,7 +220,8 @@ BEGIN
         INNER JOIN tx ON tx.block_id = b.id
       WHERE
         b.epoch_no = _epoch_no_to_update
-    ) last_tx;
+    ) last_tx
+    WHERE epoch_no = _epoch_no_to_update;
   END IF;
 
   UPDATE


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
The epoch transition part of the function was overwriting `i_last_tx_id`  values for all epochs instead of just the recently finished one.

~I removed `AND b.epoch_no <> _curr_epoch`, is there any use for it?~