### PR TITLE
Improved-premerge-summaries

### DIFF
--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -54,6 +54,10 @@ jobs:
           --build-arg COMMIT=${{ env.COMMIT }} \
           --build-arg G_ACCOUNT=${{ env.G_ACCOUNT }} \
           --tag ${{ env.REGISTRY }}/${{ env.G_ACCOUNT }}/pre-merge-${{ matrix.distro }}:guild-deploy-l_${{ env.COMMIT }}
+    - name: Get Image ID
+      run: |
+        PREMERGE_IMAGE_ID1=$(docker inspect ${{ env.REGISTRY }}/${{ env.G_ACCOUNT }}/pre-merge-${{ matrix.distro }}:guild-deploy-l_${{ env.COMMIT }} --format='{{.Id}}')
+        echo "PREMERGE_IMAGE_ID1=${PREMERGE_IMAGE_ID1}" >> $GITHUB_ENV
     - name: Push pre-merge-${{ matrix.distro }}:guild-deploy-l_${{ env.COMMIT }}
       run: |
         docker push ${{ env.REGISTRY }}/${{ env.G_ACCOUNT }}/pre-merge-${{ matrix.distro }}:guild-deploy-l_${{ env.COMMIT }}
@@ -67,15 +71,28 @@ jobs:
         --build-arg COMMIT=${{ env.COMMIT }} \
         --build-arg G_ACCOUNT=${{ env.G_ACCOUNT }} \
         --tag ${{ env.REGISTRY }}/${{ env.G_ACCOUNT }}/pre-merge-${{ matrix.distro }}:cabal-l_${{ env.COMMIT }}
+    - name: Get Versions and Image ID
+      run: |
+        VERSION_DETAILS=($(docker run --rm ${{ env.REGISTRY }}/${{ env.G_ACCOUNT }}/pre-merge-${{ matrix.distro }}:cabal-l_${{ env.COMMIT }} cardano-node --version | awk '/^cardano-node/'))
+        PREMERGE_IMAGE_ID2=$(docker inspect ${{ env.REGISTRY }}/${{ env.G_ACCOUNT }}/pre-merge-${{ matrix.distro }}:cabal-l_${{ env.COMMIT }} --format='{{.Id}}')
+        echo "CARDANO_NODE_VERSION=${VERSION_DETAILS[1]}" >> $GITHUB_ENV
+        echo "GHC_VERSION=${VERSION_DETAILS[5]}" >> $GITHUB_ENV
+        echo "PREMERGE_IMAGE_ID2=${PREMERGE_IMAGE_ID2}" >> $GITHUB_ENV
     - name: Push pre-merge-${{ matrix.distro }}:cabal-l_${{ env.COMMIT }}
       run: |
         docker push ${{ env.REGISTRY }}/${{ env.G_ACCOUNT }}/pre-merge-${{ matrix.distro }}:cabal-l_${{ env.COMMIT }}
     - name: Add summary details
       if: always()
       run: |
-        echo "## Summary Details" >> $GITHUB_STEP_SUMMARY
-        echo "* Pre-Merge Guild Deploy Image: ${{ env.REGISTRY }}/${{ env.G_ACCOUNT }}/pre-merge-${{ matrix.distro }}:guild-deploy-l_${{ env.COMMIT }}" >> $GITHUB_STEP_SUMMARY
-        echo "* Pre-Merge Cabal Build Image: ${{ env.REGISTRY }}/${{ env.G_ACCOUNT }}/pre-merge-${{ matrix.distro }}:cabal-l_${{ env.COMMIT }}" >> $GITHUB_STEP_SUMMARY
-        echo "* BRANCH: ${{ env.BRANCH }}" >> $GITHUB_STEP_SUMMARY
-        echo "* G_ACCOUNT: ${{ env.G_ACCOUNT }}" >> $GITHUB_STEP_SUMMARY
-        echo "* COMMIT: ${{ env.COMMIT }}" >> $GITHUB_STEP_SUMMARY
+        echo "## Pre-Merge Summary Details" >> $GITHUB_STEP_SUMMARY
+        echo "| Name | Value |" >> $GITHUB_STEP_SUMMARY
+        echo "| ---- | ----- |" >> $GITHUB_STEP_SUMMARY
+        echo "| Guild Deploy Image | ${{ env.REGISTRY }}/${{ env.G_ACCOUNT }}/pre-merge-${{ matrix.distro }}:guild-deploy-l_${{ env.COMMIT }} |" >> $GITHUB_STEP_SUMMARY
+        echo "| Guild Deploy Image ID | ${{ env.PREMERGE_IMAGE_ID1 }} |" >> $GITHUB_STEP_SUMMARY
+        echo "| Cabal Build Image | ${{ env.REGISTRY }}/${{ env.G_ACCOUNT }}/pre-merge-${{ matrix.distro }}:cabal-l_${{ env.COMMIT }} |" >> $GITHUB_STEP_SUMMARY
+        echo "| Cabal Build Image ID | ${{ env.PREMERGE_IMAGE_ID2 }} |" >> $GITHUB_STEP_SUMMARY
+        echo "| G_ACCOUNT | ${{ env.G_ACCOUNT }} |" >> $GITHUB_STEP_SUMMARY
+        echo "| BRANCH | ${{ env.BRANCH }} |" >> $GITHUB_STEP_SUMMARY
+        echo "| COMMIT | ${{ env.COMMIT }} |" >> $GITHUB_STEP_SUMMARY
+        echo "| CARDANO_NODE_VERSION | ${{ env.CARDANO_NODE_VERSION }} |" >> $GITHUB_STEP_SUMMARY
+        echo "| GHC_VERSION | ${{ env.GHC_VERSION }} |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Description
* Summary output as table format.
* Adds the Guild Deploy and Cabal Build image ID's to Summary.
* Includes the CARDANO_NODE_VERSION and GHC_VERSION in summary output.

## Where should the reviewer start?


## Motivation and context
1. Easier to review the summary information presented.
2. Quick access to which which image ID was generated.
2. Quick access to which GHC was used to compile cardano binaries.
3. Quick access to which cardano-node was compiled.

## Which issue it fixes?
None.

## How has this been tested?
* [Forked branch PR](https://github.com/TrevorBenson/guild-operators/actions/runs/6066797394), currentl running after squash/fixups.
* [Simulated workflow](https://github.com/TrevorBenson/itsatest/actions/runs/6066786050), contains the example table layout without waiting for the entire build process.
