### PR TITLE
Add procps to avoid lack of pgrep on debian based OS

### DIFF
--- a/scripts/cnode-helper-scripts/prereqs.sh
+++ b/scripts/cnode-helper-scripts/prereqs.sh
@@ -201,7 +201,7 @@ if [ "$WANT_BUILD_DEPS" = 'Y' ]; then
     $sudo apt-get ${pkg_opts} install curl > /dev/null
     $sudo env NEEDRESTART_MODE=a env DEBIAN_FRONTEND=noninteractive env DEBIAN_PRIORITY=critical apt-get ${pkg_opts} update > /dev/null
     echo "  Installing missing prerequisite packages, if any.."
-    pkg_list="libpq-dev python3 build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev systemd libsystemd-dev libsodium-dev zlib1g-dev make g++ tmux git jq libncursesw5 gnupg aptitude libtool autoconf secure-delete iproute2 bc tcptraceroute dialog automake sqlite3 bsdmainutils libusb-1.0-0-dev libudev-dev unzip"
+    pkg_list="libpq-dev python3 build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev systemd libsystemd-dev libsodium-dev zlib1g-dev make g++ tmux git jq libncursesw5 gnupg aptitude libtool autoconf secure-delete iproute2 bc tcptraceroute dialog automake sqlite3 bsdmainutils libusb-1.0-0-dev libudev-dev unzip procps"
     pkg_list="${pkg_list} llvm clang libnuma-dev"
     $sudo env NEEDRESTART_MODE=a env DEBIAN_FRONTEND=noninteractive env DEBIAN_PRIORITY=critical apt-get ${pkg_opts} install ${pkg_list} > /dev/null;rc=$?
     if [ $rc != 0 ]; then


### PR DESCRIPTION
## Description
Debian based OS, failed to run gLiveView with `pgrep command not found`

## Where should the reviewer start?

on a debian based docker image [For example](https://gist.github.com/mberrueta/e10a47d6147998541720798193bf643f)

## Motivation and context
Can't run gLiveView

## Which issue it fixes?
[ gLiveView fail to exec on debian docker based img #1582 ](https://github.com/cardano-community/guild-operators/issues/1582)

## How has this been tested?
Manually running
