### PR TITLE
Update guild-deploy.sh - libsecp build

### DIFF
--- a/scripts/cnode-helper-scripts/guild-deploy.sh
+++ b/scripts/cnode-helper-scripts/guild-deploy.sh
@@ -277,6 +277,10 @@ build_dependencies() {
   fi
   # Cannot verify the version and availability of libsecp256k1 package built previously, hence have to re-install each time
   echo -e "\n[Re]-Install libsecp256k1 ..."
+  if ! grep -q "/usr/local/lib:\$LD_LIBRARY_PATH" "${HOME}"/.bashrc; then
+    echo -e "\nexport LD_LIBRARY_PATH=/usr/local/lib:\$LD_LIBRARY_PATH" >> "${HOME}"/.bashrc
+    export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+  fi
   mkdir -p "${HOME}"/git > /dev/null 2>&1 # To hold git repositories that will be used for building binaries
   pushd "${HOME}"/git >/dev/null || err_exit
   [[ ! -d "./secp256k1" ]] && git clone https://github.com/bitcoin-core/secp256k1 &>/dev/null
@@ -287,10 +291,6 @@ build_dependencies() {
   make > make.log 2>&1 || err_exit " Could not complete \"make\" for libsecp256k1 package, please try to run it manually to diagnose!"
   make check >>make.log 2>&1
   $sudo make install > install.log 2>&1
-  if ! grep -q "/usr/local/lib:\$LD_LIBRARY_PATH" "${HOME}"/.bashrc; then
-    echo -e "\nexport LD_LIBRARY_PATH=/usr/local/lib:\$LD_LIBRARY_PATH" >> "${HOME}"/.bashrc
-    export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-  fi
 }
 
 # Build fork of libsodium


### PR DESCRIPTION
Moved LD_LIBRARY_PATH check to the front of the libsecp build, so it is applied on first run of the script.
PR from local merged alpha repo.

## Description
Just ran the script on the fresh host. Libsecp was build but put into /usr/lib not /usr/local/lib due to the too late placement of the LD_LIBRARY_PATH check

## Where should the reviewer start?
Libsecp build

## Motivation and context
Sets correct location for libsecp 

## Which issue it fixes?
No issue yet to my knowledge

## How has this been tested?
Master script ran as is, libsecp libs in wrong folder, moved manually. Looked at source code found error. No re-runs of the script as of yet.
