### PR TITLE
Move OFFLINE_MODE setup to top of env file

### DIFF
--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -81,6 +81,10 @@
 # Do NOT modify code below           #
 ######################################
 
+# Initialise/Set offline mode prior to calling functions
+OFFLINE_MODE='N'
+[[ $1 = "offline" ]] && OFFLINE_MODE='Y'
+
 # Description : Check if provided file exists
 #             : $1 = File (with path) to check
 is_file() {
@@ -729,8 +733,6 @@ telegramSend() {
 }
 
 set_default_vars() {
-  OFFLINE_MODE='N'
-  [[ $1 = "offline" ]] && OFFLINE_MODE='Y'
   [[ $(basename $0 2>/dev/null) = "cnode.sh" ]] && OFFLINE_MODE='Y' # for backwards compatibility
   [[ $(basename $0 2>/dev/null) = "topologyUpdater.sh" ]] && OFFLINE_MODE='Y' # for backwards compatibility
 


### PR DESCRIPTION
## Description
Initialisation of `OFFLINE_MODE` (along with few other variables) was recently moved to `set_defaults_vars()` function, but OFFLINE_MODE is a single exception as it relies on arg to the env file itself, moving to the top of the file