### PR TITLE
Fix last commit for G_ACCOUNT change

### DIFF
--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -719,24 +719,6 @@ getEraIdentifier() {
 
 [[ ${0} != '-bash' ]] && PARENT=$(dirname $0) || PARENT="$(pwd)" # If sourcing at terminal, $0 would be "-bash" , which is invalid. Thus, fallback to present working directory
 
-OFFLINE_MODE='N'
-[[ $1 = "offline" ]] && OFFLINE_MODE='Y'
-[[ $(basename $0 2>/dev/null) = "cnode.sh" ]] && OFFLINE_MODE='Y' # for backwards compatibility
-[[ $(basename $0 2>/dev/null) = "topologyUpdater.sh" ]] && OFFLINE_MODE='Y' # for backwards compatibility
-
-[[ -f "${PARENT}"/.env_branch ]] && BRANCH=$(cat "${PARENT}"/.env_branch) || BRANCH=master
-
-URL_RAW="https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/${BRANCH}"
-DB_SCRIPTS_URL="${URL_RAW}/scripts/grest-helper-scripts/db-scripts"
-export LC_ALL=C.UTF-8
-
-# special mapping of coreutils gdate to date for MacOS
-if [[ $(uname) == Darwin ]]; then
-   date () { gdate "$@"; }
-fi
-
-[[ -z ${CURL_TIMEOUT} ]] && CURL_TIMEOUT=10
-
 telegramSend() {
   if [[ -z "${TG_BOT_TOKEN}" ]] || [[ -z "${TG_CHAT_ID}" ]]; then
     echo "Warn: to use the telegramSend function you must first set the bot and chat id in the env file"
@@ -747,11 +729,26 @@ telegramSend() {
 }
 
 set_default_vars() {
+  OFFLINE_MODE='N'
+  [[ $1 = "offline" ]] && OFFLINE_MODE='Y'
+  [[ $(basename $0 2>/dev/null) = "cnode.sh" ]] && OFFLINE_MODE='Y' # for backwards compatibility
+  [[ $(basename $0 2>/dev/null) = "topologyUpdater.sh" ]] && OFFLINE_MODE='Y' # for backwards compatibility
+
+  [[ -f "${PARENT}"/.env_branch ]] && BRANCH=$(cat "${PARENT}"/.env_branch) || BRANCH=master
+  [[ -z ${G_ACCOUNT} ]] && G_ACCOUNT="cardano-community"
+
+  URL_RAW="https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/${BRANCH}"
+  DB_SCRIPTS_URL="${URL_RAW}/scripts/grest-helper-scripts/db-scripts"
+  export LC_ALL=C.UTF-8
+  # special mapping of coreutils gdate to date for MacOS
+  if [[ $(uname) == Darwin ]]; then
+     date () { gdate "$@"; }
+  fi
+  [[ -z ${CURL_TIMEOUT} ]] && CURL_TIMEOUT=10
   [[ -z "${CNODE_HOME}" ]] && CNODE_HOME=/opt/cardano/cnode
   CNODE_NAME="$(basename ${CNODE_HOME})"
   CNODE_VNAME=$(tr '[:upper:]' '[:lower:]' <<< ${CNODE_NAME//_HOME/})
   CNODE_VNAME_UPPERCASE=$(tr '[:lower:]' '[:upper:]' <<< ${CNODE_VNAME})
-  [[ -z ${G_ACCOUNT} ]] && G_ACCOUNT="cardano-community"
   [[ -z "${CNODE_PORT}" ]] && CNODE_PORT=6000
   [[ -z ${UPDATE_CHECK} ]] && UPDATE_CHECK="Y"
   [[ -z ${TOPOLOGY} ]] && TOPOLOGY="${CNODE_HOME}/files/topology.json"

--- a/scripts/cnode-helper-scripts/prereqs.sh
+++ b/scripts/cnode-helper-scripts/prereqs.sh
@@ -581,7 +581,7 @@ updateWithCustomConfig() {
     return
   fi
   if [[ -f ${file} && ${FORCE_OVERWRITE} = 'N' ]]; then
-    if grep '^# Do NOT modify' ${file} >/dev/null 2>&1; then
+    if grep '^# User Variables' ${file}.tmp >/dev/null 2>&1; then
       TEMPL_CMD=$(awk '/^# Do NOT modify/,0' ${file}.tmp)
       if [[ -z ${TEMPL_CMD} ]]; then
         echo "ERROR!! Script downloaded from GitHub corrupt, ignoring update for '${file}'"


### PR DESCRIPTION
## Description

The [previous commit](https://github.com/cardano-community/guild-operators/commit/c603a4b48ce46be909f32f97b74511c99cbcd31d) to account for `G_ACCOUNT` caused an issue because `URL_RAW` variable used `G_ACCOUNT` prior to it being set.

The fix here will not resolve env file that was already updated with wrong value, but it will atleast fix the future env file updates