### PR TITLE
Use github raw URL instead of api.github.com

### DIFF
--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -154,10 +154,9 @@ checkUpdate() {
   [[ "${UPDATE_CHECK}" != "Y" ]] && return 0
 
   if [[ ${OFFLINE_MODE} = N && ${BRANCH} != master && ${BRANCH} != alpha ]]; then
-    if ! curl -s -f -m ${CURL_TIMEOUT} "https://api.github.com/repos/${G_ACCOUNT}/guild-operators/branches" | jq -e ".[] | select(.name == \"${BRANCH}\")" &>/dev/null ; then
-      echo -e "WARN!! The folder was configured against ${BRANCH} branch - which does not exist anymore, falling back to alpha branch"
-      # alpha because if someone was testing something against a custom branch, it would likely be merged to alpha first. Production systems should not be using custom branch anyways
-      BRANCH=alpha
+    if ! curl -s -f -m ${CURL_TIMEOUT} "${URL_RAW}/LICENSE" -o /dev/null ; then
+      echo -e "WARN!! The folder was configured against ${BRANCH} branch - which does not exist anymore, falling back to master branch"
+      BRANCH=master
       echo "${BRANCH}" > "${CNODE_HOME}"/scripts/.env_branch
     fi
   fi

--- a/scripts/cnode-helper-scripts/prereqs.sh
+++ b/scripts/cnode-helper-scripts/prereqs.sh
@@ -511,9 +511,9 @@ echo "Downloading files..."
 pushd "${CNODE_HOME}"/files >/dev/null || err_exit
 
 
-if ! curl -s -f -m ${CURL_TIMEOUT} "https://api.github.com/repos/${G_ACCOUNT}/guild-operators/branches" | jq -e ".[] | select(.name == \"${BRANCH}\")" &>/dev/null ; then
-  echo -e "\nWARN!! ${BRANCH} branch does not exist, falling back to alpha branch\n"
-  BRANCH=alpha
+if ! curl -s -f -m ${CURL_TIMEOUT} "${REPO_RAW}/${BRANCH}/LICENSE" -o /dev/null ; then
+  echo -e "\nWARN!! ${BRANCH} branch does not exist, falling back to master branch\n"
+  BRANCH=master
   URL_RAW="${REPO_RAW}/${BRANCH}"
   echo "${BRANCH}" > "${CNODE_HOME}"/scripts/.env_branch
 else


### PR DESCRIPTION
## Description

When using tags (for older node versions or for Koios releases), the scripts fallback to alpha branch due to checks against api.github.com for `branches`. This behaviour causes 2 issues:
1. If alpha branch has newer updates than release, future execution of setup-grest.sh or one of the tools will get updates from inconsistent branch
2. Even if folks are using a release version, the fallback was against `alpha` instead of `master`

Originally , the decision to include `alpha` as default fallback was 'only advanced users/testers/devs should be using a branch other than master' - this is still true for scripts like CNTools, gLiveView, topologyUpdater, etc. But this assumption is incorrect for setting up `gRest` instances. Thus, the change to fallback on `master` instead.

Also, when using api.github.com, we can check for existence of a tag and/or branch sequentially. However, a simpler solution is to check for existence of a file from github raw URL, which checks for "ref" (thus, both of those conditions)