### PR TITLE
Ask for user input to deploy cardano-submit-api as a service

### DIFF
--- a/scripts/cnode-helper-scripts/deploy-as-systemd.sh
+++ b/scripts/cnode-helper-scripts/deploy-as-systemd.sh
@@ -26,9 +26,13 @@ if grep -q "^PGPASSFILE=" "${CNODE_HOME}/scripts/dbsync.sh" 2> /dev/null || [[ -
 fi
 
 echo -e "\e[32m~~ Cardano Submit API ~~\e[0m"
-echo "launches the main submitapi.sh script to deploy cardano-submit-api as service"
+echo "Please note that cardano-submit-api will listen on ports on your system to serve the API."
+echo "Deploy Cardano Submit API as systemd services? [y|n]"
 echo
-./submitapi.sh -d
+read -rsn1 yn
+if [[ ${yn} = [Yy]* ]]; then
+  ./submitapi.sh -d
+fi
 
 if command -v ogmios >/dev/null 2>&1 ; then
   echo -e "\e32m~~ Cardano Ogmios Server ~~\e[0m"

--- a/scripts/cnode-helper-scripts/deploy-as-systemd.sh
+++ b/scripts/cnode-helper-scripts/deploy-as-systemd.sh
@@ -26,7 +26,7 @@ if grep -q "^PGPASSFILE=" "${CNODE_HOME}/scripts/dbsync.sh" 2> /dev/null || [[ -
 fi
 
 echo -e "\e[32m~~ Cardano Submit API ~~\e[0m"
-echo "Deploy Cardano Submit API as systemd services? [y|n]"
+echo "Deploy Cardano Submit API as systemd service? [y|n]"
 echo
 read -rsn1 yn
 if [[ ${yn} = [Yy]* ]]; then

--- a/scripts/cnode-helper-scripts/deploy-as-systemd.sh
+++ b/scripts/cnode-helper-scripts/deploy-as-systemd.sh
@@ -26,7 +26,6 @@ if grep -q "^PGPASSFILE=" "${CNODE_HOME}/scripts/dbsync.sh" 2> /dev/null || [[ -
 fi
 
 echo -e "\e[32m~~ Cardano Submit API ~~\e[0m"
-echo "Please note that cardano-submit-api will listen on ports on your system to serve the API."
 echo "Deploy Cardano Submit API as systemd services? [y|n]"
 echo
 read -rsn1 yn


### PR DESCRIPTION
## Description
Add question + read answer before deploying cardano-submit-api as a service.

## Where should the reviewer start?
run deploy-as-systemd.sh

## Motivation and context
cardano-submit-api binds local IP and listens to a new port.
I strongly believe that end user should decide whether he needs this API service to run or not on his system.

## Which issue it fixes?
n/a

## How has this been tested?
I've run the script and confirmed that systemd service was deployed if answered y and not deployed if answered n.
