### PR TITLE
[container] install vim for adding transaction messages

### DIFF
--- a/files/docker/node/dockerfile_bin
+++ b/files/docker/node/dockerfile_bin
@@ -32,7 +32,7 @@ RUN set -x && apt update \
     && echo "export LC_ALL=en_US.UTF-8" >> ~/.bashrc \
     && echo "export LANG=en_US.UTF-8" >> ~/.bashrc \
     && echo "export LANGUAGE=en_US.UTF-8" >> ~/.bashr \
-    && apt-get install -y procps libsecp256k1-0 libcap2 libselinux1 libc6 libsodium-dev ncurses-bin iproute2 curl wget apt-utils xz-utils netbase sudo coreutils dnsutils net-tools procps tcptraceroute bc usbip sqlite3 python3 tmux jq ncurses-base libtool autoconf git gnupg tcptraceroute util-linux less openssl bsdmainutils dialog \
+    && apt-get install -y procps libsecp256k1-0 libcap2 libselinux1 libc6 libsodium-dev ncurses-bin iproute2 curl wget apt-utils xz-utils netbase sudo coreutils dnsutils net-tools procps tcptraceroute bc usbip sqlite3 python3 tmux jq ncurses-base libtool autoconf git gnupg tcptraceroute util-linux less openssl bsdmainutils dialog vim \
     && apt-get -y remove libpq-dev build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev libsystemd-dev zlib1g-dev make g++ && apt-get -y purge && apt-get -y clean && apt-get -y autoremove && rm -rf /var/lib/apt/lists/* \
     && cd /usr/bin \
     && wget http://www.vdberg.org/~richard/tcpping \


### PR DESCRIPTION
## Description
Installs vi into the container.

## Where should the reviewer start?
[`files/docker/node/dockerfile_bin`  line 35](https://github.com/TrevorBenson/guild-operators/blob/container-include-vi-for-tx-messages/files/docker/node/dockerfile_bin#L35)

## Motivation and context
To allow cntools to add messages to transactions inside the container.

## Which issue it fixes?
Closes #1640 

## How has this been tested?
1. Installed vim package `[docker|podman] exec -it -u root <container_name> bash -c 'apt-get update ; apt-get install -y vim'`
2. Repeat steps **To Reproduce** in #1640    