### PR TITLE
Add changelog for koios-1.0.10rc

### DIFF
--- a/docs/Build/grest-changelog.md
+++ b/docs/Build/grest-changelog.md
@@ -1,5 +1,45 @@
 # Koios gRest Changelog
 
+## [1.0.10rc] - For non-mainnet networks
+
+This release primarily focuses on ability to support better DeFi rojects alongwith some value addition endpoints. Overall issue is only breaking for two output column fields, the input param changes are optional, while there are a few additional fields on output for some endpoints. Also, dbsync 13.1.x.x was released and is being tested primarily for performance impacts.
+
+### New endpoints added
+
+- `/asset_addresses` -  Equivalent of deprecated `/asset_address_list` [#149](https://github.com/cardano-community/koios-artifacts/pull/149)
+- `/asset_nft_address` - Returns address where the specified NFT sits on [#149](https://github.com/cardano-community/koios-artifacts/pull/149)
+- `/account_utxos` - Returns brief details on non-empty UTxOs associated with a given stake address [#149](https://github.com/cardano-community/koios-artifacts/pull/149)
+- `/asset_info_bulk` - Bulk version of `/asset_info` [#142](https://github.com/cardano-community/koios-artifacts/pull/142)
+- `/asset_policy_list` - Returns list of all asset under a policy [#142](https://github.com/cardano-community/koios-artifacts/pull/142)
+- `/asset_token_registry` - Returns assets registered via token registry on github [#145](https://github.com/cardano-community/koios-artifacts/pull/145)
+- `/credential_utxos` - Returns UTxOs associated with a payment credential [#149](https://github.com/cardano-community/koios-artifacts/pull/149)
+- `/param_updates` - Returns list of parameter update proposals applied to the network [#149](https://github.com/cardano-community/koios-artifacts/pull/149)
+- `/policy_asset_addresses` - Returns addresses with quantity for each asset on a given policy [#149](https://github.com/cardano-community/koios-artifacts/pull/149)
+- `/policy_asset_info` - Equivalent of deprecated `/asset_policy_info` but with more details in output [#149](https://github.com/cardano-community/koios-artifacts/pull/149)
+
+### Data Input/Output Changes
+- Input - `/account_addresses` - Add optional `_first_only` and `_empty` flags to show only first address with tx or to include empty addresses to output [#149](https://github.com/cardano-community/koios-artifacts/pull/149)
+- Input - `/epoch_info` - Add optional `_include_next_epoch` field to show next epoch stats if available (eg: nonce, active stake) [#143](https://github.com/cardano-community/koios-artifacts/pull/143)
+- Output (addition) - `/account_assets` , `/address_assets` , `/address_info`, `/tx_info`, `/tx_utxos` - Add `decimals` to output [#142](https://github.com/cardano-community/koios-artifacts/pull/142)
+- Output (addition) - `/policy_asset_info` - Add `minting_tx_hash`, `total_supply`, `mint_cnt`, `burn_cnt` and `creation_time` fields to the output [#149](https://github.com/cardano-community/koios-artifacts/pull/149)
+- Output (**breaking**) - `/tx_info` - Change `_invalid_before` and `_invalid_after` to text field [#141](https://github.com/cardano-community/koios-artifacts/pull/141)
+- Output (**breaking**) - `/policy_asset_list` - Update `total_supply` to text (in line with other lovelace output columns) [#149](https://github.com/cardano-community/koios-artifacts/pull/149)
+- Output (**breaking**/removal) - `tx_info` - Remove the field `plutus_contracts` > [array] > `outputs` as there is no logic to connect it to inputs spending [#163](https://github.com/cardano-community/koios-artifacts/pull/163)
+
+### Deprecations:
+- `/asset_address_list` - Renamed to `asset_addresses` keeping naming line with other endpoints (old one still present, but will be deprecated in future release) [#149](https://github.com/cardano-community/koios-artifacts/pull/149)
+- `/asset_policy_info` - Renamed to `policy_asset_info` keeping naming line with other endpoints (old one still present, but will be deprecated in future release) [#149](https://github.com/cardano-community/koios-artifacts/pull/149)
+
+### Chores:
+- `/epoch_info`, `/epoch_params` - Restrict output to current epoch [#149](https://github.com/cardano-community/koios-artifacts/pull/149)
+- `/block_info` - Use `/previous_id` field to show previous/next blocks (previously was using block_id/height) [#145](https://github.com/cardano-community/koios-artifacts/pull/145)
+- `/asset_info`/`asset_policy_info` - Fix mint tx data to be latest [#141](https://github.com/cardano-community/koios-artifacts/pull/141)
+- Support new guild scripts revamp
+- New cache table `grest.asset_info_cache` to hold mint/burn counts alongwith first/last mint tx/keys [#142](https://github.com/cardano-community/koios-artifacts/pull/142)
+- Bump to Koios 1.0.10rc [#149](https://github.com/cardano-community/koios-artifacts/pull/149)
+- Fix typo in specs for `/pool_delegators` output column `latest_delegation_tx_hash` [#149](https://github.com/cardano-community/koios-artifacts/pull/149)
+
+
 ## [1.0.9] - For all networks
 
 This release is effectively same as `1.0.9rc` below (please check out the notes accordingly), just with minor bug fix on `setup-grest.sh` itself.

--- a/docs/Build/node-cli.md
+++ b/docs/Build/node-cli.md
@@ -17,9 +17,9 @@ cd cardano-node
 
 You can use the instructions below to build the latest release of [cardano-node](https://github.com/input-output-hk/cardano-node). 
 
-??? danger "Known issue on cardano-node 1.35.[4-5]"
+??? danger "Known issue on cardano-node 1.35.[4-6]"
     
-    Guild tools use a couple of additional binaries that is not part of node repository. Traditionally, these (eg: `cardano-address` and previously `cardano-ping`) were made available as part of build process by cabal.project.local file. However, for node tag 1.35.[4-5] - `cabal install` is [broken](https://github.com/cardano-community/guild-operators/issues/1573#issuecomment-1310230673) which means `cabal install cardano-addresses-cli` will no longer work and report error as below:
+    Guild tools use a couple of additional binaries that is not part of node repository. Traditionally, these (eg: `cardano-address` and previously `cardano-ping`) were made available as part of build process by cabal.project.local file. However, for node tag 1.35.[4-6] - `cabal install` is [broken](https://github.com/cardano-community/guild-operators/issues/1573#issuecomment-1310230673) which means `cabal install cardano-addresses-cli` will no longer work and report error as below:
     
     ```
     Got NamedPackage ouroboros-consensus-cardano-tools

--- a/docs/Scripts/cntools-changelog.md
+++ b/docs/Scripts/cntools-changelog.md
@@ -6,6 +6,10 @@ All notable changes to this tool will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.1.1] - 2023-02-07
+#### Fixed
+- Disable `dialog` by default, it is an optional component - and no longer installed by default.
+
 ## [10.1.0] - 2023-01-17
 #### Added
 - Hardware Wallets: Allow signing using cold keys for a pool, use it for rotating KES keys.

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -56,8 +56,7 @@ The script will always update dynamic content from existing scripts retaining ex
 
 ```
 
-1. If you receive an error for libssl, you may need to compile cncli manually on your OS as per instructions [here](https://github.com/cardano-community/cncli/blob/develop/INSTALL.md#compile-from-source)
-
+1. If you receive an error for `glibc`, it would likely be due to the build mismatch between pre-compiled binary and your OS, which is not uncommon. You may need to compile cncli manually on your OS as per instructions [here](https://github.com/cardano-community/cncli/blob/develop/INSTALL.md#compile-from-source) - make sure to copy the output binary to `"${HOME}/.local/bin"` folder.
 
 This script uses opt-in election of what you'd like the script to do (as against previous version that used to try and auto-detect versions). The defaults without any arguments will only update static part of script contents for you.
 A typical example install to install most components but not overwrite static part of existing files for preview network would be:

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -50,7 +50,7 @@ You can move the binaries by using mv command (for example, if you dont have any
     Ideally, you should shutdown services (eg: cnode, cnode-dbsync, etc) prior to running the below to ensure they run from new location (you can also re-deploy them if you haven't done so in a while, eg: `./cnode.sh -d`). At the end of the guide, you can start them back up.
 
 ``` bash
-mv -t "${HOME}"/.local/bin/ "${HOME}"/.cabal/bin/* "${HOME}"/.cargo/* "${HOME}"/bin/*
+mv -t "${HOME}"/.local/bin/ "${HOME}"/.cabal/bin/* "${HOME}"/.cargo/bin/* "${HOME}"/bin/*
 ```
 
 - We've found users often confuse between $PATH variable resolution between multiple shell sessions, systemd, etc. To avoid this, edit the following files and uncomment and set the following variables to the appropriate paths as per your deployment (eg: `CCLI="${HOME}"/.local/bin/cardano-cli` if following above):

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -15,7 +15,7 @@ CNTOOLS_MAJOR_VERSION=10
 # Minor: Changes and features of minor character that can be applied without breaking existing functionality or workflow
 CNTOOLS_MINOR_VERSION=1
 # Patch: Backwards compatible bug fixes. No additional functionality or major changes
-CNTOOLS_PATCH_VERSION=0
+CNTOOLS_PATCH_VERSION=1
 
 CNTOOLS_VERSION="${CNTOOLS_MAJOR_VERSION}.${CNTOOLS_MINOR_VERSION}.${CNTOOLS_PATCH_VERSION}"
 
@@ -35,7 +35,7 @@ if ! mkdir -p "${ASSET_FOLDER}" 2>/dev/null; then myExit 1 "${FG_RED}ERROR${NC}:
 [[ -z ${KES_WARNING_PERIOD} ]] && KES_WARNING_PERIOD=604800 # default 7 days
 [[ $(uname) == Darwin ]] && ENABLE_CHATTR=false
 [[ -z ${ENABLE_CHATTR} ]] && ENABLE_CHATTR=true
-[[ -z ${ENABLE_DIALOG} ]] && ENABLE_DIALOG=true
+[[ -z ${ENABLE_DIALOG} ]] && ENABLE_DIALOG=false
 [[ ${ENABLE_ADVANCED} = "true" ]] && ADVANCED_MODE="true"
 [[ -z ${CHECK_KES} ]] && CHECK_KES=true
 [[ -z ${CNTOOLS_LOG} ]] && CNTOOLS_LOG="${LOG_DIR}/cntools-history.log"

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -42,7 +42,7 @@ fi
 
 # enable or disable dialog used to help in file/dir selection by providing a gui to see available files and folders. [true|false] (not supported on all systems)
 # if disabled standard tty input is used
-#ENABLE_DIALOG=true
+#ENABLE_DIALOG=false
 
 # enable advanced/developer features like metadata transactions, multi-asset management etc. [true|false] (not needed for SPO usage)
 #ENABLE_ADVANCED=false

--- a/scripts/cnode-helper-scripts/guild-deploy.sh
+++ b/scripts/cnode-helper-scripts/guild-deploy.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2086,SC1090,SC2059
+# shellcheck disable=SC2086,SC1090,SC2059,SC2016
 # shellcheck source=/dev/null
 
 unset CNODE_HOME
@@ -15,7 +15,7 @@ unset CNODE_HOME
                         # topology.json, config.json and genesis files normally saved will also be overwritten
 #LIBSODIUM_FORK='Y'     # Use IOG fork of libsodium instead of official repositories - Recommended as per IOG instructions (Default: IOG fork)
 #INSTALL_CNCLI='N'      # Install/Upgrade and build CNCLI with RUST
-#INSTALL_VCHC='N'       # Install/Upgrade Vacuumlabs cardano-hw-cli for hardware wallet support
+#INSTALL_CWHCLI='N'       # Install/Upgrade Vacuumlabs cardano-hw-cli for hardware wallet support
 #INSTALL_OGMIOS='N'     # Install Ogmios Server
 #INSTALL_CSIGNER='N'    # Install/Upgrade Cardano Signer
 #CNODE_NAME='cnode'     # Alternate name for top level folder, non alpha-numeric chars will be replaced with underscore (Default: cnode)
@@ -93,7 +93,7 @@ set_defaults() {
   [[ -z ${FORCE_OVERWRITE} ]] && FORCE_OVERWRITE='N'
   [[ -z ${LIBSODIUM_FORK} ]] && LIBSODIUM_FORK='N'
   [[ -z ${INSTALL_CNCLI} ]] && INSTALL_CNCLI='N'
-  [[ -z ${INSTALL_VCHC} ]] && INSTALL_VCHC='N'
+  [[ -z ${INSTALL_CWHCLI} ]] && INSTALL_CWHCLI='N'
   [[ -z ${INSTALL_OGMIOS} ]] && INSTALL_OGMIOS='N'
   [[ -z ${INSTALL_CSIGNER} ]] && INSTALL_CSIGNER='N'
   [[ -z ${CNODE_PATH} ]] && CNODE_PATH="/opt/cardano"
@@ -385,7 +385,7 @@ download_cardanohwcli() {
         rm -rf "${HOME}"/.local/bin/cardano-hw-cli 
       fi
       pushd "${HOME}"/.local/bin >/dev/null || err_exit
-      mv -f /tmp/chwcli-bin/cardano-hw-cli/cardano-hw-cli .
+      mv -f /tmp/chwcli-bin/cardano-hw-cli/* ./
       if [[ ! -f "/etc/udev/rules.d/20-hw1.rules" ]]; then
         # Ledger udev rules
         curl -s -f -m ${CURL_TIMEOUT} https://raw.githubusercontent.com/LedgerHQ/udev-rules/master/add_udev_rules.sh | $sudo bash >/dev/null 2>&1


### PR DESCRIPTION
## Description

- [x] Changelog for docs corresponding to PR for koios [v1.0.10rc](https://github.com/cardano-community/koios-artifacts/pull/159)
- [x] guild-deploy: Copy all files from cardano-hw-cli release archive to ~/.local/bin/
- [x] guild-deploy: Remove redundant variable
- [x] cabal-build-all: Make cabal.project.local creation optional
- [x] cntools.library: Bump CNTools to 10.1.1 and change default value for ENABLE_DIALOG to false