### PR TITLE
cncli: export SHELLEY_TRANS_EPOCH

### DIFF
--- a/scripts/cnode-helper-scripts/cncli.sh
+++ b/scripts/cnode-helper-scripts/cncli.sh
@@ -203,6 +203,9 @@ cncliInit() {
     [[ -z "${POOL_VRF_VKEY}" ]] && POOL_VRF_VKEY="${POOL_DIR}/${POOL_VRF_VK_FILENAME}"
   fi
 
+  # export SHELLEY_TRANS_EPOCH to be seen by cncli
+  export SHELLEY_TRANS_EPOCH
+
   return 0
 }
 


### PR DESCRIPTION
## Description
export SHELLEY_TRANS_EPOCH due to update of cncli that requires this env variable to be set, alternatively set as param to cncli call. 

## Where should the reviewer start?

## Motivation and context

## Which issue it fixes?

## How has this been tested?
untested as new cncli version is not available yet
