### PR TITLE
CNTools 10.2.1

### DIFF
--- a/docs/Scripts/cntools-changelog.md
+++ b/docs/Scripts/cntools-changelog.md
@@ -6,6 +6,10 @@ All notable changes to this tool will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.2.1] - 2023-04-04
+#### Fixed
+- Moved `test_koios` call from cntools.library to cntools.sh
+
 ## [10.2.0] - 2023-03-13
 #### Fixed
 - HW signing fix due to deprecated cardano-hw-cli sign call.

--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -15,7 +15,7 @@ CNTOOLS_MAJOR_VERSION=10
 # Minor: Changes and features of minor character that can be applied without breaking existing functionality or workflow
 CNTOOLS_MINOR_VERSION=2
 # Patch: Backwards compatible bug fixes. No additional functionality or major changes
-CNTOOLS_PATCH_VERSION=0
+CNTOOLS_PATCH_VERSION=1
 
 CNTOOLS_VERSION="${CNTOOLS_MAJOR_VERSION}.${CNTOOLS_MINOR_VERSION}.${CNTOOLS_PATCH_VERSION}"
 
@@ -40,7 +40,6 @@ if ! mkdir -p "${ASSET_FOLDER}" 2>/dev/null; then myExit 1 "${FG_RED}ERROR${NC}:
 [[ -z ${CHECK_KES} ]] && CHECK_KES=true
 [[ -z ${CNTOOLS_LOG} ]] && CNTOOLS_LOG="${LOG_DIR}/cntools-history.log"
 getEraIdentifier
-test_koios
 
 ############################################################
 # library sourced by cntools with common taskes to perform #

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -128,6 +128,9 @@ else
   . "${PARENT}"/env &>/dev/null
 fi
 
+# Source cntools.library to populate defaults for CNTools
+! . "${PARENT}"/cntools.library && myExit 1
+
 [[ ${PRINT_VERSION} = "true" ]] && myExit 0 "CNTools v${CNTOOLS_VERSION} (branch: $([[ -f "${PARENT}"/.env_branch ]] && cat "${PARENT}"/.env_branch || echo "master"))"
 
 # Do some checks when run in connected mode
@@ -202,8 +205,8 @@ if [[ ${CNTOOLS_MODE} = "CONNECTED" ]]; then
   echo "${PROT_PARAMS}" > "${TMP_DIR}"/protparams.json
 fi
 
-# get helper functions from library file
-! . "${PARENT}"/cntools.library && myExit 1
+# Test if koios is reachable , otherwise - unset KOIOS_API
+test_koios
 
 archiveLog # archive current log and cleanup log archive folder
 
@@ -2452,7 +2455,7 @@ function main {
               println DEBUG "Current epoch: ${FG_LBLUE}${epoch}${NC}"
               epoch_start=$((epoch + 1))
               epoch_end=$((epoch + poolRetireMaxEpoch))
-              println DEBUG "earlist epoch to retire pool is ${FG_LBLUE}${epoch_start}${NC} and latest ${FG_LBLUE}${epoch_end}${NC}"
+              println DEBUG "earliest epoch to retire pool is ${FG_LBLUE}${epoch_start}${NC} and latest ${FG_LBLUE}${epoch_end}${NC}"
               echo
               getAnswerAnyCust epoch_enter "Enter epoch in which to retire pool (blank for ${epoch_start})"
               [[ -z "${epoch_enter}" ]] && epoch_enter=${epoch_start}


### PR DESCRIPTION
## Description

Move `test_koios` from cntools.library to cntools.sh

## Motivation and context

With 10.2.0, the cntools.library call was re-arranged - which resulted in TMP_DIR getting assigned with value from `env` file instead of `cntools.library` - for writing to protocol_parameter file, resulting in errors when trying to read from the file post being sourced via `cntools.library`. The motivation behind this re-arrangement - as I understand - was a reference to test_koios to unset `KOIOS_API` based on user preference was being overwritten by `env` file sourced later.

Instead of moving the entire `cntools.library` call which can have larger implication in future (currently it seemed to be only `TMP_DIR`), we move `test_koios` call itself to cntools.sh file - and ensure `env` file isnt sourced after

PS: There is already a `cntools-10.2.1` branch that aims to fix hardware wallet, but unsure of the status. That branch can later be updated to a successive version when ready