### PR TITLE
Move script backups to archive subfolder

### DIFF
--- a/scripts/cnode-helper-scripts/cabal-build-all.sh
+++ b/scripts/cnode-helper-scripts/cabal-build-all.sh
@@ -30,7 +30,7 @@ else
   CUSTOM_CABAL="N"
 fi
 
-[[ -f cabal.project.local ]] && mv cabal.project.local cabal.project.local.bkp_"$(date +%s)"
+[[ -f cabal.project.local ]] && mv cabal.project.local cabal.project.local_bkp"$(date +%s)"
 cat <<-EOF > .tmp.cabal.project.local
 	${USE_SYSTEM_LIBSODIUM}
 	

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -200,7 +200,8 @@ checkUpdate() {
         if [[ $3 != Y ]] && grep -q "# Do NOT modify" "${dname}/${fname}"; then
           printf '%s\n%s\n' "${NEW_STATIC}" "${GIT_TEMPL}" > "${dname}/${fname}".tmp
         fi
-        cp "${dname}/${fname}" "${dname}/${fname}_bkp$(date +%s)"
+        [[ ! -d "${dname}"/archive ]] && mkdir "${dname}"/archive
+        cp "${dname}/${fname}" "${dname}/archive/${fname}_bkp$(date +%s)"
         mv -f "${dname}/${fname}".tmp "${dname}/${fname}"
         [[ ! "${fname}" == "env" ]] && chmod +x "${dname}/${fname}"
         echo -e "\n${FG_YELLOW}${fname}${NC} update successfully applied!"

--- a/scripts/cnode-helper-scripts/guild-deploy.sh
+++ b/scripts/cnode-helper-scripts/guild-deploy.sh
@@ -176,7 +176,8 @@ updateWithCustomConfig() {
       return
     fi
   fi
-  [[ -f ${file} ]] && cp -f ${file} "${file}_bkp$(date +%s)"
+  [[ ! -d ./archive ]] && mkdir archive
+  [[ -f ${file} ]] && cp -f ${file} ./archive/"${file}_bkp$(date +%s)"
   mv -f ${file}.tmp ${file}
   [[ "${file}" == *.sh ]] && chmod 755 ${file}
 }
@@ -492,7 +493,7 @@ setup_folder() {
     echo -e "\nexport ${CNODE_VNAME}_HOME=${CNODE_HOME}" >> "${HOME}"/.bashrc
   fi
   
-  $sudo mkdir -p "${CNODE_HOME}"/files "${CNODE_HOME}"/db "${CNODE_HOME}"/guild-db "${CNODE_HOME}"/logs "${CNODE_HOME}"/scripts "${CNODE_HOME}"/sockets "${CNODE_HOME}"/priv
+  $sudo mkdir -p "${CNODE_HOME}"/files "${CNODE_HOME}"/db "${CNODE_HOME}"/guild-db "${CNODE_HOME}"/logs "${CNODE_HOME}"/scripts "${CNODE_HOME}"/scripts/archive "${CNODE_HOME}"/sockets "${CNODE_HOME}"/priv
   $sudo chown -R "$U_ID":"$G_ID" "${CNODE_HOME}" 2>/dev/null
 }
 

--- a/scripts/grest-helper-scripts/setup-grest.sh
+++ b/scripts/grest-helper-scripts/setup-grest.sh
@@ -388,7 +388,7 @@ SGVERSION=1.0.10
     # Create PostgREST config template
     printf "\n[Re]Deploying Configs.."
     sudo chmod 755 "${CNODE_HOME}" "${CNODE_HOME}"/priv
-    [[ -f "${CNODE_HOME}"/priv/grest.conf ]] && sudo mv "${CNODE_HOME}"/priv/grest.conf "${CNODE_HOME}"/priv/grest.conf.bkp_$(date +%s)
+    [[ -f "${CNODE_HOME}"/priv/grest.conf ]] && sudo mv "${CNODE_HOME}"/priv/grest.conf "${CNODE_HOME}"/priv/grest.conf_bkp$(date +%s)
     cat <<-EOF > "${CNODE_HOME}"/priv/grest.conf
 			db-uri = "postgres://authenticator@/${PGDATABASE}"
 			db-schema = "grest"
@@ -403,7 +403,7 @@ SGVERSION=1.0.10
     sudo chmod 640 "${CNODE_HOME}"/priv/grest.conf
     sudo chown authenticator:${USER} "${CNODE_HOME}"/priv/grest.conf
     # Create HAProxy config template
-    [[ -f "${HAPROXY_CFG}" ]] && cp "${HAPROXY_CFG}" "${HAPROXY_CFG}".bkp_$(date +%s)
+    [[ -f "${HAPROXY_CFG}" ]] && cp "${HAPROXY_CFG}" "${HAPROXY_CFG}"_bkp$(date +%s)
 
     bash -c "cat <<-EOF > ${HAPROXY_CFG}
 			global


### PR DESCRIPTION
## Description
<!--- Describe your changes -->
- When scripts go through updates, previous backups are saved with _bkp$(date +%s) suffix in same folder. Instead, we start saving **future** backups to a subfolder called archive. This is only true for scripts (not for configs, which will continue to be saved in same folder). To keep it non-intrusive from user actions point of view, added a check for missing archive folder to create it within update function, instead of having to re-run guild-deploy.sh
- Also, addressed slight inconsistency with setup-grest.sh and cabal-build-all.sh which was saving using `.bkp_$(date +%s)` to keep it consistent with format used at other places.

## Which issue it fixes?
<!--- Link to issue: Closes #issue-number -->
#1632
