### PR TITLE
Testable workflows for forked reposiories

### DIFF
--- a/.github/workflows/docker_bin.yml
+++ b/.github/workflows/docker_bin.yml
@@ -8,15 +8,25 @@ on:
       
 jobs:
   build:
+    env:
+      REGISTRY: docker.io
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
+    - name: Add variables to environment
+      run: |
+        echo "G_ACCOUNT=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
+        echo "CNVERSION=$(cat files/docker/node/release-versions/cardano-node-latest.txt)" >> $GITHUB_ENV
     - name: Compiling new node software suite
-      run: |      
-        DOCKER_BUILDKIT=1 docker build . --file files/docker/node/dockerfile_bin --compress --tag cardanocommunity/cardano-node:latest
+      run: |
+        DOCKER_BUILDKIT=1 docker build . \
+          --file files/docker/node/dockerfile_bin \
+          --compress \
+          --build-arg G_ACCOUNT=${{ env.G_ACCOUNT }} \
+          --tag ${{ env.REGISTRY }}/${{ secrets.DOCKER_USER }}/cardano-node:latest
         # Workaround to provide additional free space for builds.
         #   https://github.com/actions/virtual-environments/issues/2840
         sudo apt-get remove -y '^dotnet-.*'
@@ -30,6 +40,13 @@ jobs:
     - name: docker push latest
       run: |
         CNVERSION=`cat files/docker/node/release-versions/cardano-node-latest.txt`
-        docker push cardanocommunity/cardano-node:latest
-        docker tag cardanocommunity/cardano-node:latest cardanocommunity/cardano-node:$CNVERSION
-        docker push cardanocommunity/cardano-node:$CNVERSION
+        docker push ${{ env.REGISTRY }}/${{ secrets.DOCKER_USER }}/cardano-node:latest
+        docker tag ${{ env.REGISTRY }}/${{ secrets.DOCKER_USER }}/cardano-node:latest ${{ secrets.DOCKER_USER }}/cardano-node:${{ env.CNVERSION }}
+        docker push ${{ env.REGISTRY }}/${{ secrets.DOCKER_USER }}/cardano-node:${{ env.CNVERSION }}
+    - name: Add summary details
+      if: always()
+      run: |
+        echo "## Summary Details" >> $GITHUB_STEP_SUMMARY
+        echo "* Docker Image: ${{ env.REGISTRY }}/${{ secrets.DOCKER_USER }}/cardano-node:${{ env.CNVERSION }}" >> $GITHUB_STEP_SUMMARY
+        echo "* G_ACCOUNT: ${GITHUB_REPOSITORY_OWNER}" >> $GITHUB_STEP_SUMMARY
+        echo "* CNVERSION: ${{ env.CNVERSION }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/premerge_amazonlinux2.yml
+++ b/.github/workflows/premerge_amazonlinux2.yml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   guild-deploy-and-build-amazonlinux2:
+    env:
+      REGISTRY: ghcr.io
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
@@ -34,44 +36,48 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - uses: actions/checkout@v2
-    - name: Extract branch from PR
-      shell: bash
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Define BRANCH, COMMIT and G_ACCOUNT in environment
       run: |
-        echo "##[set-output name=branch;]${GITHUB_HEAD_REF}"
-        echo "##[set-output name=owner;]${GITHUB_REPOSITORY_OWNER}"
-      id: pr_branch
-    #- name: Testing guild-deploy.sh (system libsodium)
-    #  run: |
-    #    export BRANCH=${{ steps.pr_branch.outputs.branch }}
-    #    export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-    #    export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-    #    docker build . --file files/tests/pre-merge/amazonlinux2-guild-deploy.sh.containerfile --compress --build-arg BRANCH --build-arg COMMIT --build-arg G_ACCOUNT --tag ghcr.io/cardano-community/pre-merge-amazonlinux2:guild-deploy_${COMMIT}
-    #- name: Push pre-merge-amazonlinux2:guild-deploy_${COMMIT}
-    #  run: |
-    #    export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-    #    docker push ghcr.io/cardano-community/pre-merge-amazonlinux2:guild-deploy_${COMMIT}
-    #- name: Testing cabal-build-all.sh (system libsodium)
-    #  run: |
-    #    export BRANCH=${{ steps.pr_branch.outputs.branch }}
-    #    export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-    #    export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-    #    echo "Working from PR Branch ${G_ACCOUNT}/guild-operators/${BRANCH} on Commit ${COMMIT}"
-    #    docker build . --file files/tests/pre-merge/amazonlinux2-cabal.containerfile --compress --build-arg BRANCH --build-arg COMMIT --tag ghcr.io/cardano-community/pre-merge-amazonlinux2:cabal_${COMMIT}
+        echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+        echo "G_ACCOUNT=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
+        echo "COMMIT=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
     - name: Testing guild-deploy.sh (IO fork of libsodium)
       run: |
-        export BRANCH=${{ steps.pr_branch.outputs.branch }}
-        export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-        export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-        docker build . --file files/tests/pre-merge/amazonlinux2-guild-deploy.sh-l.containerfile --compress --build-arg BRANCH --build-arg COMMIT --build-arg G_ACCOUNT --tag ghcr.io/cardano-community/pre-merge-amazonlinux2:guild-deploy-l_${COMMIT}
-    - name: Push pre-merge-amazonlinux2:guild-deploy_${COMMIT}
+        docker build . \
+          --file files/tests/pre-merge/amazonlinux2-guild-deploy.sh-l.containerfile \
+          --compress \
+          --build-arg BRANCH=${{ env.BRANCH }} \
+          --build-arg COMMIT=${{ env.COMMIT }} \
+          --build-arg G_ACCOUNT=${{ env.G_ACCOUNT }} \
+          --tag ${{ env.REGISTRY }}${{ env.G_ACCOUNT }}pre-merge-amazonlinux2:guild-deploy-l_${{ env.COMMIT }}
+    - name: Push pre-merge-amazonlinux2:guild-deploy_${{ env.COMMIT }}
       run: |
-        export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-        docker push ghcr.io/cardano-community/pre-merge-amazonlinux2:guild-deploy-l_${COMMIT}
+        docker push ${{ env.REGISTRY }}${{ env.G_ACCOUNT }}pre-merge-amazonlinux2:guild-deploy-l_${{ env.COMMIT }}
     - name: Testing cabal-build-all.sh (IO fork of libsodium)
       run: |
-        export BRANCH=${{ steps.pr_branch.outputs.branch }}
-        export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-        export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-        echo "Working from PR Branch ${G_ACCOUNT}/guild-operators/${BRANCH} on Commit ${COMMIT}"
-        docker build . --file files/tests/pre-merge/amazonlinux2-cabal.containerfile --compress --build-arg BRANCH --build-arg COMMIT --tag ghcr.io/cardano-community/pre-merge-amazonlinux2:cabal-l_${COMMIT}
+        echo "Working from PR Branch ${G_ACCOUNT}/guild-operators/${{ env.BRANCH }} on Commit ${{ env.COMMIT }}"
+        docker build . \
+          --file files/tests/pre-merge/amazonlinux2-cabal.containerfile \
+          --compress \
+          --build-arg BRANCH=${{ env.BRANCH }} \
+          --build-arg COMMIT=${{ env.COMMIT }} \
+          --build-arg G_ACCOUNT=${{ env.G_ACCOUNT }} \
+          --tag ${{ env.REGISTRY }}${{ env.G_ACCOUNT }}pre-merge-amazonlinux2:cabal-l_${{ env.COMMIT }}
+    - name: Add summary details
+      if: always()
+      run: |
+          echo "## Summary Details" >> $GITHUB_STEP_SUMMARY
+          echo "* Docker Image: ${{ env.REGISTRY }}/${{ secrets.DOCKER_USER }}/cardano-node:$CNVERSION" >> $GITHUB_STEP_SUMMARY
+          echo "* BRANCH: ${{ env.BRANCH }}" >> $GITHUB_STEP_SUMMARY
+          echo "* G_ACCOUNT: ${GITHUB_REPOSITORY_OWNER}" >> $GITHUB_STEP_SUMMARY
+          echo "* COMMIT: ${{ env.COMMIT }}" >> $GITHUB_STEP_SUMMARY
+    - name: Add summary details
+      if: always()
+      run: |
+        echo "## Summary Details" >> $GITHUB_STEP_SUMMARY
+        echo "* Docker Image: ${{ env.REGISTRY }}/${{ secrets.DOCKER_USER }}/cardano-node:$CNVERSION" >> $GITHUB_STEP_SUMMARY
+        echo "* BRANCH: ${{ env.BRANCH }}" >> $GITHUB_STEP_SUMMARY
+        echo "* G_ACCOUNT: ${GITHUB_REPOSITORY_OWNER}" >> $GITHUB_STEP_SUMMARY
+        echo "* COMMIT: ${{ env.COMMIT }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/premerge_debian.yml
+++ b/.github/workflows/premerge_debian.yml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   guild-deploy-and-build-debian:
+    env:
+      REGISTRY: ghcr.io
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
@@ -34,45 +36,39 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - uses: actions/checkout@v2
-    - name: Extract branch from PR
-      shell: bash
+    - uses: actions/checkout@v3
+    - name: Define BRANCH, COMMIT and G_ACCOUNT in environment
       run: |
-        echo "##[set-output name=branch;]${GITHUB_HEAD_REF}"
-        echo "##[set-output name=owner;]${GITHUB_REPOSITORY_OWNER}"
-      id: pr_branch
-    #- name: Testing guild-deploy.sh (system libsodium)
-    #  run: |
-    #    export BRANCH=${{ steps.pr_branch.outputs.branch }}
-    #    export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-    #    export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-    #    docker build . --file files/tests/pre-merge/debian-guild-deploy.sh.containerfile --compress --build-arg BRANCH --build-arg COMMIT --build-arg G_ACCOUNT --tag ghcr.io/cardano-community/pre-merge-debian:guild-deploy_${COMMIT}
-    #- name: Push pre-merge-debian:guild-deploy_${COMMIT}
-    #  run: |
-    #    export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-    #    docker push ghcr.io/cardano-community/pre-merge-debian:guild-deploy_${COMMIT}
-    #- name: Testing cabal-build-all.sh (system libsodium)
-    #  run: |
-    #    export BRANCH=${{ steps.pr_branch.outputs.branch }}
-    #    export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-    #    export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-    #    echo "Working from PR Branch ${G_ACCOUNT}/guild-operators/${BRANCH} on Commit ${COMMIT}"
-    #    docker build . --file files/tests/pre-merge/debian-cabal.containerfile --compress --build-arg BRANCH --build-arg COMMIT --tag ghcr.io/cardano-community/pre-merge-debian:cabal_${COMMIT}
+        echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+        echo "G_ACCOUNT=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
+        echo "COMMIT=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
     - name: Testing guild-deploy.sh (IO fork of libsodium)
       run: |
-        export BRANCH=${{ steps.pr_branch.outputs.branch }}
-        export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-        export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-        docker build . --file files/tests/pre-merge/debian-guild-deploy.sh-l.containerfile --compress --build-arg BRANCH --build-arg COMMIT --build-arg G_ACCOUNT --tag ghcr.io/cardano-community/pre-merge-debian:guild-deploy-l_${COMMIT}
-    - name: Push pre-merge-debian:guild-deploy-l_${COMMIT}
+        docker build . \
+          --file files/tests/pre-merge/debian-guild-deploy.sh-l.containerfile \
+          --compress \
+          --build-arg BRANCH=${{ env.BRANCH }} \
+          --build-arg COMMIT=${{ env.COMMIT }} \
+          --build-arg G_ACCOUNT=${{ env.G_ACCOUNT }} \
+          --tag ${{ env.REGISTRY }}/${{ env.G_ACCOUNT }}/pre-merge-debian:guild-deploy-l_${{ env.COMMIT }}
+    - name: Push pre-merge-debian:guild-deploy-l_${{ env.COMMIT }}
       run: |
-        export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-        docker push ghcr.io/cardano-community/pre-merge-debian:guild-deploy-l_${COMMIT}
+        docker push ${{ env.REGISTRY }}/${{ env.G_ACCOUNT }}/pre-merge-debian:guild-deploy-l_${{ env.COMMIT }}
     - name: Testing cabal-build-all.sh (IO fork of libsodium)
       run: |
-        export BRANCH=${{ steps.pr_branch.outputs.branch }}
-        export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-        export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-        echo "Working from PR Branch ${G_ACCOUNT}/guild-operators/${BRANCH} on Commit ${COMMIT}"
-        docker build . --file files/tests/pre-merge/debian-cabal-l.containerfile --compress --build-arg BRANCH --build-arg COMMIT --tag ghcr.io/cardano-community/pre-merge-debian:cabal-l_${COMMIT}
-
+        echo "Working from PR Branch ${{ env.G_ACCOUNT }}/guild-operators/${{ env.BRANCH }} on Commit ${{ env.COMMIT }}"
+        docker build . \
+        --file files/tests/pre-merge/debian-cabal-l.containerfile \
+        --compress \
+        --build-arg BRANCH=${{ env.BRANCH }} \
+        --build-arg COMMIT=${{ env.COMMIT }} \
+        --build-arg G_ACCOUNT=${{ env.G_ACCOUNT }} \
+        --tag ${{ env.REGISTRY }}/${{ env.G_ACCOUNT }}/pre-merge-debian:cabal-l_${{ env.COMMIT }}
+    - name: Add summary details
+      if: always()
+      run: |
+        echo "## Summary Details" >> $GITHUB_STEP_SUMMARY
+        echo "* Docker Image: ${{ env.REGISTRY }}/${{ secrets.DOCKER_USER }}/cardano-node:$${{ env.COMMIT }}" >> $GITHUB_STEP_SUMMARY
+        echo "* BRANCH: ${{ env.BRANCH }}" >> $GITHUB_STEP_SUMMARY
+        echo "* G_ACCOUNT: ${GITHUB_REPOSITORY_OWNER}" >> $GITHUB_STEP_SUMMARY
+        echo "* COMMIT: ${{ env.COMMIT }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/premerge_rockylinux.yml
+++ b/.github/workflows/premerge_rockylinux.yml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   guild-deploy-and-build-rockylinux:
+    env:
+      REGISTRY: ghcr.io
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
@@ -34,44 +36,39 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - uses: actions/checkout@v2
-    - name: Extract branch from PR
-      shell: bash
+    - uses: actions/checkout@v3
+    - name: Define BRANCH, COMMIT and G_ACCOUNT in environment
       run: |
-        echo "##[set-output name=branch;]${GITHUB_HEAD_REF}"
-        echo "##[set-output name=owner;]${GITHUB_REPOSITORY_OWNER}"
-      id: pr_branch
-    #- name: Testing guild-deploy.sh (system libsodium)
-    #  run: |
-    #    export BRANCH=${{ steps.pr_branch.outputs.branch }}
-    #    export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-    #    export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-    #    docker build . --file files/tests/pre-merge/rockylinux-guild-deploy.sh.containerfile --compress --build-arg BRANCH --build-arg COMMIT --build-arg G_ACCOUNT --tag ghcr.io/cardano-community/pre-merge-rockylinux:guild-deploy_${COMMIT}
-    #- name: Push pre-merge-rockylinux:guild-deploy_${COMMIT}
-    #  run: |
-    #    export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-    #    docker push ghcr.io/cardano-community/pre-merge-rockylinux:guild-deploy_${COMMIT}
-    #- name: Testing cabal-build-all.sh (system libsodium)
-    #  run: |
-    #    export BRANCH=${{ steps.pr_branch.outputs.branch }}
-    #    export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-    #    export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-    #    echo "Working from PR Branch ${G_ACCOUNT}/guild-operators/${BRANCH} on Commit ${COMMIT}"
-    #    docker build . --file files/tests/pre-merge/rockylinux-cabal.containerfile --compress --build-arg BRANCH --build-arg COMMIT --tag ghcr.io/cardano-community/pre-merge-rockylinux:cabal_${COMMIT}
+        echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+        echo "G_ACCOUNT=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
+        echo "COMMIT=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
     - name: Testing guild-deploy.sh (IO fork of libsodium)
       run: |
-        export BRANCH=${{ steps.pr_branch.outputs.branch }}
-        export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-        export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-        docker build . --file files/tests/pre-merge/rockylinux-guild-deploy.sh-l.containerfile --compress --build-arg BRANCH --build-arg COMMIT --build-arg G_ACCOUNT --tag ghcr.io/cardano-community/pre-merge-rockylinux:guild-deploy-l_${COMMIT}
-    - name: Push pre-merge-rockylinux:guild-deploy-l_${COMMIT}
+        docker build . \
+          --file files/tests/pre-merge/rockylinux-guild-deploy.sh-l.containerfile \
+          --compress \
+          --build-arg BRANCH=${{ env.BRANCH }} \
+          --build-arg COMMIT=${{ env.COMMIT }} \
+          --build-arg G_ACCOUNT=${{ env.G_ACCOUNT }} \
+          --tag ${{ env.REGISTRY }}/${{ env.G_ACCOUNT }}/pre-merge-rockylinux:guild-deploy-l_${{ env.COMMIT }}
+    - name: Push pre-merge-rockylinux:guild-deploy-l_${{ env.COMMIT }}
       run: |
-        export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-        docker push ghcr.io/cardano-community/pre-merge-rockylinux:guild-deploy-l_${COMMIT}
+        docker push ${{ env.REGISTRY }}/${{ env.G_ACCOUNT }}/pre-merge-rockylinux:guild-deploy-l_${{ env.COMMIT }}
     - name: Testing cabal-build-all.sh (IO fork of libsodium)
       run: |
-        export BRANCH=${{ steps.pr_branch.outputs.branch }}
-        export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-        export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-        echo "Working from PR Branch ${G_ACCOUNT}/guild-operators/${BRANCH} on Commit ${COMMIT}"
-        docker build . --file files/tests/pre-merge/rockylinux-cabal-l.containerfile --compress --build-arg BRANCH --build-arg COMMIT --tag ghcr.io/cardano-community/pre-merge-rockylinux:cabal-l_${COMMIT}
+        echo "Working from PR Branch ${{ env.G_ACCOUNT }}/guild-operators/${{ env.BRANCH }} on Commit ${{ env.COMMIT }}"
+        docker build . \
+          --file files/tests/pre-merge/rockylinux-cabal-l.containerfile \
+          --compress \
+          --build-arg BRANCH=${{ env.BRANCH }} \
+          --build-arg COMMIT=${{ env.COMMIT }} \
+          --build-arg G_ACCOUNT=${{ env.G_ACCOUNT }} \
+          --tag ${{ env.REGISTRY }}/${{ env.G_ACCOUNT }}/pre-merge-rockylinux:cabal-l_${{ env.COMMIT }}
+    - name: Add summary details
+      if: always()
+      run: |
+        echo "## Summary Details" >> $GITHUB_STEP_SUMMARY
+        echo "* Docker Image: ${{ env.REGISTRY }}/${{ secrets.DOCKER_USER }}/cardano-node:$CNVERSION" >> $GITHUB_STEP_SUMMARY
+        echo "* BRANCH: ${{ env.BRANCH }}" >> $GITHUB_STEP_SUMMARY
+        echo "* G_ACCOUNT: ${GITHUB_REPOSITORY_OWNER}" >> $GITHUB_STEP_SUMMARY
+        echo "* COMMIT: ${{ env.COMMIT }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/premerge_ubuntu.yml
+++ b/.github/workflows/premerge_ubuntu.yml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   guild-deploy-and-build-ubuntu:
+    env:
+      REGISTRY: ghcr.io
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
@@ -34,44 +36,32 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - uses: actions/checkout@v2
-    - name: Extract branch from PR
-      shell: bash
+    - uses: actions/checkout@v3
+    - name: Define BRANCH, COMMIT and G_ACCOUNT in environment
       run: |
-        echo "##[set-output name=branch;]${GITHUB_HEAD_REF}"
-        echo "##[set-output name=owner;]${GITHUB_REPOSITORY_OWNER}"
-      id: pr_branch
-    #- name: Testing guild-deploy.sh (system libsodium)
-    #  run: |
-    #    export BRANCH=${{ steps.pr_branch.outputs.branch }}
-    #    export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-    #    export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-    #    docker build . --file files/tests/pre-merge/ubuntu-guild-deploy.sh.containerfile --compress --build-arg BRANCH --build-arg COMMIT --build-arg G_ACCOUNT --tag ghcr.io/cardano-community/pre-merge-ubuntu:guild-deploy_${COMMIT}
-    #- name: Push pre-merge-ubuntu:guild-deploy_${COMMIT}
-    #  run: |
-    #    export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-    #    docker push ghcr.io/cardano-community/pre-merge-ubuntu:guild-deploy_${COMMIT}
-    #- name: Testing cabal-build-all.sh (system libsodium)
-    #  run: |
-    #    export BRANCH=${{ steps.pr_branch.outputs.branch }}
-    #    export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-    #    export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-    #    echo "Working from PR Branch ${G_ACCOUNT}/guild-operators/${BRANCH} on Commit ${COMMIT}"
-    #    docker build . --file files/tests/pre-merge/ubuntu-cabal.containerfile --compress --build-arg BRANCH --build-arg COMMIT --tag ghcr.io/cardano-community/pre-merge-ubuntu:cabal_${COMMIT}
+        echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+        echo "G_ACCOUNT=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
+        echo "COMMIT=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
     - name: Testing guild-deploy.sh (IO fork of libsodium)
       run: |
-        export BRANCH=${{ steps.pr_branch.outputs.branch }}
-        export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-        export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-        docker build . --file files/tests/pre-merge/ubuntu-guild-deploy.sh-l.containerfile --compress --build-arg BRANCH --build-arg COMMIT --build-arg G_ACCOUNT --tag ghcr.io/cardano-community/pre-merge-ubuntu:guild-deploy-l_${COMMIT}
-    - name: Push pre-merge-ubuntu:guild-deploy-l_${COMMIT}
+        docker build . \
+          --file files/tests/pre-merge/ubuntu-guild-deploy.sh-l.containerfile \
+          --compress \
+          --build-arg BRANCH=${{ env.BRANCH }} \
+          --build-arg COMMIT=${{ env.COMMIT }} \
+          --build-arg G_ACCOUNT=${{ env.G_ACCOUNT }} \
+          --tag ${{ env.REGISTRY }}/${{ env.G_ACCOUNT }}/pre-merge-ubuntu:guild-deploy-l_${{ env.COMMIT }}
+    - name: Push pre-merge-ubuntu:guild-deploy-l_${{ env.COMMIT }}
       run: |
         export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-        docker push ghcr.io/cardano-community/pre-merge-ubuntu:guild-deploy-l_${COMMIT}
+        docker push ${{ env.REGISTRY }}/${{ env.G_ACCOUNT }}/pre-merge-ubuntu:guild-deploy-l_${{ env.COMMIT }}
     - name: Testing cabal-build-all.sh (IO fork of libsodium)
       run: |
-        export BRANCH=${{ steps.pr_branch.outputs.branch }}
-        export G_ACCOUNT=${{ steps.pr_branch.outputs.owner }}
-        export COMMIT=$(git rev-parse --short "$GITHUB_SHA")
-        echo "Working from PR Branch ${G_ACCOUNT}/guild-operators/${BRANCH} on Commit ${COMMIT}"
-        docker build . --file files/tests/pre-merge/ubuntu-cabal-l.containerfile --compress --build-arg BRANCH --build-arg COMMIT --tag ghcr.io/cardano-community/pre-merge-ubuntu:cabal-l_${COMMIT}
+        echo "Working from PR Branch ${{ env.G_ACCOUNT }}/guild-operators/${{ env.BRANCH }} on Commit ${{ env.COMMIT }}"
+        docker build . \
+          --file files/tests/pre-merge/ubuntu-cabal-l.containerfile \
+          --compress \
+          --build-arg BRANCH=${{ env.BRANCH }} \
+          --build-arg COMMIT=${{ env.COMMIT }} \
+          --build-arg G_ACCOUNT=${{ env.G_ACCOUNT }} \
+          --tag ${{ env.REGISTRY }}/${{ env.G_ACCOUNT }}/pre-merge-ubuntu:cabal-l_${{ env.COMMIT }}

--- a/files/docker/node/dockerfile_bin
+++ b/files/docker/node/dockerfile_bin
@@ -2,6 +2,7 @@ FROM debian:stable-slim
 
 LABEL desc="Cardano Node by Guild's Operators"
 ARG DEBIAN_FRONTEND=noninteractive
+ARG G_ACCOUNT
 
 USER root
 WORKDIR /
@@ -19,7 +20,7 @@ ENV \
 RUN set -x && apt update \
     && mkdir -p /root/.local/bin \
     && apt install -y curl wget gnupg apt-utils git udev \
-    && wget https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/guild-deploy.sh \
+    && wget https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/master/scripts/cnode-helper-scripts/guild-deploy.sh \
     && export SUDO='N' \
     && export UPDATE_CHECK='N' \
     && export SKIP_DBSYNC_DOWNLOAD='Y' \
@@ -45,7 +46,7 @@ USER guild
 WORKDIR /home/guild
 
 # Commit Version
-RUN  curl -sL -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/cardano-community/guild-operators/commits | grep -v md | grep -A 2 guild-deploy.sh | grep sha | head -n 1 | cut -d "\"" -f 4 > ~/guild-latest.txt \
+RUN  curl -sL -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${G_ACCOUNT}/guild-operators/commits | grep -v md | grep -A 2 guild-deploy.sh | grep sha | head -n 1 | cut -d "\"" -f 4 > ~/guild-latest.txt \
     && echo "head -n 8 /home/guild/.scripts/banner.txt" >> ~/.bashrc \
     && echo "grep MENU -A 6 /home/guild/.scripts/banner.txt | grep -v MENU" >> ~/.bashrc \
     && echo "alias env=/usr/bin/env" >> ~/.bashrc \
@@ -55,12 +56,12 @@ RUN  curl -sL -H "Accept: application/vnd.github.everest-preview+json" -H "Conte
 
 
 # ENTRY SCRIPT
-ADD https://raw.githubusercontent.com/cardano-community/guild-operators/master/files/docker/node/addons/banner.txt /home/guild/.scripts/
-ADD https://raw.githubusercontent.com/cardano-community/guild-operators/master/files/docker/node/addons/guild-topology.sh /home/guild/.scripts/
-ADD https://raw.githubusercontent.com/cardano-community/guild-operators/master/files/docker/node/addons/block_watcher.sh /home/guild/.scripts/
-ADD https://raw.githubusercontent.com/cardano-community/guild-operators/master/files/docker/node/addons/healthcheck.sh /home/guild/.scripts/
-ADD https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/guild-deploy.sh /opt/cardano/cnode/scripts/
-ADD https://raw.githubusercontent.com/cardano-community/guild-operators/master/files/docker/node/addons/entrypoint.sh ./
+ADD https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/master/files/docker/node/addons/banner.txt /home/guild/.scripts/
+ADD https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/master/files/docker/node/addons/guild-topology.sh /home/guild/.scripts/
+ADD https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/master/files/docker/node/addons/block_watcher.sh /home/guild/.scripts/
+ADD https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/master/files/docker/node/addons/healthcheck.sh /home/guild/.scripts/
+ADD https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/master/scripts/cnode-helper-scripts/guild-deploy.sh /opt/cardano/cnode/scripts/
+ADD https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/master/files/docker/node/addons/entrypoint.sh ./
 
 RUN sudo chown -R guild:guild $CNODE_HOME/* \
     && mkdir /home/guild/.local/ \
@@ -71,3 +72,4 @@ RUN sudo chown -R guild:guild $CNODE_HOME/* \
 HEALTHCHECK --start-period=5m --interval=5m --timeout=100s CMD /home/guild/.scripts/healthcheck.sh
 
 ENTRYPOINT ["./entrypoint.sh"]
+

--- a/files/docker/node/dockerfile_stage1
+++ b/files/docker/node/dockerfile_stage1
@@ -1,5 +1,7 @@
 FROM debian
 
+ARG G_ACCOUNT
+
 ENV \
 DEBIAN_FRONTEND=noninteractive \
 LANG=C.UTF-8 \
@@ -11,7 +13,7 @@ WORKDIR /
 RUN set -x && apt update \
   && mkdir -p /root/.local/bin && mkdir -p /root/.ghcup/bin \
   && apt install -y curl wget gnupg apt-utils git udev \
-  && wget https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/guild-deploy.sh \
+  && wget https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/master/scripts/cnode-helper-scripts/guild-deploy.sh \
   && export SUDO='N' \
   && export UPDATE_CHECK='N' \
   && export BOOTSTRAP_HASKELL_NO_UPGRADE=1 \

--- a/files/docker/node/dockerfile_stage2
+++ b/files/docker/node/dockerfile_stage2
@@ -1,5 +1,7 @@
 FROM cardanocommunity/cardano-node:stage1
 
+ARG G_ACCOUNT
+
 ENV \
   CNODE_HOME=/opt/cardano/cnode \
   DEBIAN_FRONTEND=noninteractive \ 
@@ -10,7 +12,7 @@ ENV \
 RUN git clone https://github.com/input-output-hk/cardano-node.git \
   && export BOOTSTRAP_HASKELL_NO_UPGRADE=1 \
   && mkdir -p /root/.local/bin/ \
-  && wget https://raw.githubusercontent.com/cardano-community/guild-operators/master/files/docker/node/release-versions/cardano-node-latest.txt \
+  && wget https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/master/files/docker/node/release-versions/cardano-node-latest.txt \
   && CNVERSION=$(cat cardano-node-latest.txt) \
   && cd cardano-node \
   && git fetch --tags --all && git checkout tags/$CNVERSION \

--- a/files/docker/node/dockerfile_stage3
+++ b/files/docker/node/dockerfile_stage3
@@ -2,6 +2,7 @@ FROM debian:stable-slim
 
 LABEL desc="Cardano Node by Guild's Operators"
 ARG DEBIAN_FRONTEND=noninteractive
+ARG G_ACCOUNT
 
 USER root
 WORKDIR /
@@ -52,7 +53,7 @@ USER guild
 WORKDIR /home/guild
 
 # Commit Version 
-RUN  curl -sL -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/cardano-community/guild-operators/commits | grep -v md | grep -A 2 guild-deploy.sh | grep sha | head -n 1 | cut -d "\"" -f 4 > ~/guild-latest.txt
+RUN  curl -sL -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${G_ACCOUNT}/guild-operators/commits | grep -v md | grep -A 2 guild-deploy.sh | grep sha | head -n 1 | cut -d "\"" -f 4 > ~/guild-latest.txt
 
 RUN echo "head -n 8 /home/guild/.scripts/banner.txt" >> ~/.bashrc \
     && echo "grep MENU -A 6 /home/guild/.scripts/banner.txt | grep -v MENU" >> ~/.bashrc \
@@ -62,12 +63,12 @@ RUN echo "head -n 8 /home/guild/.scripts/banner.txt" >> ~/.bashrc \
     && echo "export PATH=/opt/cardano/cnode/scripts:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/home/guild/.local/bin"  >> ~/.bashrc
 
 # ENTRY SCRIPT
-ADD https://raw.githubusercontent.com/cardano-community/guild-operators/master/files/docker/node/addons/banner.txt /home/guild/.scripts/
-ADD https://raw.githubusercontent.com/cardano-community/guild-operators/master/files/docker/node/addons/guild-topology.sh /home/guild/.scripts/
-ADD https://raw.githubusercontent.com/cardano-community/guild-operators/master/files/docker/node/addons/block_watcher.sh /home/guild/.scripts/
-ADD https://raw.githubusercontent.com/cardano-community/guild-operators/master/files/docker/node/addons/healthcheck.sh /home/guild/.scripts/
-ADD https://raw.githubusercontent.com/cardano-community/guild-operators/master/scripts/cnode-helper-scripts/guild-deploy.sh /opt/cardano/cnode/scripts/
-ADD https://raw.githubusercontent.com/cardano-community/guild-operators/master/files/docker/node/addons/entrypoint.sh ./
+ADD https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/master/files/docker/node/addons/banner.txt /home/guild/.scripts/
+ADD https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/master/files/docker/node/addons/guild-topology.sh /home/guild/.scripts/
+ADD https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/master/files/docker/node/addons/block_watcher.sh /home/guild/.scripts/
+ADD https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/master/files/docker/node/addons/healthcheck.sh /home/guild/.scripts/
+ADD https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/master/scripts/cnode-helper-scripts/guild-deploy.sh /opt/cardano/cnode/scripts/
+ADD https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/master/files/docker/node/addons/entrypoint.sh ./
 
 RUN sudo chown -R guild:guild $CNODE_HOME/* \
     && sudo chown -R guild:guild /home/guild/.* \


### PR DESCRIPTION
* G_ACCOUNT added to remaining workflows and Dockerfiles.
  * Set from GITHUB_REPOSITORY_OWNER
  * Stored in the GITHUB_ENV
* Set env variable REGISTRY
  * ghcr.io for premerge
  * docker.io for docker_bin

Result is premerge testing workflows and docker container build processes natively target origin (the fork) when pulling files instead of upstream (cardano-community). The following secrets are required as part of the forked repository:

* DOCKER_USER
* DOCKER_PASSWORD
* REPO_SCOPED_PASSWORD
* REPO_SCOPED_TOKEN
* REPO_SCOPED_USER