### PR TITLE
fix missing space in if condition

### DIFF
--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -2492,7 +2492,7 @@ witnessTx() {
       println ERROR "\n${FG_RED}ERROR${NC}: file not found: ${skey}"
       return 1
     elif [[ $(jq -r '.description' "${skey}") = *"Hardware"* ]]; then # HW signing key
-      if[[ ${isHW} = 'Y' ]]; then
+      if [[ ${isHW} = 'Y' ]]; then
         # just add key to witness_command()
         hw_witness_command+=( --hw-signing-file "${skey}" )
       else


### PR DESCRIPTION
## Description
add a space that if missing prevent cntools.library to load, and therefore cntools to run

## Where should the reviewer start?
exec cntools.sh

## How has this been tested?
running cntools.sh was OK
