### PR TITLE
feat: use https://github.com/input-output-hk/metadata-registry-testnet as metadata-registry for preprod and preview networks

### DIFF
--- a/scripts/grest-helper-scripts/setup-grest.sh
+++ b/scripts/grest-helper-scripts/setup-grest.sh
@@ -164,13 +164,13 @@ SGVERSION=1.0.8 # Using versions from 1.0.5-1.0.9 for minor commit alignment bef
     set_cron_variables "stake-snapshot-cache"
     install_cron_job "stake-snapshot-cache" "*/10 * * * *"
 
-    # Only testnet and mainnet asset registries supported
+    # Only (legacy) testnet, preprod, preview and mainnet asset registries supported
     # Possible future addition for the Guild network once there is a guild registry
-    if [[ ${NWMAGIC} -eq 764824073 || ${NWMAGIC} -eq 1097911063 ]]; then
+    if [[ ${NWMAGIC} -eq 764824073 || ${NWMAGIC} -eq 1097911063 || ${NWMAGIC} -eq 1 || ${NWMAGIC} -eq 2 ]]; then
       get_cron_job_executable "asset-registry-update"
       set_cron_variables "asset-registry-update"
       # Point the update script to testnet regisry repo structure (default: mainnet)
-      [[ ${NWMAGIC} -eq 1097911063 ]] && set_cron_asset_registry_testnet_variables
+      [[ ${NWMAGIC} -eq 1097911063 || ${NWMAGIC} -eq 1 || ${NWMAGIC} -eq 2 ]] && set_cron_asset_registry_testnet_variables
       install_cron_job "asset-registry-update" "*/10 * * * *"
     fi
   }

--- a/scripts/grest-helper-scripts/setup-grest.sh
+++ b/scripts/grest-helper-scripts/setup-grest.sh
@@ -164,7 +164,8 @@ SGVERSION=1.0.8 # Using versions from 1.0.5-1.0.9 for minor commit alignment bef
     set_cron_variables "stake-snapshot-cache"
     install_cron_job "stake-snapshot-cache" "*/10 * * * *"
 
-    # Only (legacy) testnet, preprod, preview and mainnet asset registries supported
+    # Only (legacy) testnet and mainnet asset registries supported
+    # In absence of official messaging, current (soon to be reset) preprod/preview networks use same registry as testnet. TBC - once there is an update from IO on these
     # Possible future addition for the Guild network once there is a guild registry
     if [[ ${NWMAGIC} -eq 764824073 || ${NWMAGIC} -eq 1097911063 || ${NWMAGIC} -eq 1 || ${NWMAGIC} -eq 2 ]]; then
       get_cron_job_executable "asset-registry-update"


### PR DESCRIPTION
setup-grest.sh currently does not use any metadata-registry for preprod and preview networks.
This PR adds https://github.com/input-output-hk/metadata-registry-testnet as metadata-registry for NWMAGIC 1 (preprod) and NWMAGIC 2 (preview).
Patch successfully tested with wUSDC token:
http://<localkoios>:8053/api/v0/asset_info?_asset_policy=648823ffdad1610b4162f4dbc87bd47f6f9cf45d772ddef661eff198&_asset_name=7755534443
