### PR TITLE
Update guild-deploy.sh for cncli 5.3.2 download compiled with musl

### DIFF
--- a/scripts/cnode-helper-scripts/guild-deploy.sh
+++ b/scripts/cnode-helper-scripts/guild-deploy.sh
@@ -349,7 +349,7 @@ download_cncli() {
   echo -e "\n  Downloading CNCLI..."
   rm -rf /tmp/cncli-bin && mkdir /tmp/cncli-bin
   pushd /tmp/cncli-bin >/dev/null || err_exit
-  cncli_asset_url="$(curl -s https://api.github.com/repos/cardano-community/cncli/releases/latest | jq -r '.assets[].browser_download_url' | grep 'linux-gnu.tar.gz')"
+  cncli_asset_url="$(curl -s https://api.github.com/repos/cardano-community/cncli/releases/latest | jq -r '.assets[].browser_download_url' | grep 'linux-musl.tar.gz')"
   if curl -sL -f -m ${CURL_TIMEOUT} -o cncli.tar.gz ${cncli_asset_url}; then
     tar zxf cncli.tar.gz &>/dev/null
     rm -f cncli.tar.gz


### PR DESCRIPTION
Changed cncli download parser to linux-musl from linux-gnu. Andrew obviously changed the compiler from standard GNU glibc to MUSL with cncli 5.3.2

## Description
Changed cncli download parser to linux-musl from linux-gnu

## Where should the reviewer start?
Try to download cncli 5.2.3 with script before patch and after patch

## Motivation and context
Andrew obviously changed the compiler from standard GNU to MUSL with cncli 5.3.2 and with this the file name changed and thus the parser fails without fix.

## Which issue it fixes?
Download cncli 5.3.2+

## How has this been tested?
Locally with patch and downloading cncli 5.3.2
