### PR TITLE
getmetrics: deduct zfs arc cache from memused

### DIFF
--- a/scripts/grest-helper-scripts/getmetrics.sh
+++ b/scripts/grest-helper-scripts/getmetrics.sh
@@ -43,7 +43,8 @@ function get-metrics() {
   meminf=$(grep "^Mem" /proc/meminfo)
   load1m=$(( $(awk '{ print $1*100 }' /proc/loadavg) / $(grep -c ^processor /proc/cpuinfo) ))
   memtotal=$(( $(echo "${meminf}" | grep MemTotal | awk '{print $2}') ))
-  memused=$(( memtotal - $(echo "${meminf}" | grep MemAvailable | awk '{print $2}') ))
+  arcused=$(grep "^size" /proc/spl/kstat/zfs/arcstats | awk '{print $3}')
+  memused=$(( memtotal - $(echo "${meminf}" | grep MemAvailable | awk '{print $2}') - ( arcused / 1024 )  ))
   cpuutil=$(awk -v a="$(awk '/cpu /{print $2+$4,$2+$4+$5}' /proc/stat; sleep 1)" '/cpu /{split(a,b," "); print 100*($2+$4-b[1])/($2+$4+$5-b[2])}'  /proc/stat)
   # in Bytes
   pubschsize=$(psql -t --csv -d ${PGDATABASE} -c "SELECT sum(pg_total_relation_size(quote_ident(schemaname) || '.' || quote_ident(tablename))::bigint) FROM pg_tables WHERE schemaname = 'public'" | grep "^[0-9]")

--- a/scripts/grest-helper-scripts/getmetrics.sh
+++ b/scripts/grest-helper-scripts/getmetrics.sh
@@ -45,7 +45,7 @@ function get-metrics() {
   memtotal=$(( $(echo "${meminf}" | grep MemTotal | awk '{print $2}') ))
   arcused=$(awk '/^size/ { print $3/1024 }' /proc/spl/kstat/zfs/arcstats 2>/dev/null)
   [[ -z "${arcused}" ]] && arcused=0
-  memused=$(( memtotal - $(echo "${meminf}" | grep MemAvailable | awk '{print $2}') - arcused )  ))
+  memused=$(( memtotal - $(echo "${meminf}" | grep MemAvailable | awk '{print $2}') - arcused ))
   cpuutil=$(awk -v a="$(awk '/cpu /{print $2+$4,$2+$4+$5}' /proc/stat; sleep 1)" '/cpu /{split(a,b," "); print 100*($2+$4-b[1])/($2+$4+$5-b[2])}'  /proc/stat)
   # in Bytes
   pubschsize=$(psql -t --csv -d ${PGDATABASE} -c "SELECT sum(pg_total_relation_size(quote_ident(schemaname) || '.' || quote_ident(tablename))::bigint) FROM pg_tables WHERE schemaname = 'public'" | grep "^[0-9]")


### PR DESCRIPTION
## Description
Added a new variable arcused to be able to deduct it from final memory used calculation.

## Where should the reviewer start?
Test on machines without zfs and with zfs

## Motivation and context
The memory used should not include ZFS ARC Cache, as it's misleading.

## How has this been tested?
Tested on Ubuntu 22.04 with ZFS arc cache present.
