### PR TITLE
Clear header addr and header port every round

### DIFF
--- a/scripts/cnode-helper-scripts/blockPerf.sh
+++ b/scripts/cnode-helper-scripts/blockPerf.sh
@@ -317,6 +317,7 @@ reportBlock() {
   slotHeightPrev=$blockSlot; 
   blockTimeTbh=""; missingTbh=true; blockTimeSfr1=""; blockTimeSfrX=""; blockTimeCbf=""; missingCbf=true; blockTimeCbfAddr=""; blockTimeCbfPort=""; blockTimeAb=""; blockSlot=""; blockSlotTime=""
   blockDelay=""; blockSize=""; blockTimeDeltaSlots=0; deltaCbf=""; deltaSfr=""; deltaAb=""; 
+  blockTimeTbhAddr=""; blockTimeTbhPort="";
 }
 
 if [[ "${PARSE_MANUAL}" == "Y" ]]; then


### PR DESCRIPTION


## Description
<!--- Describe your changes -->
Clear blockTimeTbhAddr and blockTimeTbhPort at the end of each round. Without it the first peer that provided a header when to scrip started will be reported as the first forever.
## Where should the reviewer start?
<!--- Describe where reviewer should start testing -->
This is a one-line patch.
## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
See description.
## Which issue it fixes?
<!--- Link to issue: Closes #issue-number -->

## How has this been tested?
<!--- Describe how you tested changes -->
Apply patch and observer the output of blockPerf.sh
