### PR TITLE
Minor additions to node, dbsync and postgres docs

### DIFF
--- a/docs/Appendix/postgres.md
+++ b/docs/Appendix/postgres.md
@@ -1,5 +1,8 @@
-These deployment instructions used for reference while building [cardano-db-sync](../Build/dbsync.md) tool. These are just for reference and ease of set up and consistency for those who are new to Postgres DB.
+These deployment instructions used for reference while building [cardano-db-sync](../Build/dbsync.md) tool, with the scope being ease of set up, and some tuning baselines for those who are new to Postgres DB.
 It is recommended to customise these as per your needs for Production builds.
+
+!!! important
+    You'd find it pretty useful to set up ZFS on your system prior to setting up Postgres, to help with your IOPs throughput requirements. You can find sample install instructions [here](https://openzfs.github.io/openzfs-docs/Getting%20Started/Debian/index.html). You can set up your entire root mount to be on ZFS, or you can opt to mount a file as ZFS on "${CNODE_HOME}"
 
 #### Install PostgreSQL Server
 
@@ -7,7 +10,7 @@ Execute commands below to set up Postgres Server
 
 ``` bash
 # Determine OS platform
-OS_ID=$(grep -i ^id_like= /etc/os-release | cut -d= -f 2)
+OS_ID=$(grep -i ^ID_LIKE= /etc/os-release | cut -d= -f 2)
 DISTRO=$(grep -i ^NAME= /etc/os-release | cut -d= -f 2)
 
 if [ -z "${OS_ID##*debian*}" ]; then
@@ -80,7 +83,7 @@ You might want to fill in some sample information as per below to fill in the fo
 | Number of Connections | 200 |
 | Data Storage   | HDD Storage |
 
-In addition to above, due to the nature of usage by dbsync (restart of instance does a rollback to start of epoch), and data retention on blockchain - we're not affected by loss of volatile information upon a restart of instance. Thus, we can relax some of the data retention and protection against corruption related settings, as those are IOPs/CPU Load Average impacts that the instance does not need to spend. We'd recommend setting 3 of those below in your `/etc/postgresql/14/main/postgresql.conf`:
+In addition to above, due to the nature of usage by dbsync (restart of instance does a rollback to last saved ledger-state snapshot), and data retention on blockchain - we're not affected by loss of volatile information upon a restart of instance. Thus, we can relax some of the data retention and protection against corruption related settings, as those are IOPs/CPU Load Average impacts that the instance does not need to spend. We'd recommend setting 3 of those below in your `/etc/postgresql/14/main/postgresql.conf`:
 
 | Parameter          | Value   |
 |--------------------|---------|

--- a/docs/Build/dbsync.md
+++ b/docs/Build/dbsync.md
@@ -3,6 +3,7 @@
 
     - Ensure the [Pre-Requisites](../basics.md#pre-requisites) are in place before you proceed.
     - The [Cardano DB Sync](https://github.com/input-output-hk/cardano-db-sync) relies on an existing PostgreSQL server. To keep the focus on building dbsync tool, and not how to setup postgres itself, you can refer to [Sample Local PostgreSQL Server Deployment instructions](../Appendix/postgres.md) for setting up a Postgres instance. Specifically, we expect the `PGPASSFILE` environment variable is set as per the instructions in the sample guide, for `db-sync` to be able to connect.
+    - One of the biggest obstacles for user experience when running dbsync is ensuring you satisfy EACH of the points mentioned in System Requirements [here](https://github.com/input-output-hk/cardano-db-sync#system-requirements). Also, note that we do not advise running dbsync on mainnet if your RAM is below 48GB.
 
 
 ### Build Instructions

--- a/docs/Build/node-cli.md
+++ b/docs/Build/node-cli.md
@@ -32,7 +32,7 @@ The above would copy the binaries built into `~/.cabal/bin` folder.
 #### Download pre-compiled Binary from Node release
 
 While certain folks might want to build the node themselves (could be due to OS/arch compatibility, trust factor or customisations), for most it might not make sense to build the node locally.
-Instead, you can download the binaries using [cardano-node release notes](https://github.com/input-output-hk/cardano-node/releases) , where-in you can find the download links for every version.
+Instead, you can download the binaries using [cardano-node release notes](https://github.com/input-output-hk/cardano-node/releases), where-in you can find the download links for every version.
 Once downloaded, you would want to make it available to preferred `PATH` in your environment (if you're asking how - that'd mean you've skipped skillsets mentioned on homepage).
 
 ### Verify

--- a/docs/Build/node-cli.md
+++ b/docs/Build/node-cli.md
@@ -29,16 +29,22 @@ $CNODE_HOME/scripts/cabal-build-all.sh
 
 The above would copy the binaries built into `~/.cabal/bin` folder.
 
+#### Download pre-compiled Binary from Node release
+
+While certain folks might want to build the node themselves (could be due to OS/arch compatibility, trust factor or customisations), for most it might not make sense to build the node locally.
+Instead, you can download the binaries using [cardano-node release notes](https://github.com/input-output-hk/cardano-node/releases) , where-in you can find the download links for every version.
+Once downloaded, you would want to make it available to preferred `PATH` in your environment (if you're asking how - that'd mean you've skipped skillsets mentioned on homepage).
+
 ### Verify
 
 Execute `cardano-cli` and `cardano-node` to verify output as below (the exact version and git rev should depend on your checkout tag on github repository):
 
 ```bash
 cardano-cli version
-# cardano-cli 1.35.0 - linux-x86_64 - ghc-8.10
+# cardano-cli 1.35.3 - linux-x86_64 - ghc-8.10
 # git rev <...>
 cardano-node version
-# cardano-node 1.35.0 - linux-x86_64 - ghc-8.10
+# cardano-node 1.35.3 - linux-x86_64 - ghc-8.10
 # git rev <...>
 ```
 
@@ -47,6 +53,8 @@ cardano-node version
 Before you go ahead with starting your node, you may want to update values for `CNODE_PORT` in `$CNODE_HOME/scripts/env`. Note that it is imperative for operational relays and pools to ensure that the port mentioned is opened via firewall to the destination your node is supposed to connect from. Update your network/firewall configuration accordingly. Future executions of `prereqs.sh` will preserve and not overwrite these values.
 
 ```bash
+CNODEBIN="${HOME}/.cabal/bin/cardano-node"
+CCLI="${HOME}/.cabal/bin/cardano-cli"
 CNODE_PORT=6000
 POOL_NAME="GUILD"
 ```


### PR DESCRIPTION
## Description

- Add suggestion for ZFS to Postgres sample instructions
- Correction in dbsync docs (rollback is now to last known ledger-snapshot, not start of epoch)
- For DBSync, Add another reminder about importance of system requirements (wrt UX)
- For Node, document what should've been a common sense 😉 - one can opt to use pre-compiled binary from Node release notes