### PR TITLE
Fix tx_metalabels casting, closes koios-artifacts#95

### DIFF
--- a/files/grest/rpc/transactions/tx_metalabels.sql
+++ b/files/grest/rpc/transactions/tx_metalabels.sql
@@ -7,13 +7,13 @@ CREATE FUNCTION grest.tx_metalabels()
 BEGIN
   RETURN QUERY
   WITH RECURSIVE t AS (
-    (SELECT tm.key::text FROM public.tx_metadata tm ORDER BY key LIMIT 1) 
+    (SELECT tm.key FROM public.tx_metadata tm ORDER BY key LIMIT 1)
     UNION ALL
     SELECT (SELECT tm.key FROM tx_metadata tm WHERE tm.key > t.key ORDER BY key LIMIT 1)
     FROM t
       WHERE t.key IS NOT NULL
   )
-  SELECT t.key FROM t WHERE t.key IS NOT NULL;
+  SELECT t.key::text FROM t WHERE t.key IS NOT NULL;
 END;
 $$;
 


### PR DESCRIPTION
## Description

Slipped a bug for koios-1.0.7 for tx_metalabels (cast was placed incorrectly)

## Which issue it fixes?
Closes cardano-community/koios-artifacts#95
