### PR TITLE
Container Shutdown with SIGINT

### DIFF
--- a/files/docker/node/addons/entrypoint.sh
+++ b/files/docker/node/addons/entrypoint.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-trap 'killall -s SIGINT cardano-node' SIGINT SIGTERM
-# "docker run --init" to enable the docker init proxy
-# To manually test: docker kill -s SIGTERM container
-
 head -n 8 ~/.scripts/banner.txt
 
 . ~/.bashrc > /dev/null 2>&1

--- a/files/docker/node/dockerfile_bin
+++ b/files/docker/node/dockerfile_bin
@@ -1,5 +1,8 @@
 FROM debian:stable-slim
 
+# DEFINE THE PREFERRED STOP SIGNAL
+STOPSIGNAL SIGINT
+
 LABEL desc="Cardano Node by Guild's Operators"
 ARG DEBIAN_FRONTEND=noninteractive
 ARG G_ACCOUNT

--- a/scripts/cnode-helper-scripts/cnode.sh
+++ b/scripts/cnode-helper-scripts/cnode.sh
@@ -133,7 +133,7 @@ pre_startup_sanity
 
 # Run Node
 if [[ -f "${POOL_DIR}/${POOL_OPCERT_FILENAME}" && -f "${POOL_DIR}/${POOL_VRF_SK_FILENAME}" && -f "${POOL_DIR}/${POOL_HOTKEY_SK_FILENAME}" ]]; then
-  "${CNODEBIN}" "${CPU_RUNTIME[@]}" run \
+  exec "${CNODEBIN}" "${CPU_RUNTIME[@]}" run \
     --topology "${TOPOLOGY}" \
     --config "${CONFIG}" \
     --database-path "${DB_DIR}" \
@@ -144,7 +144,7 @@ if [[ -f "${POOL_DIR}/${POOL_OPCERT_FILENAME}" && -f "${POOL_DIR}/${POOL_VRF_SK_
     --port ${CNODE_PORT} \
     ${MEMPOOL_OVERRIDE} "${host_addr[@]}"
 else
-  "${CNODEBIN}" "${CPU_RUNTIME[@]}" run \
+  exec "${CNODEBIN}" "${CPU_RUNTIME[@]}" run \
     --topology "${TOPOLOGY}" \
     --config "${CONFIG}" \
     --database-path "${DB_DIR}" \


### PR DESCRIPTION
The change this branch makes is to:
1. Define `STOPSIGNAL` as **SIGINT** in the dockerfile_bin used to build the container.
2. Remove the trap from `entrypoint.sh` because it uses `exec` and is no longer running inside the container to catch any signals.
3. Add **exec** to `cnode.sh` for command `$CNODEBIN` so that cnode.sh is not running, but relinquishes control to cardano-node.

This results in the container process having cardano-node as PID 1 and the runtime engine will default to sending a SIGINT signal to PID1. 
```
guild@b2a142633c12:~$ ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
guild          1  4.4  3.0 1073794660 1907756 ?  Ssl  03:05  44:14 /home/guild/.local/bin/cardano-node run --topology /opt/cardano/cnode/files/topology.json --config /opt/cardano/cnode/files/config.json --
guild    1846631  0.0  0.0   7196  3872 pts/0    Ss   19:38   0:00 bash
guild    1846637  0.0  0.0  11084  4456 pts/0    R+   19:38   0:00 ps aux
```

This should also result in the systemd setup having the `Main PID` of the `cardano-node` process itself, instead of `cnode.sh` as the Main PID of the service. From inside the container the `cnode.sh -s` shutdown logic still worked as intended. 

I believe since the service unit has KillSignal defined as SIGINT, that if cnode.sh uses exec the service unit could have the **ExecStop** removed. When cardano-node is the Main PID it will receive the SIGINT instead of `cnode.sh`. I believe this was the reason for an explicit **ExecStop** after defining the signal.

Closes #1670