### PR TITLE
Misc updates (incl node 1.35.5)

### DIFF
--- a/docs/Build/node-cli.md
+++ b/docs/Build/node-cli.md
@@ -17,9 +17,9 @@ cd cardano-node
 
 You can use the instructions below to build the latest release of [cardano-node](https://github.com/input-output-hk/cardano-node). 
 
-??? danger "Known issue on cardano-node 1.35.4"
+??? danger "Known issue on cardano-node 1.35.[4-5]"
     
-    Guild tools use a couple of additional binaries that is not part of node repository. Traditionally, these (eg: `cardano-address` and previously `cardano-ping`) were made available as part of build process by cabal.project.local file. However, for node tag 1.35.4 - `cabal install` is [broken](https://github.com/cardano-community/guild-operators/issues/1573#issuecomment-1310230673) which means `cabal install cardano-addresses-cli` will no longer work and report error as below:
+    Guild tools use a couple of additional binaries that is not part of node repository. Traditionally, these (eg: `cardano-address` and previously `cardano-ping`) were made available as part of build process by cabal.project.local file. However, for node tag 1.35.[4-5] - `cabal install` is [broken](https://github.com/cardano-community/guild-operators/issues/1573#issuecomment-1310230673) which means `cabal install cardano-addresses-cli` will no longer work and report error as below:
     
     ```
     Got NamedPackage ouroboros-consensus-cardano-tools
@@ -54,10 +54,10 @@ Execute `cardano-cli` and `cardano-node` to verify output as below (the exact ve
 
 ```bash
 cardano-cli version
-# cardano-cli 1.35.3 - linux-x86_64 - ghc-8.10
+# cardano-cli 1.35.5 - linux-x86_64 - ghc-8.10
 # git rev <...>
 cardano-node version
-# cardano-node 1.35.3 - linux-x86_64 - ghc-8.10
+# cardano-node 1.35.5 - linux-x86_64 - ghc-8.10
 # git rev <...>
 ```
 

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -49,12 +49,15 @@ The script will always update dynamic content from existing scripts retaining ex
   l   Build and Install libsodium fork from IO repositories (Default: skip)
   f   Force overwrite entire content of scripts and config files (backups of existing ones will be created) (Default: skip)
   d   Download latest (released) binaries for bech32, cardano-address, cardano-node, cardano-cli, cardano-db-sync and cardano-submit-api binaries (Default: skip)
-  c   Install/Upgrade CNCLI binary (Default: skip)
+  c   Install/Upgrade CNCLI binary (Default: skip) # (1)!
   o   Install/Upgrade Ogmios Server binary (Default: skip)
   w   Install/Upgrade Cardano Hardware CLI (Default: skip)
   x   Install/Upgrade Cardano Signer binary (Default: skip)
 
 ```
+
+1. If you receive an error for libssl, you may need to compile cncli manually on your OS as per instructions [here](https://github.com/cardano-community/cncli/blob/develop/INSTALL.md#compile-from-source)
+
 
 This script uses opt-in election of what you'd like the script to do (as against previous version that used to try and auto-detect versions). The defaults without any arguments will only update static part of script contents for you.
 A typical example install to install most components but not overwrite static part of existing files for preview network would be:

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -979,8 +979,8 @@ if [[ -n "${CNODE_PID}" ]]; then
 fi
 
 node_version="$(${CCLI} version | head -1 | cut -d' ' -f2)"
-if ! versionCheck "1.35.2" "${node_version}"; then
-  echo -e "\nGuild scripts has now been upgraded to support cardano-node 1.35.2 or higher (${node_version} found).\nPlease update cardano-node (note that you should ideally update your config too) or use tagged branches for older node version.\n\n"
+if ! versionCheck "1.35.5" "${node_version}"; then
+  echo -e "\nGuild scripts has now been upgraded to support cardano-node 1.35.5 or higher (${node_version} found).\nPlease update cardano-node (note that you should ideally update your config too) or use tagged branches for older node version.\n\n"
   return 1
 fi
 

--- a/scripts/cnode-helper-scripts/guild-deploy.sh
+++ b/scripts/cnode-helper-scripts/guild-deploy.sh
@@ -316,9 +316,9 @@ build_libsodium() {
 download_cnodebins() {
   echo "Downloading binaries.."
   pushd "${HOME}"/tmp >/dev/null || err_exit
-  echo "  Downloading Cardano Node archive from IO Hydra CI builds.."
+  echo "  Downloading Cardano Node archive created from IO CI builds.."
   rm -f cardano-node cardano-address
-  curl -m 200 -sfL https://update-cardano-mainnet.iohk.io/cardano-node-releases/cardano-node-1.35.4-linux.tar.gz -o cnode.tar.gz || err_exit " Could not download cardano-node's latest release archive from IO CI builds at update-cardano-mainnet.iohk.io!"
+  curl -m 200 -sfL https://update-cardano-mainnet.iohk.io/cardano-node-releases/cardano-node-1.35.5-linux.tar.gz -o cnode.tar.gz || err_exit " Could not download cardano-node's latest release archive from IO CI builds at update-cardano-mainnet.iohk.io!"
   tar zxf cnode.tar.gz ./cardano-node ./cardano-cli ./cardano-submit-api ./bech32 &>/dev/null
   rm -f cnodebin.tar.gz
   [[ -f cardano-node ]] || err_exit " cardano-node archive downloaded but binary (cardano-node) not found after extracting package!"
@@ -328,9 +328,9 @@ download_cnodebins() {
   rm -f caddress.tar.gz
   [[ -f cardano-address ]] || err_exit " cardano-address archive downloaded but binary (bin/cardano-address) not found after extracting package!"
   if [[ "${SKIP_DBSYNC_DOWNLOAD}" != "N" ]]; then
-    echo "  Downloading Cardano DB Sync archive from IO Hydra CI Builds.."
-    curl -m 200 -sfL https://api.koios.rest/bin/cardano-db-sync.tar.gz -o cnodedbsync.tar.gz || err_exit "  Could not download cardano-db-sync's latest release archive from IO CI builds at hydra.iohk.io!"
-    tar zxf cnodedbsync.tar.gz cardano-db-sync &>/dev/null
+    echo "  Downloading Cardano DB Sync archive created from IO CI Builds.."
+    curl -m 200 -sfL https://update-cardano-mainnet.iohk.io/cardano-db-sync/cardano-db-sync-13.1.0.0-linux.tar.gz -o cnodedbsync.tar.gz || err_exit "  Could not download cardano-db-sync's latest release archive from IO CI builds at hydra.iohk.io!"
+    tar zxf cnodedbsync.tar.gz ./cardano-db-sync &>/dev/null
     [[ -f cardano-db-sync ]] || err_exit " cardano-db-sync archive downloaded but binary (cardano-db-sync) not found after extracting package!"
     rm -f cnodedbsync.tar.gz
     mv -t "${HOME}"/.local/bin cardano-db-sync

--- a/scripts/grest-helper-scripts/grest-poll.sh
+++ b/scripts/grest-helper-scripts/grest-poll.sh
@@ -196,7 +196,7 @@ function chk_endpt_post() {
 function chk_asset_registry() {
   ct=$(curl -sfL -H 'Prefer: count=exact' "${GURL}/asset_registry_cache?select=name&limit=1" -I 2>/dev/null | grep content-range | cut -d/ -f2)
   [[ "${ct}" == "" ]] && log_err "Asset registry cache not yet populated!"
-  [[ ${ct} -lt 500 ]] && log_err "Asset registry cache seems incomplete (<500) assets, try deleting key: asset_registry_commit in control_table and wait for next cron run"
+  [[ ${ct} -lt 150 ]] && log_err "Asset registry cache seems incomplete (<150) assets, try deleting key: asset_registry_commit in control_table and wait for next cron run"
 }
 
 ##################

--- a/scripts/grest-helper-scripts/setup-grest.sh
+++ b/scripts/grest-helper-scripts/setup-grest.sh
@@ -16,8 +16,7 @@
 # Do NOT modify code below           #
 ######################################
 
-SGVERSION=1.0.9
-# Using versions from 1.0.5-1.0.9 for minor commit alignment before we're prepared for wider networks
+SGVERSION=1.0.10rc
 
 ######## Functions ########
   usage() {
@@ -107,7 +106,7 @@ SGVERSION=1.0.9
     local cron_pattern=$2
     local cron_job_path="${CRON_DIR}/${CNODE_VNAME}-${job}"
     local cron_scripts_path="${CRON_SCRIPTS_DIR}/${job}.sh"
-    local cron_log_path="${LOG_DIR}/${job}_\`date +%d%m%y\`.log"
+    local cron_log_path="${LOG_DIR}/${job}_\`date +\\%d\\%m\\%y\`.log"
     local cron_job_entry="${cron_pattern} ${USER} /bin/bash ${cron_scripts_path} >> ${cron_log_path} 2>&1"
     remove_cron_job "${job}"
     sudo bash -c "{ echo '${cron_job_entry}'; } > ${cron_job_path}"


### PR DESCRIPTION
- Reduce asset registry check to 150 items, and add escape char for cron jobs
- Bump baseline for node versions to 1.35.5
- Update download links for node
- Update doc references for 1.35.5
- Add a note for cncli clarification wrt openssl error