### PR TITLE
gRest: addr_info - Handle empty UTxO sets for stake_address and script_address fields

### DIFF
--- a/files/grest/rpc/transactions/tx_info.sql
+++ b/files/grest/rpc/transactions/tx_info.sql
@@ -812,7 +812,7 @@ BEGIN
       ), JSONB_BUILD_ARRAY()),
       COALESCE((SELECT AW.list  FROM _all_withdrawals AW        WHERE AW.tx_id  = ATX.id), JSONB_BUILD_ARRAY()),
       COALESCE((SELECT AMI.list FROM _all_mints AMI             WHERE AMI.tx_id = ATX.id), JSONB_BUILD_ARRAY()),
-      COALESCE((SELECT AME.list FROM _all_metadata AME          WHERE AME.tx_id = ATX.id), JSONB_BUILD_ARRAY()),
+      COALESCE((SELECT AME.list FROM _all_metadata AME          WHERE AME.tx_id = ATX.id), NULL),
       COALESCE((SELECT AC.list  FROM _all_certs AC              WHERE AC.tx_id  = ATX.id), JSONB_BUILD_ARRAY()),
       COALESCE((SELECT ANS.list FROM _all_native_scripts ANS    WHERE ANS.tx_id = ATX.id), JSONB_BUILD_ARRAY()),
       COALESCE((SELECT APC.list FROM _all_plutus_contracts APC  WHERE APC.tx_id = ATX.id), JSONB_BUILD_ARRAY())


### PR DESCRIPTION
## Description

When UTxO set is empty (0-balance addresses), there are no fields returned from `_all_utxos` . Thus, with 0 rows, the stake_address and script_address were returned as empty. The change here is to create a temp table to hold stake_address and script_address for 1st tx of a given address (since it wouldn't change between transactions), and add a coalesce to set `script_address` to false if no entries found in tx_out table.


Closes cardano-community/koios-artifacts#113

Also: fix tx_info => metadata field when result is empty, to return NULL instead of empty array