### PR TITLE
gRest: Bump setup-grest version to 1.0.9

### DIFF
--- a/docs/Build/grest-changelog.md
+++ b/docs/Build/grest-changelog.md
@@ -1,5 +1,9 @@
 # Koios gRest Changelog
 
+## [1.0.9] - For all networks
+
+This release is effectively same as `1.0.9rc` below (please check out the notes accordingly), just with minor bug fix on `setup-grest.sh` itself.
+
 ## [1.0.9rc] - For non-mainnet networks
 
 This release candidate is non-breaking for existing methods and inputs, but breaking for output objects for endpoints.

--- a/docs/Build/grest.md
+++ b/docs/Build/grest.md
@@ -56,24 +56,28 @@ cd "${CNODE_HOME}"/scripts
 #
 ```
 
-To run the setup with typical options, you may want to use:
+To run the setup overwriting all standard deployment tasks from a branch (eg: `koios-1.0.9` branch), you may want to use:
 ``` bash
-./setup-grest.sh -f -q
+./setup-grest.sh -f -i prmcd -r -q -b koios-1.0.9
 ```
 
-Similarly - if instead, you'd like to re-install all components as well as force overwrite all configs and queries, you may run:
+Similarly - if you'd like to re-install all components and force overwrite all configs but not reset cache tables, you may run:
 ``` bash
 ./setup-grest.sh -f -i prmcd -q
 ```
 
-Another example could be to preserve your config, but only update queries using an alternate branch (eg: let's say you want to try the tag `koios-1.0.0`). To do so, you may run:
+Another example could be to preserve your config, but only update queries using an alternate branch (eg: let's say you want to try the branch `alpha` prior to a tagged release). To do so, you may run:
 ``` bash
-./setup-grest.sh -q -b koios-1.0.0
+./setup-grest.sh -q -b alpha
 ```
 
 Please ensure to follow the on-screen instructions, if any (for example restarting deployed services, or updating configs to specify correct target postgres URLs/enable TLS/add peers etc in `${CNODE_HOME}/priv/grest.conf` and `${CNODE_HOME}/files/haproxy.cfg`).
 
 The default ports used will make haproxy instance available at port 8053 or 8453 if TLS is enabled (you might want to enable firewall rule to open this port to services you would like to access). If you want to prevent unauthenticated access to grest schema, uncomment the jwt-secret and specify a custom `secret-token`.
+
+!!! info "Reminder"
+
+Once you've successfully deployed the grest instance, it will deploy certain cron jobs that will ensure the relevant cache tables are updated periodically. Until these have finished (especially on first run, it could take an hour or so on mainnet, your instance will likely not pass any tests from `grest-poll.sh` but that's expected.
 
 ### Enable TLS on HAProxy {: id="tls"}
 
@@ -135,4 +139,4 @@ If you're interested to participate in decentralised infrastructure by providing
 
 3. Create a PR specifying connectivity information to your HAProxy port [here](https://github.com/cardano-community/koios-artifacts/tree/main/topology).
 
-4. Make sure to join the [telegram discussions group](https://t.me/+zE4Lce_QUepiY2U1) to participate in any discussions, actions, polls for new-features, etc. Feel free to give a shout in the group in case you have trouble following any of the above
+4. Make sure to join the [telegram discussions group](https://t.me/CardanoKoios) to participate in any discussions, actions, polls for new-features, etc. Feel free to give a shout in the group in case you have trouble following any of the above

--- a/scripts/grest-helper-scripts/setup-grest.sh
+++ b/scripts/grest-helper-scripts/setup-grest.sh
@@ -16,8 +16,8 @@
 # Do NOT modify code below           #
 ######################################
 
-SGVERSION=1.0.9rc # Using versions from 1.0.5-1.0.9 for minor commit alignment before we're prepared for wider networks, targetted support for dbsync 13 will be against v1.1.0. Using a gap from 1.0.1 - 1.0.5 allows for scope to have any urgent fixes required before then on alpha branch itself
-
+SGVERSION=1.0.9
+# Using versions from 1.0.5-1.0.9 for minor commit alignment before we're prepared for wider networks
 
 ######## Functions ########
   usage() {
@@ -494,7 +494,6 @@ SGVERSION=1.0.9rc # Using versions from 1.0.5-1.0.9 for minor commit alignment b
     # Create skeleton whitelist URL file if one does not already exist using most common option
     curl -sfkL "https://${KOIOS_SRV}/koiosapi.yaml" -o "${CNODE_HOME}"/files/koiosapi.yaml 2>/dev/null
     grep " #RPC" "${CNODE_HOME}"/files/koiosapi.yaml | sed -e 's#^  /#/#' | cut -d: -f1 | sort > "${CNODE_HOME}"/files/grestrpcs 2>/dev/null
-    [[ "${SKIP_UPDATE}" == "Y" ]] && return 0
     checkUpdate grest-poll.sh Y N N grest-helper-scripts >/dev/null
     sed -i "s# API_STRUCT_DEFINITION=\"https://api.koios.rest/koiosapi.yaml\"# API_STRUCT_DEFINITION=\"https://${KOIOS_SRV}/koiosapi.yaml\"#g" grest-poll.sh
     checkUpdate checkstatus.sh Y N N grest-helper-scripts >/dev/null
@@ -689,12 +688,12 @@ SGVERSION=1.0.9rc # Using versions from 1.0.5-1.0.9 for minor commit alignment b
   common_init
   set_environment_variables
   parse_args
+  common_update
   [[ "${INSTALL_POSTGREST}" == "Y" ]] && deploy_postgrest
   [[ "${INSTALL_HAPROXY}" == "Y" ]] && deploy_haproxy
   [[ "${INSTALL_MONITORING_AGENTS}" == "Y" ]] && deploy_monitoring_agents
   [[ "${OVERWRITE_CONFIG}" == "Y" ]] && deploy_configs
   [[ "${OVERWRITE_SYSTEMD}" == "Y" ]] && deploy_systemd
-  common_update
   [[ "${RESET_GREST}" == "Y" ]] && setup_db_basics && reset_grest
   [[ "${DB_QRY_UPDATES}" == "Y" ]] && setup_db_basics && deploy_query_updates && update_grest_version
   pushd -0 >/dev/null || err_exit


### PR DESCRIPTION
## Description

Update setup-grest version to `1.0.9` and borrow setup-grest.sh fix applied in #1572