### PR TITLE
gRest: Fix issues discovered with multi assets (non-breaking)

### DIFF
--- a/files/grest/rpc/assets/asset_info.sql
+++ b/files/grest/rpc/assets/asset_info.sql
@@ -45,7 +45,7 @@ BEGIN
           ma_tx_mint MTM
           INNER JOIN tx ON tx.id = MTM.tx_id
         WHERE
-          MTM.ident = _asset_id
+          MTM.ident = _asset_id AND MTM.quantity > 0
         ORDER BY
           MTM.tx_id ASC
         LIMIT 1
@@ -69,7 +69,7 @@ BEGIN
           TM.tx_id = (
             SELECT MAX(MTM.tx_id)
             FROM ma_tx_mint MTM
-            WHERE MTM.ident = _asset_id
+            WHERE MTM.ident = _asset_id AND MTM.quantity > 0
           )
       ) AS minting_tx_metadata,
       (

--- a/files/grest/rpc/assets/asset_policy_info.sql
+++ b/files/grest/rpc/assets/asset_policy_info.sql
@@ -30,7 +30,7 @@ BEGIN
           tx_metadata TM
           INNER JOIN ma_tx_mint MTM on MTM.tx_id = TM.tx_id
         WHERE
-          MTM.ident = ANY(_policy_asset_ids)
+          MTM.ident = ANY(_policy_asset_ids) AND MTM.quantity > 0
         ORDER BY
           MTM.ident,
           TM.tx_id ASC


### PR DESCRIPTION
## Description
<!--- Describe your changes -->

- [x] - asset_info: minting_tx_metadata should account for latest mint transaction that has metadata, note that minting table also contains burn represented via negative numbers [cardano-community/koios-artifacts#111]
- [x] - Align change above to any other instances for minting_tx_metadata