### PR TITLE
address_info: Fix join used for asset_info

### DIFF
--- a/files/grest/rpc/address/address_info.sql
+++ b/files/grest/rpc/address/address_info.sql
@@ -23,6 +23,7 @@ BEGIN
       SELECT
         tx.id,
         tx.hash,
+        tx_out.id as txo_id,
         tx_out.address,
         tx_out.value,
         tx_out.index,
@@ -90,7 +91,7 @@ BEGIN
                       ma_tx_out MTX
                       INNER JOIN multi_asset MA ON MA.id = MTX.ident
                   WHERE
-                      MTX.tx_out_id = au.id
+                      MTX.tx_out_id = au.txo_id
                 ),
                 JSON_BUILD_ARRAY()
               )


### PR DESCRIPTION
## Description

For `koios-1.0.7` , the `address_info` endpoint did not return `asset_info` due to an error in join column (tx.id instead of tx_out.id).