### PR TITLE
Remove the decimal from costADA to get lovelace instead of multiplying

### DIFF
--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -2709,7 +2709,7 @@ function main {
               if [[ ${CNTOOLS_MODE} = "OFFLINE" && -f "${pool_config}" ]]; then
                 conf_pledge=$(( $(jq -r '.pledgeADA //0' "${pool_config}") * 1000000 ))
                 conf_margin=$(jq -r '.margin //0' "${pool_config}")
-                conf_cost=$(( $(jq -r '.costADA //0' "${pool_config}") * 1000000 ))
+                conf_cost=$(jq -r '.costADA //0' "${pool_config}" | tr -d '.')
                 conf_owner=$(jq -r '.pledgeWallet //"unknown"' "${pool_config}")
                 conf_reward=$(jq -r '.rewardWallet //"unknown"' "${pool_config}")
                 println "$(printf "%-21s : ${FG_LBLUE}%s${NC} Ada" "Pledge" "$(formatAsset "${conf_pledge::-6}")")"


### PR DESCRIPTION
## Description
Changes from an arithmetic operation for `.costADA` in the `pool.config` file to get lovelace into a truncate of the decimal point, as the value already contains the lovelace details when stored.

## Where should the reviewer start?
Confirm offline mode (and online mode) Pool->Show does not crash or contain errors.

## Motivation and context
Make CNTools stable for all available operations in offline mode.

## Which issue it fixes?
Closes #1637 

## How has this been tested?
Preprod, Preview and Guild network on CNTools 10.2.1 and 10.2.3 with Cardano Node 1.35.
