### PR TITLE
gRest: Prevent triggering no duplicate runs for stake distribution cache of new accounts

### DIFF
--- a/files/grest/rpc/01_cached_tables/stake_distribution_new_accounts.sql
+++ b/files/grest/rpc/01_cached_tables/stake_distribution_new_accounts.sql
@@ -3,6 +3,18 @@ LANGUAGE PLPGSQL AS
 $$
 BEGIN
   IF (
+      -- If checking query with a different name there will be 1 result
+      SELECT COUNT(pid) > 1
+        FROM pg_stat_activity
+        WHERE state = 'active'
+          AND query ILIKE '%GREST.UPDATE_NEWLY_REGISTERED_ACCOUNTS_STAKE_DISTRIBUTION_CACHE(%'
+          AND query NOT ILIKE '%pg_stat_activity%'
+          AND datname = (
+            SELECT current_database()
+          )
+    ) THEN
+      RAISE EXCEPTION 'New accounts query already running! Exiting...';
+  ELSIF (
     -- If checking query with a different name there will be 1 result
     SELECT COUNT(pid) > 0
       FROM pg_stat_activity


### PR DESCRIPTION
## Description

Add a check for stake distribution cache update for new accounts to exit if the function itself  is already running

## Motivation and context

On guildnet, noticed the instance was down due to number of parallel queries already running

## Which issue it fixes?

Closes cardano-community/koios-artifacts#115

## How has this been tested?

Ran on guildnet
