### PR TITLE
branch as input for premerge workflow

### DIFF
--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -2,6 +2,10 @@ name: Pre-merge
 
 on:
   workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to test'
+        required: true
   pull_request:
     paths:
       - scripts/cnode-helper-scripts/guild-deploy.sh
@@ -16,6 +20,7 @@ jobs:
         distro: [rockylinux, ubuntu]
     env:
       REGISTRY: ghcr.io
+      BRANCH: ${{ github.event.inputs.branch || '' }}
     if: github.event.pull_request.draft == false
     steps:
     - name: Provide additional free space
@@ -42,9 +47,13 @@ jobs:
     - uses: actions/checkout@v3
     - name: Define BRANCH, COMMIT and G_ACCOUNT in environment
       run: |
-        echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
         echo "G_ACCOUNT=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
-        echo "COMMIT=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
+        if [[ -z ${{ env.BRANCH }} ]]; then
+          echo "BRANCH=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+          echo "COMMIT=$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
+        else
+          echo "COMMIT=$(git rev-parse --short ${{ env.BRANCH }})" >> $GITHUB_ENV
+        fi
     - name: Testing guild-deploy.sh (IO fork of libsodium)
       run: |
         docker build . \


### PR DESCRIPTION
## Description
Adding the branch as a workflow input, and then setting it via input when defined allows pre-merge testing without opening a pull request.

## Where should the reviewer start?

### Original Workflow w/o Branch
1. Choose **Pre-merge** workflow under actions
2. Leave the **alpha** or **main** as the branch in the`Use workflow from` dropdown.
3. Click **Run workflow**
4. Observe **BRANCH** is missing and workflow eventially fails.

### Updated Workflow w/ Branch
1. Choose **Pre-merge** workflow under actions
2. Select the **branch-as-workflow-input**  as the branch in the`Use workflow from` dropdown.
3. Click **Run workflow**
4. Observe **BRANCH** is populated and the workflow runs as expected.

## Motivation and context
* Remove the need for opening a PR to test pre-merge workflows.
* Reduce noise to collaborators emails who are monitoring the repository for Pull Requests.
* Simplified Fork testing, commits to `guild-deploy.sh` or `cabal-build-all.sh` are no longer required to test a premerge workflow.


## Which issue it fixes?
None, just feature/improvement.

## How has this been tested?
With a mix of other enhancements (cherry-picked into separate PR's to submit) it was tested on this [forked repo workflow](https://github.com/TrevorBenson/guild-operators/actions/runs/6066270895)