### PR TITLE
Fix startupLogMonitor systemd and remove duplicate service definition

### DIFF
--- a/scripts/cnode-helper-scripts/deploy-as-systemd.sh
+++ b/scripts/cnode-helper-scripts/deploy-as-systemd.sh
@@ -408,32 +408,7 @@ echo
 echo "Deploy Startup Log Monitor as systemd services? [y|n]"
 read -rsn1 yn
 if [[ ${yn} = [Yy]* ]]; then
-  ##############################################./blockPerf.sh -d
-  sudo bash -c "cat << 'EOF' > /etc/systemd/system/${vname}-startup-logmonitor.service
-[Unit]
-Description=Cardano Node - Startup Log Monitor
-BindsTo=${vname}.service
-Before=${vname}.service
-
-[Service]
-Type=simple
-Restart=on-failure
-RestartSec=20
-User=$USER
-WorkingDirectory=${CNODE_HOME}/scripts
-ExecStart=/bin/bash -l -c \"exec ${CNODE_HOME}/scripts/startupLogMonitor.sh\"
-ExecStop=/bin/bash -l -c \"exec kill -2 \$(ps -ef | grep -m1 ${CNODE_HOME}/scripts/startupLogMonitor.sh | tr -s ' ' | cut -d ' ' -f2) &>/dev/null\"
-KillSignal=SIGINT
-SuccessExitStatus=143
-StandardOutput=syslog
-StandardError=syslog
-SyslogIdentifier=${vname}-startup-logmonitor
-TimeoutStopSec=5
-KillMode=mixed
-
-[Install]
-WantedBy=${vname}.service
-EOF"
+  ./startupLogMonitor.sh -d
 else
   if [[ -f /etc/systemd/system/${vname}-startup-logmonitor.service ]]; then
     sudo systemctl disable ${vname}-startup-logmonitor.service


### PR DESCRIPTION
## Description
<!--- Describe your changes -->

In it's current state, startupLogMonitor was preventing node startup if not running - due to dependency created on cnode itself (there does not need to be a dependency with node - as the script itself is primarily only reading log files). Additionally, the service definition was duplicated in deploy-as-systemd.sh as well as the original script, modify the script to 'call' the existing script instead.