### PR TITLE
fix systemd pid file cleanup

### DIFF
--- a/scripts/cnode-helper-scripts/blockPerf.sh
+++ b/scripts/cnode-helper-scripts/blockPerf.sh
@@ -19,7 +19,7 @@
 # Do NOT modify code below           #
 ######################################
 
-BP_VERSION=v1.2.0
+BP_VERSION=v1.2.1
 
 deploy_systemd() {
   echo "Deploying ${CNODE_VNAME} blockPerf as systemd service.."
@@ -42,6 +42,7 @@ StandardError=syslog
 SyslogIdentifier=${CNODE_VNAME}-tu-blockperf
 TimeoutStopSec=5
 KillMode=mixed
+ExecStop=rm -f -- '${CNODE_HOME}/blockPerf-running.pid'
 
 [Install]
 WantedBy=${CNODE_VNAME}.service


### PR DESCRIPTION
## Description
added missing execStop command to cleanup the pid file when service is stopped/restarted

## Where should the reviewer start?
try to start a second instance of the script in shell and or service mode. it should work only once per node instance

## Motivation and context
blockperf script can run as service or in console, but should not report the same data twice.

## Which issue it fixes?
Closes #1508

