### PR TITLE
minor BP and TU fixes

### DIFF
--- a/docs/Scripts/topologyupdater.md
+++ b/docs/Scripts/topologyupdater.md
@@ -33,8 +33,8 @@ Out of the box, the scripts might come with some assumptions, that may or may no
 CNODE_HOSTNAME="CHANGE ME"                                # (Optional) Must resolve to the IP you are requesting from
 CNODE_VALENCY=1                                           # (Optional) for multi-IP hostnames
 MAX_PEERS=15                                              # Maximum number of peers to return on successful fetch
-#CUSTOM_PEERS="None"                                      # Additional custom peers to (IP:port[:valency]) to add to your target topology.json
-                                                          # eg: "10.0.0.1:3001|10.0.0.2:3002|relays.mydomain.com:3003:3"
+#CUSTOM_PEERS="None"                                      # Additional custom peers to (IP,port[,valency]) to add to your target topology.json
+                                                          # eg: "10.0.0.1,3001|10.0.0.2,3002|relays.mydomain.com,3003,3"
 #BATCH_AUTO_UPDATE=N                                      # Set to Y to automatically update the script if a new version is available without user interaction
 ```
 
@@ -84,7 +84,7 @@ Note that the change in topology is only effective upon restart of your node. Ma
 Most of the Stake Pool Operators may have few preferences (own relays, close friends, etc) that they would like to add to their topology by default. This is where the `CUSTOM_PEERS` variable in `topologyUpdater.sh` comes in. You can add a list of peers in the format of: `hostname/IP:port[:valency]` here and the output `topology.json` formed will already include the custom peers that you supplied. Every custom peer is defined in the form `[address]:[port]` and optional `:[valency]` (if not specified, the valency defaults to `1`). Multiple custom peers are separated by `|`. An example of a valid `CUSTOM_PEERS` variable would be:
 
 ```bash
-CUSTOM_PEERS="foo.bar.io:3001:2|198.175.21.197:6001|36.233.3.89:6000
+CUSTOM_PEERS="foo.bar.io,3001,2|198.175.21.197,6001|36.233.3.89,6000
 ```
 The list above would add three custom peers with the specified addresses and ports, with the first one additionally specifying the optional valency parameter (in this case `2`).
 

--- a/files/topology-mainnet.json
+++ b/files/topology-mainnet.json
@@ -2,11 +2,12 @@
   "localRoots": [
     {
       "accessPoints": [
-        {"address": "127.0.0.1", "port": 6000, "valency": 1, "pool": "BP"},
-        {"address": "127.0.0.1", "port": 6001, "valency": 1, "pool": "relay"}
+        {"address": "127.0.0.1", "port": 6000, "description": "BP"},
+        {"address": "127.0.0.1", "port": 6001, "description": "relay"}
       ],
       "advertise": false,
-      "valency": 1
+	  "valency_INFO": "set the .localRoots.valency to the number of configured accessPoints",
+      "valency": 2
     }
   ],
   "publicRoots": [
@@ -31,5 +32,6 @@
       "advertise": false
     }
   ],
+  "useLedgerAfterSlot_INFO": "the node will use the .publicRoots.accessPoints only until he synchronised up to slot .useLedgerAfterSlot. then P2P peering jumps in, plus static links to .localRoots.accessPoints",
   "useLedgerAfterSlot": 95212750
 }

--- a/scripts/cnode-helper-scripts/blockPerf.sh
+++ b/scripts/cnode-helper-scripts/blockPerf.sh
@@ -22,7 +22,7 @@
 # Do NOT modify code below           #
 ######################################
 
-BP_VERSION=v1.3.8
+BP_VERSION=v1.3.9
 
 SKIP_UPDATE=N
 [[ $1 = "-u" ]] && SKIP_UPDATE=Y && shift
@@ -303,7 +303,7 @@ reportBlock() {
       #Debug: look into when and why this happens
       #echo -e "blockheight:${iblockHeight} (negative delta) \n  bhash:${blockHash}\n  tbh:${blockTimeTbh} ${deltaSlotTbh}\n  sfr:${blockTimeSfrX} ${deltaTbhSfr}\n  cbf:${blockTimeCbf} ${deltaSfrCbf}\n  ab:${blockTimeAb} ${deltaCbfAb} \n blockTimeCbfAddr: $blockTimeCbfAddr \n blockTimeCbfPort: $blockTimeCbfPort \n sbx: $sbx \n line_tsv: $line_tsv \n \n blockLogLine: \n${blockLogLine} \n\n ${blockLog}" > zzz_debug_WARN_block_${iblockHeight}.json
     else
-      if [[ "${deltaSlotTbh}" -lt 10000 ]] && [[ "$((blockSlot-slotHeightPrev))" -lt 200 ]]; then
+      if [[ "${deltaSlotTbh}" -lt 60000 ]] && [[ "$((blockSlot-slotHeightPrev))" -lt 200 ]]; then
         [[ ${SELFISH_MODE} != "Y" ]] && result=$(curl -4 -s "https://api.clio.one/blocklog/v1/?magic=${NWMAGIC}&bpv=${BP_VERSION}&nport=${CNODE_PORT}&bn=${iblockHeight}&slot=${blockSlot}&tbh=${deltaSlotTbh}&tbhAddr=${blockTimeTbhAddrPublic}&tbhPort=${blockTimeTbhPortPublic}&sfr=${deltaTbhSfr}&cbf=${deltaSfrCbf}&ab=${deltaCbfAb}&g=${blockTimeG}&size=${blockSize}&addr=${blockTimeCbfAddrPublic}&port=${blockTimeCbfPortPublic}&bh=${blockHash}&bpenv=${envBP}" &)
         [[ ${SERVICE_MODE} != "Y" ]] && echo -e "${FG_YELLOW}Block:.... ${iblockHeight} ( ${blockHash:0:10} ...)\n${NC} Slot..... ${blockSlot} ($((blockSlot-slotHeightPrev))s)\n ......... ${blockSlotTime}\n Header... ${blockTimeTbh} (+${deltaSlotTbh} ms) from ${blockTimeTbhAddr}:${blockTimeTbhPort}\n RequestX. ${blockTimeSfrX} (+${deltaTbhSfr} ms)\n Block.... ${blockTimeCbf} (+${deltaSfrCbf} ms) from ${blockTimeCbfAddr}:${blockTimeCbfPort}\n Adopted.. ${blockTimeAb} (+${deltaCbfAb} ms)\n Size..... ${blockSize} bytes\n delay.... ${blockDelay} sec"
       else
@@ -415,7 +415,7 @@ do
         blockLog=$(grep -h -E ${blockHash:0:10} ${logfile/.json/-*} ${logfile} | grep -E 'TraceDownloadedHeader|SendFetchRequest|CompletedBlockFetch|AddedToCurrentChain|SwitchedToAFork' )
         fi
       iblockHeight=$(grep -m 1 ${blockHash} ${logfile})
-      iblockHeight=$(jq -r .data.blockNo.unBlockNo <<< "${iblockHeight}")
+      iblockHeight=$(jq -r .data.blockNo <<< "${iblockHeight}")
       #echo "b:${iblockHeight}	s:${slotNum}" >> forks.log
       reportBlock ${blockLog};
     else


### PR DESCRIPTION
BlockPerf 1.3.9:
- fork rollback handling for v8 logfiles
- increased max block delay 10 -> 60sec

TopologyUpdater
Doco CUSTOM_PEERS format (affects description only, code had the new format for years already)

P2P Topology template file
- removed localRoots.accesspoints valency and added optional description field
- added valency and useLedgerAfterSlot INFO descriptions


