### PR TITLE
CNTools 10.0.2

### DIFF
--- a/docs/Scripts/cntools-changelog.md
+++ b/docs/Scripts/cntools-changelog.md
@@ -6,6 +6,13 @@ All notable changes to this tool will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.0.2] - 2022-08-13
+#### Fixed
+- Bump min cardano-hw-cli version to 1.10.0
+- Requires cardano-hw-cli to be present on online node for pool registration/modification to be able to transform tx if needed
+- Transform tx if needed before any witnessing/signing is done.
+- Wrong arguments in call to cardano-hw-cli for cddl-formatted tx
+
 ## [10.0.1] - 2022-07-14
 #### Changed
 - Transactions now built using cddl-format to ensure that the formatting of transaction adheres the ledger specs.

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -11,7 +11,7 @@ CNTOOLS_MAJOR_VERSION=10
 # Minor: Changes and features of minor character that can be applied without breaking existing functionality or workflow
 CNTOOLS_MINOR_VERSION=0
 # Patch: Backwards compatible bug fixes. No additional functionality or major changes
-CNTOOLS_PATCH_VERSION=1
+CNTOOLS_PATCH_VERSION=2
 
 CNTOOLS_VERSION="${CNTOOLS_MAJOR_VERSION}.${CNTOOLS_MINOR_VERSION}.${CNTOOLS_PATCH_VERSION}"
 
@@ -1735,6 +1735,16 @@ registerPool() {
   [[ -n ${owner_delegation_cert} ]] && build_args+=( --certificate-file "${owner_delegation_cert}" )
 
   if ! buildTx; then return 1; fi
+
+  needHWCLI=false
+  for index in "${!owner_wallets[@]}"; do
+    stake_vk_file="${WALLET_FOLDER}/${owner_wallets[${index}]}/${WALLET_STAKE_VK_FILENAME}"
+    [[ $(jq .description "${stake_vk_file}") = *Hardware* ]] && needHWCLI=true && break
+  done
+  if [[ ${needHWCLI} = true ]]; then
+    if ! HWCLIversionCheck; then return 1; fi
+    if ! transformRawTx "${TMP_DIR}"/tx.raw; then return 1; fi
+  fi
   
   if [[ ${op_mode} = "hybrid" ]]; then
     if ! buildOfflineJSON "Pool Registration"; then return 1; fi
@@ -1849,6 +1859,16 @@ modifyPool() {
   )
 
   if ! buildTx; then return 1; fi
+
+  needHWCLI=false
+  for index in "${!owner_wallets[@]}"; do
+    stake_vk_file="${WALLET_FOLDER}/${owner_wallets[${index}]}/${WALLET_STAKE_VK_FILENAME}"
+    [[ $(jq .description "${stake_vk_file}") = *Hardware* ]] && needHWCLI=true && break
+  done
+  if [[ ${needHWCLI} = true ]]; then
+    if ! HWCLIversionCheck; then return 1; fi
+    if ! transformRawTx "${TMP_DIR}"/tx.raw; then return 1; fi
+  fi
   
   if [[ ${op_mode} = "hybrid" ]]; then
     if ! buildOfflineJSON "Pool Update"; then return 1; fi
@@ -2392,7 +2412,6 @@ witnessTx() {
       return 1
     elif [[ $(jq -r '.description' "${skey}") = *"Hardware"* ]]; then # HW signing key
       if ! unlockHWDevice "witness the transaction"; then return 1; fi
-      if ! transformRawTx "${tx_raw}"; then return 1; fi
       tx_witness="$(mktemp "${TMP_DIR}/tx.witness_XXXXXXXXXX")"
       witness_command=(
         cardano-hw-cli transaction witness
@@ -2457,6 +2476,9 @@ signTx() {
   tx_raw="$1"
   shift
   tx_signed="${TMP_DIR}/tx.signed_$(date +%s)"
+  if HWCLIversionCheck >/dev/null; then 
+    if ! transformRawTx "${tx_raw}"; then return 1; fi
+  fi
   if [[ $# -gt 0 ]]; then
     tx_sign_out=()
     hw_wallet='N'
@@ -2480,7 +2502,6 @@ signTx() {
     done
     if [[ ${hw_wallet} = 'Y' ]]; then
       if ! unlockHWDevice "sign the transaction"; then return 1; fi
-      if ! transformRawTx "${tx_raw}"; then return 1; fi
       sign_command=(
         cardano-hw-cli transaction sign
         --tx-body-file "${tx_raw}"
@@ -2528,8 +2549,8 @@ submitTx() {
 transformRawTx() {
   tx_raw="$1"
   tx_raw_tmp="$(mktemp "${TMP_DIR}/tx.raw_XXXXXXXXXX")"
-  println ACTION "cardano-hw-cli transaction transform-raw --tx-body-file ${tx_raw} --out-file ${tx_raw_tmp}"
-  if ! cardano-hw-cli transaction transform-raw --tx-body-file "${tx_raw}" --out-file "${tx_raw_tmp}" >/dev/null; then return 1; fi
+  println ACTION "cardano-hw-cli transaction transform --tx-file ${tx_raw} --out-file ${tx_raw_tmp}"
+  if ! cardano-hw-cli transaction transform --tx-file "${tx_raw}" --out-file "${tx_raw_tmp}" >/dev/null; then return 1; fi
   println ACTION "mv ${tx_raw_tmp} ${tx_raw}"
   if ! mv "${tx_raw_tmp}" "${tx_raw}" >/dev/null; then return 1; fi
 }
@@ -2567,11 +2588,12 @@ unlockHWDevice() {
 }
 
 HWCLIversionCheck() {
+  ! command -v "cardano-hw-cli" &>/dev/null && echo "cardano-hw-cli not found, please install using prereqs.sh with -w option" && return 1
   println ACTION "cardano-hw-cli version"
   HWCLI_version="$(cardano-hw-cli version 2>/dev/null | head -n 1 | cut -d' ' -f6)"
   println LOG "cardano-hw-cli version: ${HWCLI_version}"
-  if ! versionCheck "1.9.0" "${HWCLI_version}"; then
-    println ERROR "${FG_RED}ERROR${NC}: Vacuumlabs cardano-hw-cli ${FG_LGRAY}v${HWCLI_version}${NC} installed on system, minimum required version is ${FG_GREEN}v1.9.0${NC} !!"
+  if ! versionCheck "1.10.0" "${HWCLI_version}"; then
+    println ERROR "${FG_RED}ERROR${NC}: Vacuumlabs cardano-hw-cli ${FG_LGRAY}v${HWCLI_version}${NC} installed on system, minimum required version is ${FG_GREEN}v1.10.0${NC} !!"
     println ERROR "Please run ${FG_LGRAY}prereqs.sh -w${NC} to upgrade to the latest version."
     return 1
   fi

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -2415,7 +2415,7 @@ witnessTx() {
       tx_witness="$(mktemp "${TMP_DIR}/tx.witness_XXXXXXXXXX")"
       witness_command=(
         cardano-hw-cli transaction witness
-        --tx-body-file "${tx_raw}"
+        --tx-file "${tx_raw}"
         --hw-signing-file "${skey}"
         ${NETWORK_IDENTIFIER}
         --out-file "${tx_witness}"
@@ -2504,7 +2504,7 @@ signTx() {
       if ! unlockHWDevice "sign the transaction"; then return 1; fi
       sign_command=(
         cardano-hw-cli transaction sign
-        --tx-body-file "${tx_raw}"
+        --tx-file "${tx_raw}"
         ${tx_sign_out[@]}
         ${NETWORK_IDENTIFIER}
         --out-file "${tx_signed}"

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -2085,7 +2085,7 @@ function main {
               fi
 
               if [[ ${reuse_wallets} = 'N' ]]; then
-                println DEBUG "\nRegister a multi-owner pool (you need to have stake.vkey of any additional owner in a seperate wallet folder under \$CNODE_HOME/priv/wallet)?"
+                println DEBUG "\nRegister a multi-owner pool (you need to have stake.vkey of any additional owner in a seperate wallet folder under $CNODE_HOME/priv/wallet)?"
                 while true; do
                   select_opt "[n] No" "[y] Yes" "[Esc] Cancel"
                   case $? in


### PR DESCRIPTION
## Description
- Bump min cardano-hw-cli version to 1.10.0
- Requires cardano-hw-cli to be present on online node for pool registration/modification to be able to transform tx if needed
- Transform tx if needed before any witnessing/signing is done.
- Wrong arguments in call to cardano-hw-cli for cddl-formatted tx

## Where should the reviewer start?

## Motivation and context

## Which issue it fixes?

## How has this been tested?
Tested on guild network in online mode without any hardware device as owner + hybrid/offline mode with a Ledger. 
