### PR TITLE
fix for stake_distribution_new_accounts.sql

### DIFF
--- a/files/grest/rpc/01_cached_tables/stake_distribution_new_accounts.sql
+++ b/files/grest/rpc/01_cached_tables/stake_distribution_new_accounts.sql
@@ -54,7 +54,7 @@ BEGIN
       ai.withdrawals::lovelace,
       ai.rewards_available::lovelace
     FROM newly_registered_accounts nra,
-      LATERAL grest.account_info(nra.stake_address) ai
+      LATERAL grest.account_info(array[nra.stake_address]) ai
     ON CONFLICT (STAKE_ADDRESS) DO
       UPDATE
         SET


### PR DESCRIPTION
## Description
Due to account_info now taking an array as input instead of single value, this internal use of function call needs update.

## How has this been tested?
Runs now, but no additional checks done.
