### PR TITLE
[gRest] /datum_info endpoint

### DIFF
--- a/files/grest/rpc/script/datum_info.sql
+++ b/files/grest/rpc/script/datum_info.sql
@@ -1,0 +1,22 @@
+CREATE FUNCTION grest.datum_info (_datum_hash text)
+  RETURNS TABLE (
+    hash text,
+    value jsonb,
+    bytes text
+  )
+  LANGUAGE PLPGSQL
+  AS $$
+BEGIN
+  RETURN QUERY
+    SELECT
+      _datum_hash,
+      d.value,
+      d.bytes::text
+    FROM 
+      datum d
+    WHERE
+      d.hash = DECODE(_datum_hash, 'hex');
+END;
+$$;
+
+COMMENT ON FUNCTION grest.datum_info IS 'Get the information about a given datum.';

--- a/files/grest/rpc/script/native_script_list.sql
+++ b/files/grest/rpc/script/native_script_list.sql
@@ -7,9 +7,9 @@ CREATE FUNCTION grest.native_script_list ()
   )
 LANGUAGE PLPGSQL AS
 $$
-BEGIN 
+BEGIN
   RETURN QUERY
-  SELECT 
+  SELECT
     ENCODE(script.hash, 'hex'), 
     ENCODE(tx.hash, 'hex'),
     script.type,

--- a/files/grest/rpc/script/plutus_script_list.sql
+++ b/files/grest/rpc/script/plutus_script_list.sql
@@ -5,9 +5,9 @@ CREATE FUNCTION grest.plutus_script_list ()
   )
 LANGUAGE PLPGSQL AS
 $$
-BEGIN 
+BEGIN
   RETURN QUERY
-  SELECT 
+  SELECT
     ENCODE(script.hash, 'hex') as script_hash, 
     ENCODE(tx.hash, 'hex') as creation_tx_hash
   FROM script

--- a/files/grest/rpc/script/script_redeemers.sql
+++ b/files/grest/rpc/script/script_redeemers.sql
@@ -3,7 +3,7 @@ CREATE FUNCTION grest.script_redeemers (_script_hash text)
     script_hash text,
     redeemers json
   ) 
-LANGUAGE PLPGSQL AS 
+LANGUAGE PLPGSQL AS
 $$
 DECLARE _script_hash_bytea bytea;
 BEGIN


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
Adding an endpoint for getting datum information based on its hash.
Currently returns only the datum `value` in JSON and `bytes` format. We could add more to it in the future, for now, it seems to be all that's needed.

To consider: make this endpoint accept a list of hashes as bulk input?

## Which issue it fixes?
<!--- Link to issue: Closes #issue-number -->
Closes https://github.com/cardano-community/koios-artifacts/issues/86

## How has this been tested?
<!--- Describe how you tested changes -->
Tested endpoint on guildnet.