### PR TITLE
missing adjustment from Testable workflows for forked repositories (#1646)

### DIFF
--- a/files/tests/pre-merge/debian-cabal-l.containerfile
+++ b/files/tests/pre-merge/debian-cabal-l.containerfile
@@ -1,6 +1,6 @@
 ARG COMMIT
-FROM ghcr.io/cardano-community/pre-merge-debian:guild-deploy-l_${COMMIT}
 ARG G_ACCOUNT
+FROM ghcr.io/${G_ACCOUNT}/pre-merge-debian:guild-deploy-l_${COMMIT}
 ARG BRANCH
 ARG CNODE_HOME=/opt/cardano/cnode
 

--- a/files/tests/pre-merge/rockylinux-cabal-l.containerfile
+++ b/files/tests/pre-merge/rockylinux-cabal-l.containerfile
@@ -1,6 +1,6 @@
 ARG COMMIT
-FROM ghcr.io/cardano-community/pre-merge-rockylinux:guild-deploy-l_${COMMIT}
 ARG G_ACCOUNT
+FROM ghcr.io/${G_ACCOUNT}/pre-merge-rockylinux:guild-deploy-l_${COMMIT}
 ARG BRANCH
 ARG CNODE_HOME=/opt/cardano/cnode
 

--- a/files/tests/pre-merge/ubuntu-cabal-l.containerfile
+++ b/files/tests/pre-merge/ubuntu-cabal-l.containerfile
@@ -1,6 +1,6 @@
 ARG COMMIT
-FROM ghcr.io/cardano-community/pre-merge-ubuntu:guild-deploy-l_${COMMIT}
-ARG G_ACCOUNT
+ARG G_ACCOUNT 
+FROM ghcr.io/${G_ACCOUNT}/pre-merge-ubuntu:guild-deploy-l_${COMMIT}
 ARG BRANCH
 ARG CNODE_HOME=/opt/cardano/cnode
 


### PR DESCRIPTION
## Description
Uses G_ACCOUNT for the FROM of each pre-merge containerfile so that forked repo pr tests pull the container from the G_ACCOUNT instead of upstream.

## Where should the reviewer start?
Review the 3 files. Successful test results available in [Forked repo job](https://github.com/TrevorBenson/guild-operators/actions/runs/6060624479/job/16444988331).

## Motivation and context
* Finish intent of #1646, allowing contributor forks to perform testing.

## Which issue it fixes?
No issue opened as there is no visible issue in the cardano-community repository. Only forks would have an issue.

## How has this been tested?
[Forked Repository Workflow](https://github.com/TrevorBenson/guild-operators/actions/runs/6060624476) which cherry picked this commit to perform a strategy matrix test within the forked repo.
