### PR TITLE
[EIC] Use last valid tx if no txs in epoch

### DIFF
--- a/files/grest/rpc/01_cached_tables/epoch_info_cache.sql
+++ b/files/grest/rpc/01_cached_tables/epoch_info_cache.sql
@@ -220,7 +220,9 @@ BEGIN
         block b
         INNER JOIN tx ON tx.block_id = b.id
       WHERE
-        b.epoch_no = _epoch_no_to_update
+        b.epoch_no <= _epoch_no_to_update
+        AND b.block_no IS NOT NULL
+        AND b.tx_count != 0
     ) last_tx
     WHERE epoch_no = _epoch_no_to_update;
   END IF;


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Epoch info cache had a bug where no tx is populated if there were no txs in the epoch.