### PR TITLE
Enable KOIOS in healthcheck.sh

### DIFF
--- a/files/docker/node/addons/healthcheck.sh
+++ b/files/docker/node/addons/healthcheck.sh
@@ -10,14 +10,34 @@ if [[ "$NETWORK" == "guild-mainnet" ]]; then NETWORK=mainnet; fi
 
 FIRST=$($CCLI query tip --testnet-magic ${NWMAGIC} | jq .block)
 
-sleep 60;
-
-SECOND=$($CCLI query tip --testnet-magic ${NWMAGIC} | jq .block)
-
-
-if [[ "$FIRST" -ge "$SECOND" ]]; then
-echo "there is a problem";
-exit 1
+if [[ "${ENABLE_KOIOS}" == "N" ]] || [[ -z "${KOIOS_API}" ]]; then
+    # when KOIOS is not enabled or KOIOS_API is unset, use default behavior
+    sleep 60;
+    SECOND=$($CCLI query tip --testnet-magic ${NWMAGIC} | jq .block)
+    if [[ "$FIRST" -ge "$SECOND" ]]; then
+        echo "there is a problem"
+        exit 1
+    else
+        echo "we're healthy - node: $FIRST -> node: $SECOND"
+    fi
 else
-echo "we're healthy - $FIRST -> $SECOND"
+    # else leverage koios and only require the node is on tip
+    CURL=$(which curl)
+    JQ=$(which jq)
+    URL="${KOIOS_API}/tip"
+    SECOND=$($CURL -s "${URL}" | $JQ '.[0].block_no')
+    for (( CHECK=1; CHECK<=20; CHECK++ )); do
+        if [[ "$FIRST" -eq "$SECOND" ]]; then
+            echo "we're healthy - node: $FIRST == koios: $SECOND"
+            exit 0
+        elif [[ "$FIRST" -lt "$SECOND" ]]; then
+            sleep 3
+            FIRST=$($CCLI query tip --testnet-magic ${NWMAGIC} | jq .block)
+        elif [[ "$FIRST" -gt "$SECOND" ]]; then
+            sleep 3
+            SECOND=$($CURL "${KOIOS_URL}" | $JQ '.[0].block_no')
+        fi
+    done
+    echo "there is a problem"
+    exit 1
 fi

--- a/scripts/cnode-helper-scripts/guild-deploy.sh
+++ b/scripts/cnode-helper-scripts/guild-deploy.sh
@@ -349,7 +349,7 @@ download_cncli() {
   echo -e "\n  Downloading CNCLI..."
   rm -rf /tmp/cncli-bin && mkdir /tmp/cncli-bin
   pushd /tmp/cncli-bin >/dev/null || err_exit
-  cncli_asset_url="$(curl -s https://api.github.com/repos/cardano-community/cncli/releases/latest | jq -r '.assets[].browser_download_url' | grep 'linux-gnu.tar.gz')"
+  cncli_asset_url="$(curl -s https://api.github.com/repos/cardano-community/cncli/releases/latest | jq -r '.assets[].browser_download_url' | grep 'linux-musl.tar.gz')"
   if curl -sL -f -m ${CURL_TIMEOUT} -o cncli.tar.gz ${cncli_asset_url}; then
     tar zxf cncli.tar.gz &>/dev/null
     rm -f cncli.tar.gz


### PR DESCRIPTION
## Description
When ENABLE_KOIOS  and KOIOS_API are defined the healthcheck will default to checking the node and koios are in sync.

When the node and koios are not in sync healthcheck sleeps 3 seconds, updates the side which is behind, and checks again. There is a limit to 20 checks, with 3 second sleeps the max runtime of the healthcheck against KOIOS should be 60 seconds, the same as the sleep from the original logic.

When ENABLE_KOIOS is not Y or KOIOS_API is unset by the `test_koios()` function the healthcheck will use its original behavior.

## Where should the reviewer start?

If the reviewer uses containers they can:

```
docker cp /tmp/healthcheck.sh <container_name>:/home/guild/.scripts/healtcheck_koios.sh
docker exec -it <container_name> chmod +x /home/guild/.scripts/healtcheck_koios.sh
docker exec -it <container_name> /home/guild/.scripts/healtcheck_koios.sh
```

If the reviewer does not use containers then simply place the script onto a relay or bp node and execute the script. It still prints a message to the console about the results and uses exit codes 0 (healthy) and 1 (unhealthy).

## Motivation and context

- Increase observability of node/container health. 
- Ability to decrease the healthcheck 
  - **timeout** from 100s to 60s or even the default of 30s.
  - **interval** from 5 minutes.

## Which issue it fixes?
N/A

## How has this been tested?
Tested against versions:
- 1.35.4
- 1.35.5
- 1.35.6

Tested against networks:
- Preview
- PreProd
- Guild
- Mainnet
