### PR TITLE
add CNODE_NAME to backup filename

### DIFF
--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -3576,9 +3576,9 @@ function main {
                    "--delete *${ASSET_POLICY_SK_FILENAME}"
                    "--delete *${ASSET_POLICY_SK_FILENAME}.gpg"
                  )
-                 backup_file="${backup_path}online_cntools_backup-$(date '+%Y%m%d%H%M%S').tar"
+                 backup_file="${backup_path}online_cntools_backup-$(date '+%Y%m%d%H%M%S').${CNODE_NAME}.tar"
                  ;;
-              1) backup_file="${backup_path}offline_cntools_backup-$(date '+%Y%m%d%H%M%S').tar" ;;
+              1) backup_file="${backup_path}offline_cntools_backup-$(date '+%Y%m%d%H%M%S').${CNODE_NAME}.tar" ;;
             esac
             echo
             backup_source=(


### PR DESCRIPTION
## Description
I modified the cntools.sh backup filename by adding the CNODE_NAME (the one that comes from prereqs.sh -t) which comes with env.

## Where should the reviewer start?
backup operations..

## Motivation and context
We may need to deploy many instances within /opt/cardano base dir.
I thought it could help to know which instance a backup comes from by simply reading its filename instead of having to decrypt/list the produced backup.

## Which issue it fixes?
n/a

## How has this been tested?
I did backups from cntools.sh, and produced the following files:
-rw-rw-r-- 1 ubuntu ubuntu  3851 Aug 30 12:03 offline_cntools_backup-20220830120303.mix02.tar.gz.gpg
-rw-rw-r-- 1 ubuntu ubuntu  3733 Aug 30 12:03 offline_cntools_backup-20220830120333.mix02.tar.gz
-rw-rw-r-- 1 ubuntu ubuntu  3512 Aug 30 12:02 online_cntools_backup-20220830120214.mix02.tar.gz.gpg
-rw-rw-r-- 1 ubuntu ubuntu  3395 Aug 30 12:02 online_cntools_backup-20220830120248.mix02.tar.gz
Result was the expected one.

