### PR TITLE
Add arm64 support for postgrest and prereqs.sh

### DIFF
--- a/scripts/cnode-helper-scripts/prereqs.sh
+++ b/scripts/cnode-helper-scripts/prereqs.sh
@@ -186,6 +186,7 @@ if [ "$WANT_BUILD_DEPS" = 'Y' ]; then
   OS_ID=$(grep -i ^id_like= /etc/os-release | cut -d= -f 2)
   DISTRO=$(grep -i ^NAME= /etc/os-release | cut -d= -f 2)
   VERSION_ID=$(grep -i ^version_id= /etc/os-release | cut -d= -f 2 | tr -d '"' | cut -d. -f 1)
+  ARCH=$(uname -i)
 
   if [[ "${OS_ID}" =~ ebian ]] || [[ "${DISTRO}" =~ ebian ]]; then
     #Debian/Ubuntu
@@ -196,6 +197,9 @@ if [ "$WANT_BUILD_DEPS" = 'Y' ]; then
     $sudo apt-get ${pkg_opts} update > /dev/null
     echo "  Installing missing prerequisite packages, if any.."
     pkg_list="libpq-dev python3 build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev systemd libsystemd-dev libsodium-dev zlib1g-dev make g++ tmux git jq libncursesw5 gnupg aptitude libtool autoconf secure-delete iproute2 bc tcptraceroute dialog automake sqlite3 bsdmainutils libusb-1.0-0-dev libudev-dev unzip"
+    if [ -z "${ARCH##*aarch64*}" ]; then
+      pkg_list="${pkg_list} llvm clang libnuma-dev"
+    fi
     $sudo apt-get ${pkg_opts} install ${pkg_list} > /dev/null;rc=$?
     if [ $rc != 0 ]; then
       echo "An error occurred while installing the prerequisite packages, please investigate by using the command below:"
@@ -227,6 +231,9 @@ if [ "$WANT_BUILD_DEPS" = 'Y' ]; then
       pkg_opts="${pkg_opts} --allowerasing"
       pkg_list="${pkg_list} libusbx ncurses-compat-libs pkgconf-pkg-config srm"
     fi
+    if [ -z "${ARCH##*aarch64*}" ]; then
+      pkg_list="${pkg_list} llvm clang numactl-devel"
+    fi    
     add_epel_repository "${DISTRO}" "${VERSION_ID}" "${pkg_opts}"
     $sudo yum ${pkg_opts} install ${pkg_list} > /dev/null;rc=$?
     if [ $rc != 0 ]; then

--- a/scripts/grest-helper-scripts/setup-grest.sh
+++ b/scripts/grest-helper-scripts/setup-grest.sh
@@ -291,7 +291,13 @@ SGVERSION=1.0.6 # Using versions from 1.0.5-1.0.9 for minor commit alignment bef
   deploy_postgrest() {
     echo "[Re]Installing PostgREST.."
     pushd ~/tmp >/dev/null || err_exit
-    pgrest_asset_url="$(curl -s https://api.github.com/repos/PostgREST/postgrest/releases/latest | jq -r '.assets[].browser_download_url' | grep 'linux-static-x64.tar.xz')"
+    ARCH=$(uname -i)
+    if [ -z "${ARCH##*aarch64*}" ]; then
+      pgrest_binary=ubuntu-aarch64.tar.xz
+    else 
+      pgrest_binary=linux-static-x64.tar.xz
+    fi
+    pgrest_asset_url="$(curl -s https://api.github.com/repos/PostgREST/postgrest/releases/latest | jq -r '.assets[].browser_download_url' | grep ${pgrest_binary})"
     if curl -sL -f -m ${CURL_TIMEOUT} -o postgrest.tar.xz "${pgrest_asset_url}"; then
       tar xf postgrest.tar.xz &>/dev/null && rm -f postgrest.tar.xz
       [[ -f postgrest ]] || err_exit "PostgREST archive downloaded but binary not found after attempting to extract package!"


### PR DESCRIPTION
## Description
Adds support to compile cardano-node on ARM64 platforms by adding needed packages to prereqs.sh.
Downloads arm64 postgrest binary, if detected platform is arm64.

## Where should the reviewer start?
I successfully tested the modifications on ubuntu 22.04.
Tests on redhat based distributions were not performed.
## Motivation and context
Easier installation of koios on cheaper arm based cloud infrastructure.

## Which issue it fixes?
none
## How has this been tested?
I successfully tested the modifications on ubuntu 22.04.
Tests on redhat based distributions were not performed.

## Todo for full arm64 support of koios:
Download arm64 ogmios binary. Ogmios currently does not yet provide pre-compiled binarys. I opened an issue there: https://github.com/CardanoSolutions/ogmios/issues/255
