### PR TITLE
cncli leaderlog from Koios

### DIFF
--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -217,8 +217,6 @@ if [[ ${CNTOOLS_MODE} = "CONNECTED" ]]; then
   echo "${PROT_PARAMS}" > "${TMP_DIR}"/protparams.json
 fi
 
-test_koios
-
 # check that bash version is > 4.4.0
 [[ $(bash --version | head -n 1) =~ ([0-9]+\.[0-9]+\.[0-9]+) ]] || myExit 1 "Unable to get BASH version"
 if ! versionCheck "4.4.0" "${BASH_REMATCH[1]}"; then

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -34,7 +34,7 @@
 #TIMEOUT_LEDGER_STATE=300                               # Timeout in seconds for querying and dumping ledger-state
 #IP_VERSION=4                                           # The IP version to use for push and fetch, valid options: 4 | 6 | mix (Default: 4)
 #ENABLE_KOIOS=Y                                         # (Y|N) Enable KOIOS API. If disabled, local node queries will be used instead with increased system resource requirements (default Y)
-#KOIOS_API="https://api.koios.rest/api/v0/"             # Koios API for blockchain queries instead of local cli lookup.
+#KOIOS_API="https://api.koios.rest/api/v0"              # Koios API for blockchain queries instead of local cli lookup.
                                                         # Leave commented for automatic network detection between MainNet, Preview, Preprod or Guild network.
                                                         # https://www.koios.rest/
 #DBSYNC_QUERY_FOLDER="${CNODE_HOME}/files/dbsync/queries" # [advanced feature] Folder containing DB-Sync chain analysis queries


### PR DESCRIPTION
## Description
- Make Koios the the default method to get pool and stake snapshot.
- Remove duplicate test_koios call in cntools (already done when sourcing library)
- Remove trailing slash in KOIOS_API example

## Where should the reviewer start?

## Motivation and context

## Which issue it fixes?
Reduces resource consumption compared with cli stake-snapshot command that dumps and parses ledger. 

## How has this been tested?
A quick test has been done to verify that leaderlog returns the same result as with stake-snapshot method. 
