### PR TITLE
Add consumed-by-utxo flag

### DIFF
--- a/docs/Build/node-cli.md
+++ b/docs/Build/node-cli.md
@@ -41,10 +41,10 @@ Execute `cardano-cli` and `cardano-node` to verify output as below (the exact ve
 
 ```bash
 cardano-cli version
-# cardano-cli 8.1.1 - linux-x86_64 - ghc-8.10
+# cardano-cli 8.1.2 - linux-x86_64 - ghc-8.10
 # git rev <...>
 cardano-node version
-# cardano-node 8.1.1 - linux-x86_64 - ghc-8.10
+# cardano-node 8.1.2 - linux-x86_64 - ghc-8.10
 # git rev <...>
 ```
 

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -981,8 +981,8 @@ if [[ -n "${CNODE_PID}" ]]; then
 fi
 
 node_version="$(${CCLI} version | head -1 | cut -d' ' -f2)"
-if ! versionCheck "8.1.1" "${node_version}"; then
-  echo -e "\nKoios scripts has now been upgraded to support cardano-node 8.1.1 or higher (${node_version} found).\nPlease update cardano-node (note that you should ideally update your config too) or use tagged branches for older node version.\n\n"
+if ! versionCheck "8.1.2" "${node_version}"; then
+  echo -e "\nKoios scripts has now been upgraded to support cardano-node 8.1.2 or higher (${node_version} found).\nPlease update cardano-node (note that you should ideally update your config too) or use tagged branches for older node version.\n\n"
   return 1
 fi
 

--- a/scripts/cnode-helper-scripts/guild-deploy.sh
+++ b/scripts/cnode-helper-scripts/guild-deploy.sh
@@ -322,7 +322,7 @@ download_cnodebins() {
   pushd "${HOME}"/tmp >/dev/null || err_exit
   echo -e "\n  Downloading Cardano Node archive created from IO CI builds.."
   rm -f cardano-node cardano-address
-  curl -m 200 -sfL https://github.com/input-output-hk/cardano-node/releases/download/8.1.1/cardano-node-8.1.1-linux.tar.gz -o cnode.tar.gz || err_exit " Could not download cardano-node's latest release archive from IO CI builds at update-cardano-mainnet.iohk.io!"
+  curl -m 200 -sfL https://github.com/input-output-hk/cardano-node/releases/download/8.1.2/cardano-node-8.1.2-linux.tar.gz -o cnode.tar.gz || err_exit " Could not download cardano-node's latest release archive from IO CI builds at update-cardano-mainnet.iohk.io!"
   tar zxf cnode.tar.gz ./cardano-node ./cardano-cli ./cardano-submit-api ./bech32 &>/dev/null
   rm -f cnode.tar.gz
   [[ -f cardano-node ]] || err_exit " cardano-node archive downloaded but binary (cardano-node) not found after extracting package!"


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
If DBSync version is >= 13.1.1.3, no harm in setting this flag by default, it only adds value and simplifies joins

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
Various performance improvements for used vs unused tx_out consumptions