### PR TITLE
Replace book.world references with github sources instead

### DIFF
--- a/scripts/cnode-helper-scripts/prereqs.sh
+++ b/scripts/cnode-helper-scripts/prereqs.sh
@@ -471,7 +471,7 @@ if [[ ${NETWORK} = "guild" ]]; then
   curl -s -f -m ${CURL_TIMEOUT} -o topology.json.tmp ${URL_RAW}/files/topology-guild.json
   curl -s -f -m ${CURL_TIMEOUT} -o config.json.tmp ${URL_RAW}/files/config-guild.json
 elif [[ ${NETWORK} =~ ^(mainnet|preprod|preview|testnet)$ ]]; then # testnet will be retired , already marked as legacy soon
-  NWCONFURL="https://book.world.dev.cardano.org/environments"
+  NWCONFURL="https://raw.githubusercontent.com/input-output-hk/cardano-world/master/docs/environments"
   curl -sL -f -m ${CURL_TIMEOUT} -o byron-genesis.json.tmp "${NWCONFURL}/${NETWORK}/byron-genesis.json"
   curl -sL -f -m ${CURL_TIMEOUT} -o shelley-genesis.json.tmp "${NWCONFURL}/${NETWORK}/shelley-genesis.json"
   curl -sL -f -m ${CURL_TIMEOUT} -o alonzo-genesis.json.tmp "${NWCONFURL}/${NETWORK}/alonzo-genesis.json"


### PR DESCRIPTION
Avoid having additional dependency on book.world.dev.cardano.org website, which does not seem to be looked after across global timezones