### PR TITLE
Container enable chattr

### DIFF
--- a/files/docker/node/addons/entrypoint.sh
+++ b/files/docker/node/addons/entrypoint.sh
@@ -31,7 +31,7 @@ fi
 customise () {
 find /opt/cardano/cnode/files -name "*config*.json" -print0 | xargs -0 sed -i 's/127.0.0.1/0.0.0.0/g' > /dev/null 2>&1 
 grep -i ENABLE_CHATTR /opt/cardano/cnode/scripts/cntools.sh >/dev/null && sed -E -i 's/^#?ENABLE_CHATTR=(true|false)?/ENABLE_CHATTR=false/g' /opt/cardano/cnode/scripts/cntools.sh > /dev/null 2>&1
-grep -i ENABLE_DIALOG /opt/cardano/cnode/scripts/cntools.sh >/dev/null && sed -i 's/ENABLE_DIALOG=true/ENABLE_DIALOG=false/' /opt/cardano/cnode/scripts/cntools.sh >> /opt/cardano/cnode/scripts/cntools.sh
+grep -i ENABLE_DIALOG /opt/cardano/cnode/scripts/cntools.sh >/dev/null && sed -E -i 's/^#?ENABLE_DIALOG=(true|false)?/ENABLE_DIALOG=false/' /opt/cardano/cnode/scripts/cntools.sh >> /opt/cardano/cnode/scripts/cntools.sh
 find /opt/cardano/cnode/files -name "*config*.json" -print0 | xargs -0 sed -i 's/\"hasEKG\": 12788,/\"hasEKG\": [\n    \"0.0.0.0\",\n    12788\n],/g' > /dev/null 2>&1
 return 0
 }

--- a/files/docker/node/addons/entrypoint.sh
+++ b/files/docker/node/addons/entrypoint.sh
@@ -30,7 +30,7 @@ fi
 # Customisation 
 customise () {
 find /opt/cardano/cnode/files -name "*config*.json" -print0 | xargs -0 sed -i 's/127.0.0.1/0.0.0.0/g' > /dev/null 2>&1 
-grep -i ENABLE_CHATTR /opt/cardano/cnode/scripts/cntools.sh >/dev/null && sed -i 's/ENABLE_CHATTR=true/ENABLE_CHATTR=false/g' /opt/cardano/cnode/scripts/cntools.sh > /dev/null 2>&1
+grep -i ENABLE_CHATTR /opt/cardano/cnode/scripts/cntools.sh >/dev/null && sed -E -i 's/^#?ENABLE_CHATTR=(true|false)?/ENABLE_CHATTR=false/g' /opt/cardano/cnode/scripts/cntools.sh > /dev/null 2>&1
 grep -i ENABLE_DIALOG /opt/cardano/cnode/scripts/cntools.sh >/dev/null && sed -i 's/ENABLE_DIALOG=true/ENABLE_DIALOG=false/' /opt/cardano/cnode/scripts/cntools.sh >> /opt/cardano/cnode/scripts/cntools.sh
 find /opt/cardano/cnode/files -name "*config*.json" -print0 | xargs -0 sed -i 's/\"hasEKG\": 12788,/\"hasEKG\": [\n    \"0.0.0.0\",\n    12788\n],/g' > /dev/null 2>&1
 return 0


### PR DESCRIPTION
## Description

Adjusts both ENABLE_CHATTR and ENABLE_DIALOG to:
1. Changes adjust the `sed` to uncomment variables if they are currently commented out. 
2. Uses `-E` regex to make the comment optional in case `cntools.sh` uncomments it in the future.
3. Make the replacement work whether `cntools.sh` currently sets the value to true or to false.

## Where should the reviewer start?
`entrypoint.sh` only two lines changed to account for:
```
# grep -i ENABLE_CHATTR /opt/cardano/cnode/scripts/cntools.sh
#ENABLE_CHATTR=false
                      if [[ ${ENABLE_CHATTR} = true && $(lsattr -R "$file") =~ -i- ]]; then
                      if [[ ${ENABLE_CHATTR} = true && ! $(lsattr -R "$file") =~ -i- ]]; then

# grep -i ENABLE_DIALOG= /opt/cardano/cnode/scripts/cntools.sh
#ENABLE_DIALOG=false 
```


## Motivation and context
* Avoids trying to use the `chattr` tool inside containers where tool may not be available or privileges may not be granted inside the container.
* Fixes lines in `entrypoint.sh` that do not work with the current `cntools.sh` file but were already part of entrypoint logic.

## Which issue it fixes?
Closes #1621 

## How has this been tested?
1. Examine a containers `cntools.sh` post startup.
2. Observe that both **ENABLE_CHATTR** and **ENABLE_DIALOG** are not set to false.
3. Update the container with the `entrypoint.sh` of this branch. 
   * One method if the container is not ephemeral (removed when stopped)  is to use`docker cp entrypoint.sh <container_name>:/home/guild/entrypoint.sh` and restart the container.
4. Observe that both variables are uncommented and set to false.
