### PR TITLE
SDC Update:  Reduce redundant calc

### DIFF
--- a/files/grest/rpc/01_cached_tables/stake_distribution_cache.sql
+++ b/files/grest/rpc/01_cached_tables/stake_distribution_cache.sql
@@ -50,11 +50,7 @@ BEGIN
           -- Account must be present in epoch_stake table for the last validated epoch
           AND EXISTS (
             SELECT TRUE FROM EPOCH_STAKE
-              WHERE EPOCH_STAKE.EPOCH_NO = (
-                SELECT last_value::integer FROM GREST.CONTROL_TABLE
-                  WHERE key = 'last_active_stake_validated_epoch'
-                )
-                AND EPOCH_STAKE.ADDR_ID = STAKE_ADDRESS.ID
+              WHERE EPOCH_STAKE.ADDR_ID = STAKE_ADDRESS.ID
           )
     ),
     pool_ids as (

--- a/files/grest/rpc/01_cached_tables/stake_distribution_new_accounts.sql
+++ b/files/grest/rpc/01_cached_tables/stake_distribution_new_accounts.sql
@@ -1,6 +1,4 @@
-CREATE OR REPLACE PROCEDURE GREST.UPDATE_NEWLY_REGISTERED_ACCOUNTS_STAKE_DISTRIBUTION_CACHE()
-LANGUAGE PLPGSQL AS
-$$
+CREATE OR REPLACE PROCEDURE GREST.UPDATE_NEWLY_REGISTERED_ACCOUNTS_STAKE_DISTRIBUTION_CACHE() LANGUAGE PLPGSQL AS $$
 BEGIN
   IF (
       -- If checking query with a different name there will be 1 result
@@ -48,11 +46,7 @@ BEGIN
           )
           AND NOT EXISTS (
             SELECT TRUE FROM EPOCH_STAKE
-              WHERE EPOCH_STAKE.EPOCH_NO = (
-                SELECT last_value::integer FROM GREST.CONTROL_TABLE
-                  WHERE key = 'last_active_stake_validated_epoch'
-                )
-                AND EPOCH_STAKE.ADDR_ID = STAKE_ADDRESS.ID
+              WHERE EPOCH_STAKE.ADDR_ID = STAKE_ADDRESS.ID
           )
     )
   -- INSERT QUERY START


### PR DESCRIPTION
Previously, we (atleast my) understanding was that we'd need to run SDC new account calcs for all accounts that dont have an entry for latest epoch in epoch_stake table.
But in fact, we only need to check 2 epochs for delta tx, as any UTxO movements prior to 2 epochs will be captured as part of epoch_stake already.

On guildnet:
- this reduces SDC for new account calc from 48 mins to 5s (it was 48 mins because we had ample of such accounts created as part of testing)
- the increases SDC for old (existing) account runtime from 40s to 53s
- Overall time for both jobs was reduced from ~49 mins to ~1 min

There can potentially be some consideration to merge the two jobs, but scope of minor change introduced via this PR to test and verify accuracy of the data, as SDC has gone through tremendous amount of changes and testing