### PR TITLE
Remove cddl-format switch from cntools.library-buildtx

### DIFF
--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -2473,8 +2473,8 @@ burnAsset() {
 #             : populate an array variable called 'build_args' with all data
 # Parameters  : build_args  >  an array with all the arguments to assemble the transaction
 buildTx() {
-  println ACTION "${CCLI} transaction build-raw ${ERA_IDENTIFIER} --cddl-format ${build_args[*]}"
-  ${CCLI} transaction build-raw ${ERA_IDENTIFIER} --cddl-format "${build_args[@]}"
+  println ACTION "${CCLI} transaction build-raw ${ERA_IDENTIFIER} ${build_args[*]}"
+  ${CCLI} transaction build-raw ${ERA_IDENTIFIER} "${build_args[@]}"
 }
 
 # Command     : witnessTx [raw tx file] [signing keys ...]


### PR DESCRIPTION
## Description
Remove cddl-format switch from cntools.library-buildtx

## Where should the reviewer start?
anythinh that needs to build/witness/submit a TX

## Motivation and context
CLI 8.0.0 does not accept the switch anymore

## Which issue it fixes?
n/c

## How has this been tested?
modified a pool OK with 8.0.0
