### PR TITLE
Support for Mithril Signer deployment.

### DIFF
--- a/scripts/cnode-helper-scripts/cnode.sh
+++ b/scripts/cnode-helper-scripts/cnode.sh
@@ -61,6 +61,15 @@ pre_startup_sanity() {
   [[ $(find "${LOG_DIR}"/node*.json 2>/dev/null | wc -l) -gt 0 ]] && mv "${LOG_DIR}"/node*.json "${LOG_DIR}"/archive/
 }
 
+mithril_snapshot_download() {
+  [[ -z "${MITHRIL_CLIENT}" ]] && MITHRIL_CLIENT="${CNODE_HOME}"/scripts/mithril-client.sh
+  if [[ ! -f "${MITHRIL_CLIENT}" ]] || [[ ! -e "${MITHRIL_CLIENT}" ]]; then 
+    echo "ERROR: Could not locate mithril-client.sh script or script is not executable. Skipping mithril snapshot download!!"
+  else
+    "${MITHRIL_CLIENT}" -d
+  fi
+}
+
 stop_node() {
   CNODE_PID=$(pgrep -fn "$(basename ${CNODEBIN}).*.--port ${CNODE_PORT}" 2>/dev/null) # env was only called in offline mode
   kill -2 ${CNODE_PID} 2>/dev/null
@@ -130,6 +139,11 @@ if [[ "${DEPLOY_SYSTEMD}" == "Y" ]]; then
   exit 2
 fi
 pre_startup_sanity
+
+# Download the latest mithril snapshot before starting node
+if [[ "${MITHRIL_DOWNLOAD}" == "Y" ]]; then
+  mithril_snapshot_download
+fi
 
 # Run Node
 if [[ -f "${POOL_DIR}/${POOL_OPCERT_FILENAME}" && -f "${POOL_DIR}/${POOL_VRF_SK_FILENAME}" && -f "${POOL_DIR}/${POOL_HOTKEY_SK_FILENAME}" ]]; then

--- a/scripts/cnode-helper-scripts/deploy-as-systemd.sh
+++ b/scripts/cnode-helper-scripts/deploy-as-systemd.sh
@@ -43,6 +43,11 @@ if command -v mithril-signer >/dev/null 2>&1 ; then
   read -rsn1 yn
   if [[ ${yn} = [Yy]* ]]; then
     ./mithril-signer.sh -d
+  else
+    if [[ -f /etc/systemd/system/${vname}-mithril-signer.service ]]; then
+      sudo systemctl disable ${vname}-mithril-signer.service
+      sudo rm -f /etc/systemd/system/${vname}-mithril-signer.service
+    fi
   fi
 fi
 
@@ -422,7 +427,7 @@ sudo systemctl daemon-reload
 [[ -f /etc/systemd/system/${vname}-cncli-validate.service ]] && sudo systemctl enable ${vname}-cncli-validate.service
 [[ -f /etc/systemd/system/${vname}-cncli-ptsendtip.service ]] && sudo systemctl enable ${vname}-cncli-ptsendtip.service
 [[ -f /etc/systemd/system/${vname}-cncli-ptsendslots.service ]] && sudo systemctl enable ${vname}-cncli-ptsendslots.service
-[[ -f /etc/systemd/system/${vanem}-mithril-signer.service ]] && sudo systemctl enable ${vname}-mithril-signer.service
+[[ -f /etc/systemd/system/${vname}-mithril-signer.service ]] && sudo systemctl enable ${vname}-mithril-signer.service
 
 
 echo

--- a/scripts/cnode-helper-scripts/deploy-as-systemd.sh
+++ b/scripts/cnode-helper-scripts/deploy-as-systemd.sh
@@ -37,6 +37,15 @@ if [[ ${yn} = [Yy]* ]]; then
   ./submitapi.sh -d
 fi
 
+if command -v mithril-signer >/dev/null 2>&1 ; then
+  echo -e "\e[32m~~ Mithril Signer ~~\e[0m"
+  echo "Deploy Mithril Signer as a systemd service? [y|n]"
+  read -rsn1 yn
+  if [[ ${yn} = [Yy]* ]]; then
+    ./mithril-signer.sh -d
+  fi
+fi
+
 if command -v ogmios >/dev/null 2>&1 ; then
   echo -e "\e32m~~ Cardano Ogmios Server ~~\e[0m"
   echo "launches the ogmios.sh script to deploy ogmios"
@@ -413,6 +422,7 @@ sudo systemctl daemon-reload
 [[ -f /etc/systemd/system/${vname}-cncli-validate.service ]] && sudo systemctl enable ${vname}-cncli-validate.service
 [[ -f /etc/systemd/system/${vname}-cncli-ptsendtip.service ]] && sudo systemctl enable ${vname}-cncli-ptsendtip.service
 [[ -f /etc/systemd/system/${vname}-cncli-ptsendslots.service ]] && sudo systemctl enable ${vname}-cncli-ptsendslots.service
+[[ -f /etc/systemd/system/${vanem}-mithril-signer.service ]] && sudo systemctl enable ${vname}-mithril-signer.service
 
 
 echo

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -80,7 +80,7 @@
 #ASSET_POLICY_ID_FILENAME="policy.id"
 #CIP0094_POLL_URL="https://raw.githubusercontent.com/cardano-foundation/CIP-0094-polls/main/networks/polls.json" # URL for polls to vote against
 
-#MITHRIL_DOWNLOAD="Y"                                  # (Y|N) Download latest Mithril snapshot
+#MITHRIL_DOWNLOAD="N"                                  # (Y|N) Download latest Mithril snapshot
 
 ######################################
 # Do NOT modify code below           #
@@ -800,7 +800,7 @@ set_default_vars() {
   [[ -z ${ASSET_POLICY_SCRIPT_FILENAME} ]] && ASSET_POLICY_SCRIPT_FILENAME="policy.script"
   [[ -z ${ASSET_POLICY_ID_FILENAME} ]] && ASSET_POLICY_ID_FILENAME="policy.id"
   [[ -z ${CIP0094_POLL_URL} ]] && CIP0094_POLL_URL="https://raw.githubusercontent.com/cardano-foundation/CIP-0094-polls/main/networks/polls.json"
-  [[ -z ${MITHRIL_DOWNLOAD} ]] && MITHRIL_DOWNLOAD="Y"
+  [[ -z ${MITHRIL_DOWNLOAD} ]] && MITHRIL_DOWNLOAD="N"
   FG_BLACK='\e[30m'
   FG_RED='\e[31m'
   FG_GREEN='\e[32m'

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -80,6 +80,8 @@
 #ASSET_POLICY_ID_FILENAME="policy.id"
 #CIP0094_POLL_URL="https://raw.githubusercontent.com/cardano-foundation/CIP-0094-polls/main/networks/polls.json" # URL for polls to vote against
 
+#MITHRIL_DOWNLOAD="Y"                                  # (Y|N) Download latest Mithril snapshot
+
 ######################################
 # Do NOT modify code below           #
 ######################################
@@ -795,6 +797,7 @@ set_default_vars() {
   [[ -z ${ASSET_POLICY_SCRIPT_FILENAME} ]] && ASSET_POLICY_SCRIPT_FILENAME="policy.script"
   [[ -z ${ASSET_POLICY_ID_FILENAME} ]] && ASSET_POLICY_ID_FILENAME="policy.id"
   [[ -z ${CIP0094_POLL_URL} ]] && CIP0094_POLL_URL="https://raw.githubusercontent.com/cardano-foundation/CIP-0094-polls/main/networks/polls.json"
+  [[ -z ${MITHRIL_DOWNLOAD} ]] && MITHRIL_DOWNLOAD="Y"
   FG_BLACK='\e[30m'
   FG_RED='\e[31m'
   FG_GREEN='\e[32m'

--- a/scripts/cnode-helper-scripts/guild-deploy.sh
+++ b/scripts/cnode-helper-scripts/guild-deploy.sh
@@ -74,7 +74,7 @@ usage() {
 		  p   Install common pre-requisite OS-level Dependencies for most tools on this repo (Default: skip)
 		  b   Install OS level dependencies for tools required while building cardano-node/cardano-db-sync components (Default: skip)
 		  l   Build and Install libsodium fork from IO repositories (Default: skip)
-		  m   Build and install mithril from IO repositories (Default: skip)
+		  m   Download latest (released) binaries for mithril-signer, mithril-client (Default: skip)
 		  f   Force overwrite entire content of scripts and config files (backups of existing ones will be created) (Default: skip)
 		  d   Download latest (released) binaries for bech32, cardano-address, cardano-node, cardano-cli, cardano-db-sync and cardano-submit-api (Default: skip)
 		  c   Install/Upgrade CNCLI binary (Default: skip)

--- a/scripts/cnode-helper-scripts/guild-deploy.sh
+++ b/scripts/cnode-helper-scripts/guild-deploy.sh
@@ -99,7 +99,6 @@ set_defaults() {
   [[ -z ${INSTALL_OGMIOS} ]] && INSTALL_OGMIOS='N'
   [[ -z ${INSTALL_CSIGNER} ]] && INSTALL_CSIGNER='N'
   [[ -z ${CNODE_PATH} ]] && CNODE_PATH="/opt/cardano"
-  [[ -z ${MITHRIL_PATH} ]] && MITHRIL_PATH="/opt/mithril"
   [[ -z ${CNODE_NAME} ]] && CNODE_NAME='cnode'
   [[ -z ${CURL_TIMEOUT} ]] && CURL_TIMEOUT=60
   [[ -z ${UPDATE_CHECK} ]] && UPDATE_CHECK='Y'

--- a/scripts/cnode-helper-scripts/guild-deploy.sh
+++ b/scripts/cnode-helper-scripts/guild-deploy.sh
@@ -3,7 +3,6 @@
 # shellcheck source=/dev/null
 
 unset CNODE_HOME
-unset MITHRIL_HOME
 
 ##########################################
 # User Variables - Change as desired     #
@@ -111,7 +110,6 @@ set_defaults() {
   [[ "${SUDO}" = 'Y' && $(id -u) -eq 0 ]] && err_exit "Please run as non-root user."
   CNODE_HOME="${CNODE_PATH}/${CNODE_NAME}"
   CNODE_VNAME=$(echo "$CNODE_NAME" | awk '{print toupper($0)}')
-  MITHRIL_HOME="${MITHRIL_PATH}/mithril-signer"
   REPO="https://github.com/${G_ACCOUNT}/guild-operators"
   REPO_RAW="https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators"
   URL_RAW="${REPO_RAW}/${BRANCH}"
@@ -528,16 +526,9 @@ setup_folder() {
   $sudo chown -R "$U_ID":"$G_ID" "${CNODE_HOME}" 2>/dev/null
   
   if [[ ${INSTALL_MITHRIL} == 'Y' ]]; then
-
-    if grep -q "export MITHRIL_HOME=" "${HOME}"/.bashrc; then
-      echo -e "\nEnvironment Variable MITHRIL_HOME already set up!"
-    else
-      echo -e "\nSetting up MITHRIL_HOME Environment Variable"
-      echo -e "\nexport MITHRIL_HOME=${MITHRIL_HOME}" >> "${HOME}"/.bashrc
-    fi
   
-    $sudo mkdir -p "${MITHRIL_HOME}"/data-stores
-    $sudo chown -R "$U_ID":"$G_ID" "${MITHRIL_HOME}" 2>/dev/null
+    $sudo mkdir -p "${CNODE_HOME}"/mithril-signer/data-stores
+    $sudo chown -R "$U_ID":"$G_ID" "${CNODE_HOME}"/mithril-signer 2>/dev/null
   fi
 }
 

--- a/scripts/cnode-helper-scripts/guild-deploy.sh
+++ b/scripts/cnode-helper-scripts/guild-deploy.sh
@@ -3,6 +3,7 @@
 # shellcheck source=/dev/null
 
 unset CNODE_HOME
+unset MITHRIL_HOME
 
 ##########################################
 # User Variables - Change as desired     #
@@ -61,7 +62,7 @@ versionCheck() { printf '%s\n%s' "${1//v/}" "${2//v/}" | sort -C -V; } #$1=avail
 usage() {
   cat <<-EOF >&2
 		
-		Usage: $(basename "$0") [-n <mainnet|preprod|guild|preview>] [-p path] [-t <name>] [-b <branch>] [-u] [-s [p][b][l][f][d][c][o][w][x]]
+		Usage: $(basename "$0") [-n <mainnet|preprod|guild|preview>] [-p path] [-t <name>] [-b <branch>] [-u] [-s [p][b][l][m][f][d][c][o][w][x]]
 		Set up dependencies for building/using common tools across cardano ecosystem.
 		The script will always update dynamic content from existing scripts retaining existing user variables
 		
@@ -74,6 +75,7 @@ usage() {
 		  p   Install common pre-requisite OS-level Dependencies for most tools on this repo (Default: skip)
 		  b   Install OS level dependencies for tools required while building cardano-node/cardano-db-sync components (Default: skip)
 		  l   Build and Install libsodium fork from IO repositories (Default: skip)
+		  m   Build and install mithril from IO repositories (Default: skip)
 		  f   Force overwrite entire content of scripts and config files (backups of existing ones will be created) (Default: skip)
 		  d   Download latest (released) binaries for bech32, cardano-address, cardano-node, cardano-cli, cardano-db-sync and cardano-submit-api (Default: skip)
 		  c   Install/Upgrade CNCLI binary (Default: skip)
@@ -92,11 +94,13 @@ set_defaults() {
   [[ -z ${WANT_BUILD_DEPS} ]] && WANT_BUILD_DEPS='N'
   [[ -z ${FORCE_OVERWRITE} ]] && FORCE_OVERWRITE='N'
   [[ -z ${LIBSODIUM_FORK} ]] && LIBSODIUM_FORK='N'
+  [[ -z ${INSTALL_MITHRIL} ]] && INSTALL_MITHRIL='N'
   [[ -z ${INSTALL_CNCLI} ]] && INSTALL_CNCLI='N'
   [[ -z ${INSTALL_CWHCLI} ]] && INSTALL_CWHCLI='N'
   [[ -z ${INSTALL_OGMIOS} ]] && INSTALL_OGMIOS='N'
   [[ -z ${INSTALL_CSIGNER} ]] && INSTALL_CSIGNER='N'
   [[ -z ${CNODE_PATH} ]] && CNODE_PATH="/opt/cardano"
+  [[ -z ${MITHRIL_PATH} ]] && MITHRIL_PATH="/opt/mithril"
   [[ -z ${CNODE_NAME} ]] && CNODE_NAME='cnode'
   [[ -z ${CURL_TIMEOUT} ]] && CURL_TIMEOUT=60
   [[ -z ${UPDATE_CHECK} ]] && UPDATE_CHECK='Y'
@@ -107,6 +111,7 @@ set_defaults() {
   [[ "${SUDO}" = 'Y' && $(id -u) -eq 0 ]] && err_exit "Please run as non-root user."
   CNODE_HOME="${CNODE_PATH}/${CNODE_NAME}"
   CNODE_VNAME=$(echo "$CNODE_NAME" | awk '{print toupper($0)}')
+  MITHRIL_HOME="${MITHRIL_PATH}/mithril-signer"
   REPO="https://github.com/${G_ACCOUNT}/guild-operators"
   REPO_RAW="https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators"
   URL_RAW="${REPO_RAW}/${BRANCH}"
@@ -489,6 +494,25 @@ download_cardanosigner() {
   fi
 }
 
+# Download pre-built mithril-signer binary
+download_mithril() {
+    echo -e "\nDownloading Mithril..."
+    pushd "${HOME}"/tmp >/dev/null || err_exit
+    # dynamic latest release updated automatically, uncomment and comment out the hardcoded release below if needed
+    # mithril_release="$(curl -s https://api.github.com/repos/input-output-hk/mithril/releases/latest | jq -r '.tag_name')"
+    # hardcoded latest release requiring a bump
+    mithril_release="2337.0"
+    echo -e "\n  Downloading Mithril Signer/Client ${mithril_release}..."
+    rm -f mithril-signer mithril-client
+    curl -m 200 -sfL https://github.com/input-output-hk/mithril/releases/download/${mithril_release}/mithril-${mithril_release}-linux-x64.tar.gz -o mithril.tar.gz || err_exit " Could not download mithril's latest release archive from IO github!"
+    tar zxf mithril.tar.gz mithril-signer mithril-client &>/dev/null
+    rm -f mithril.tar.gz
+    [[ -f mithril-signer ]] || err_exit " mithril archive downloaded but binary (mithril-signer) not found after extracting package!"
+    [[ -f mithril-client ]] || err_exit " mithril archive downloaded but binary (mithril-client) not found after extracting package!"
+    mv -t "${HOME}"/.local/bin mithril-signer mithril-client
+    chmod +x "${HOME}"/.local/bin/*
+}
+
 # Create folder structure and set up permissions/ownerships
 setup_folder() {
   echo -e "\nCreating Folder Structure .."
@@ -502,6 +526,19 @@ setup_folder() {
   
   $sudo mkdir -p "${CNODE_HOME}"/files "${CNODE_HOME}"/db "${CNODE_HOME}"/guild-db "${CNODE_HOME}"/logs "${CNODE_HOME}"/scripts "${CNODE_HOME}"/scripts/archive "${CNODE_HOME}"/sockets "${CNODE_HOME}"/priv
   $sudo chown -R "$U_ID":"$G_ID" "${CNODE_HOME}" 2>/dev/null
+  
+  if [[ ${INSTALL_MITHRIL} == 'Y' ]]; then
+
+    if grep -q "export MITHRIL_HOME=" "${HOME}"/.bashrc; then
+      echo -e "\nEnvironment Variable MITHRIL_HOME already set up!"
+    else
+      echo -e "\nSetting up MITHRIL_HOME Environment Variable"
+      echo -e "\nexport MITHRIL_HOME=${MITHRIL_HOME}" >> "${HOME}"/.bashrc
+    fi
+  
+    $sudo mkdir -p "${MITHRIL_HOME}"/data-stores
+    $sudo chown -R "$U_ID":"$G_ID" "${MITHRIL_HOME}" 2>/dev/null
+  fi
 }
 
 # Download and update scripts for cnode
@@ -591,6 +628,7 @@ parse_args() {
     [[ "${S_ARGS}" =~ "p" ]] && INSTALL_OS_DEPS="Y"
     [[ "${S_ARGS}" =~ "b" ]] && INSTALL_OS_DEPS="Y" && WANT_BUILD_DEPS="Y"
     [[ "${S_ARGS}" =~ "l" ]] && INSTALL_OS_DEPS="Y" && WANT_BUILD_DEPS="Y" && INSTALL_LIBSODIUM_FORK="Y"
+    [[ "${S_ARGS}" =~ "m" ]] && INSTALL_MITHRIL="Y" && WANT_BUILD_DEPS="Y"
     [[ "${S_ARGS}" =~ "f" ]] && FORCE_OVERWRITE="Y" && POPULATE_CNODE="F"
     [[ "${S_ARGS}" =~ "d" ]] && INSTALL_CNODEBINS="Y"
     [[ "${S_ARGS}" =~ "c" ]] && INSTALL_CNCLI="Y"
@@ -613,6 +651,7 @@ main_flow() {
   [[ "${INSTALL_OS_DEPS}" == "Y" ]] && os_dependencies
   [[ "${WANT_BUILD_DEPS}" == "Y" ]] && build_dependencies
   [[ "${INSTALL_LIBSODIUM_FORK}" == "Y" ]] && build_libsodium
+  [[ "${INSTALL_MITHRIL}" == "Y" ]] && download_mithril
   [[ "${FORCE_OVERWRITE}" == "Y" ]] && POPULATE_CNODE="F" && populate_cnode
   [[ "${POPULATE_CNODE}" == "Y" ]] && populate_cnode
   [[ "${INSTALL_CNODEBINS}" == "Y" ]] && download_cnodebins

--- a/scripts/cnode-helper-scripts/guild-deploy.sh
+++ b/scripts/cnode-helper-scripts/guild-deploy.sh
@@ -521,13 +521,13 @@ setup_folder() {
     echo -e "\nexport ${CNODE_VNAME}_HOME=${CNODE_HOME}" >> "${HOME}"/.bashrc
   fi
   
-  $sudo mkdir -p "${CNODE_HOME}"/files "${CNODE_HOME}"/db "${CNODE_HOME}"/guild-db "${CNODE_HOME}"/logs "${CNODE_HOME}"/scripts "${CNODE_HOME}"/scripts/archive "${CNODE_HOME}"/sockets "${CNODE_HOME}"/priv
+  $sudo mkdir -p "${CNODE_HOME}"/files "${CNODE_HOME}"/db "${CNODE_HOME}"/guild-db "${CNODE_HOME}"/logs "${CNODE_HOME}"/scripts "${CNODE_HOME}"/scripts/archive "${CNODE_HOME}"/sockets "${CNODE_HOME}"/priv "${CNODE_HOME}"/mithril
   $sudo chown -R "$U_ID":"$G_ID" "${CNODE_HOME}" 2>/dev/null
   
   if [[ ${INSTALL_MITHRIL} == 'Y' ]]; then
   
-    $sudo mkdir -p "${CNODE_HOME}"/mithril-signer/data-stores
-    $sudo chown -R "$U_ID":"$G_ID" "${CNODE_HOME}"/mithril-signer 2>/dev/null
+    $sudo mkdir -p "${CNODE_HOME}"/mithril/data-stores
+    $sudo chown -R "$U_ID":"$G_ID" "${CNODE_HOME}"/mithril 2>/dev/null
   fi
 }
 

--- a/scripts/cnode-helper-scripts/mithril-client.sh
+++ b/scripts/cnode-helper-scripts/mithril-client.sh
@@ -27,6 +27,7 @@ usage() {
 		Cardano Mithril client wrapper script !!
 		-d    Download latest Mithril snapshot
 		-u    Update mithril environment file
+		-h    Show this help text
 		
 		EOF
 }
@@ -151,11 +152,24 @@ download_snapshot() {
 #####################
 
 # Parse command line options
-while getopts :du opt; do
+while getopts :duh opt; do
   case ${opt} in
     d ) MITHRIL_DOWNLOAD="Y" ;;
     u ) UPDATE_ENVIRONMENT="Y" ;;
-    \? ) usage ;;
+    h)
+      usage
+      exit 0
+      ;;
+    \?)
+      echo "Invalid option: -${OPTARG}" >&2
+      usage
+      exit 1
+      ;;
+    :)
+      echo "Option -${OPTARG} requires an argument." >&2
+      usage
+      exit 1
+      ;;
   esac
 done
 

--- a/scripts/cnode-helper-scripts/mithril-client.sh
+++ b/scripts/cnode-helper-scripts/mithril-client.sh
@@ -114,27 +114,26 @@ set_defaults() {
 }
 
 check_db_dir() {
-    # If the DB directory does not exist then set DOWNLOAD_SNAPSHOT to Y
-    if [[ ! -d "${DB_DIRECTORY}" ]]; then
-        echo "INFO: The db directory does not exist.."
-        DOWNLOAD_SNAPSHOT="Y"
-    # If the DB directory is empty then set DOWNLOAD_SNAPSHOT to Y and REMOVE_DB_DIR to Y
-    elif [[ -d "${DB_DIRECTORY}" ]] && [[ -z "$(ls -A "${DB_DIRECTORY}")" ]] && [[ $(du -cs "${DB_DIRECTORY}"/* 2>/dev/null | awk '/total$/ {print $1}') -eq 0 ]]; then
-        echo "INFO: The db directory is empty.."
-        REMOVE_DB_DIR="Y"
-        DOWNLOAD_SNAPSHOT="Y"
-    else
-        echo "INFO: The db directory is not empty.."
-    fi
-
+  # If the DB directory does not exist then set DOWNLOAD_SNAPSHOT to Y
+  if [[ ! -d "${DB_DIRECTORY}" ]]; then
+    echo "INFO: The db directory does not exist.."
+    DOWNLOAD_SNAPSHOT="Y"
+  # If the DB directory is empty then set DOWNLOAD_SNAPSHOT to Y and REMOVE_DB_DIR to Y
+  elif [[ -d "${DB_DIRECTORY}" ]] && [[ -z "$(ls -A "${DB_DIRECTORY}")" ]] && [[ $(du -cs "${DB_DIRECTORY}"/* 2>/dev/null | awk '/total$/ {print $1}') -eq 0 ]]; then
+    echo "INFO: The db directory is empty.."
+    REMOVE_DB_DIR="Y"
+    DOWNLOAD_SNAPSHOT="Y"
+  else
+    echo "INFO: The db directory is not empty.."
+  fi
 }
 
 remove_db_dir() {
-    # Mithril client errors if the db folder already exists, so remove it if it is empty
-    if [[ "${REMOVE_DB_DIR}" == "Y" ]]; then
-        echo "INFO: Removing empty db directory to prepare for snapshot download.."
-        rmdir "${DB_DIRECTORY}"
-    fi
+  # Mithril client errors if the db folder already exists, so remove it if it is empty
+  if [[ "${REMOVE_DB_DIR}" == "Y" ]]; then
+    echo "INFO: Removing empty db directory to prepare for snapshot download.."
+    rmdir "${DB_DIRECTORY}"
+  fi
 }
 
 download_snapshot() {

--- a/scripts/cnode-helper-scripts/mithril-client.sh
+++ b/scripts/cnode-helper-scripts/mithril-client.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2086
+#shellcheck source=/dev/null
+
+. "$(dirname $0)"/env offline
+
+######################################
+# User Variables - Change as desired #
+# Common variables set in env file   #
+######################################
+
+#MITHRILBIN="${HOME}"/.local/bin/mithril-client # Path for mithril-client binary, if not in $PATH
+
+######################################
+# Do NOT modify code below           #
+######################################
+
+#####################
+# Functions         #
+#####################
+
+usage() {
+  cat <<-EOF
+		
+		Usage: $(basename "$0") [-d] [-u]
+		
+		Cardano Mithril client wrapper script !!
+		-d    Download latest Mithril snapshot
+		-u    Update mithril environment file
+		
+		EOF
+}
+
+
+generate_environment_file() {
+  export ERA_READER_ADDRESS=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/era.addr
+  export ERA_READER_VKEY=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/era.vkey
+  if [[ -n "${POOL_NAME}" ]] && [[ "${POOL_NAME}" != "CHANGE_ME" ]]; then
+    bash -c "cat <<-'EOF' > ${CNODE_HOME}/mithril/mithril.env
+		KES_SECRET_KEY_PATH=${POOL_DIR}/${POOL_HOTKEY_SK_FILENAME}
+		OPERATIONAL_CERTIFICATE_PATH=${POOL_DIR}/${POOL_OPCERT_FILENAME}
+		NETWORK=${NETWORK_NAME,,}
+		RELEASE=${RELEASE}
+		AGGREGATOR_ENDPOINT=https://aggregator.${RELEASE}-${NETWORK_NAME,,}.api.mithril.network/aggregator
+		RUN_INTERVAL=60000
+		DB_DIRECTORY=${CNODE_HOME}/db
+		CARDANO_NODE_SOCKET_PATH=${CARDANO_NODE_SOCKET_PATH}
+		CARDANO_CLI_PATH=${HOME}/.local/bin/cardano-cli
+		DATA_STORES_DIRECTORY=${CNODE_HOME}/mithril/data-stores
+		STORE_RETENTION_LIMITS=5
+		ERA_READER_ADAPTER_TYPE=cardano-chain
+		ERA_READER_ADAPTER_PARAMS=$(jq -nc --arg address "$(wget -q -O - "${ERA_READER_ADDRESS}")" --arg verification_key "$(wget -q -O - "${ERA_READER_VKEY}")" '{"address": $address, "verification_key": $verification_key}')
+		GENESIS_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/genesis.vkey)
+		PARTY_ID=$(cat ${POOL_DIR}/${POOL_ID_FILENAME})
+		SNAPSHOT_DIGEST=latest
+		EOF"
+  else
+    bash -c "cat <<-'EOF' > ${CNODE_HOME}/mithril/mithril.env
+		NETWORK=${NETWORK_NAME,,}
+		RELEASE=${RELEASE}
+		AGGREGATOR_ENDPOINT=https://aggregator.${RELEASE}-${NETWORK_NAME,,}.api.mithril.network/aggregator
+		DB_DIRECTORY=${CNODE_HOME}/db
+		GENESIS_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/genesis.vkey)
+		SNAPSHOT_DIGEST=latest
+		EOF"
+  fi
+  chown $USER:$USER "${CNODE_HOME}"/mithril/mithril.env
+}
+
+
+pre_startup_sanity() {
+  REQUIRED_PARAMETERS="Y"
+  if [[ ! -f "${CNODE_HOME}"/mithril/mithril.env ]]; then
+    echo "INFO: Mithril environment file not found, creating environment file.."
+    generate_environment_file && echo "INFO: Mithril environment file created successfully!!"
+  elif [[ "${UPDATE_ENVIRONMENT}" == "Y" ]]; then
+    echo "INFO: Updating mithril environment file.."
+    generate_environment_file && echo "INFO: Mithril environment file updated successfully!!"
+  fi
+  . "${CNODE_HOME}"/mithril/mithril.env
+  [[ -z "${NETWORK}" ]] && echo "ERROR: The NETWORK must be set before calling mithril-client!!" && REQUIRED_PARAMETERS="N"
+  [[ -z "${RELEASE}" ]] && echo "ERROR: Failed to set RELEASE variable, please check NETWORK variable in env file!!" && REQUIRED_PARAMETERS="N"
+  [[ -z "${CNODE_HOME}" ]] && echo "ERROR: The CNODE_HOME must be set before calling mithril-client!!" && REQUIRED_PARAMETERS="N"
+  [[ ! -d "${CNODE_HOME}" ]] && echo "ERROR: The CNODE_HOME directory does not exist, please check CNODE_HOME variable in env file!!" && REQUIRED_PARAMETERS="N"
+  [[ -z "${AGGREGATOR_ENDPOINT}" ]] && echo "ERROR: The AGGREGATOR_ENDPOINT must be set before calling mithril-client!!" && REQUIRED_PARAMETERS="N"
+  [[ -z "${GENESIS_VERIFICATION_KEY}" ]] && echo "ERROR: The GENESIS_VERIFICATION_KEY must be set before calling mithril-client!!" && REQUIRED_PARAMETERS="N"
+  [[ ! -x "${MITHRILBIN}" ]] && echo "ERROR: The MITHRILBIN variable does not contain an executable file, please check MITHRILBIN variable in env file!!" && REQUIRED_PARAMETERS="N"
+  [[ "${REQUIRED_PARAMETERS}" != "Y" ]] && exit 1
+  export GENESIS_VERIFICATION_KEY
+  DOWNLOAD_SNAPSHOT="N"
+  REMOVE_DB_DIR="N"
+}
+
+set_defaults() {
+  [[ -z "${MITHRILBIN}" ]] && MITHRILBIN="${HOME}"/.local/bin/mithril-client
+  if [[ -z "${NETWORK_NAME}" ]]; then
+    echo "ERROR: The NETWORK_NAME must be set before mithril-client can download snapshots!!"
+    exit 1
+  else
+    case "${NETWORK_NAME,,}" in
+      mainnet|preprod|guild)
+      RELEASE="release"
+      ;;
+      preview)
+      RELEASE="pre-release"
+      ;;
+      *)
+      echo "ERROR: The NETWORK_NAME must be set to Mainnet, PreProd, Preview, Guild before mithril-client can download snapshots!!"
+      exit 1
+    esac
+  fi
+  pre_startup_sanity
+}
+
+check_db_dir() {
+    # If the DB directory does not exist then set DOWNLOAD_SNAPSHOT to Y
+    if [[ ! -d "${DB_DIRECTORY}" ]]; then
+        echo "INFO: The db directory does not exist.."
+        DOWNLOAD_SNAPSHOT="Y"
+    # If the DB directory is empty then set DOWNLOAD_SNAPSHOT to Y and REMOVE_DB_DIR to Y
+    elif [[ -d "${DB_DIRECTORY}" ]] && [[ -z "$(ls -A "${DB_DIRECTORY}")" ]] && [[ $(du -cs "${DB_DIRECTORY}"/* 2>/dev/null | awk '/total$/ {print $1}') -eq 0 ]]; then
+        echo "INFO: The db directory is empty.."
+        REMOVE_DB_DIR="Y"
+        DOWNLOAD_SNAPSHOT="Y"
+    else
+        echo "INFO: The db directory is not empty.."
+    fi
+
+}
+
+remove_db_dir() {
+    # Mithril client errors if the db folder already exists, so remove it if it is empty
+    if [[ "${REMOVE_DB_DIR}" == "Y" ]]; then
+        echo "INFO: Removing empty db directory to prepare for snapshot download.."
+        rmdir "${DB_DIRECTORY}"
+    fi
+}
+
+download_snapshot() {
+  if [[ "${DOWNLOAD_SNAPSHOT}" == "Y" ]]; then
+    echo "INFO: Downloading latest mithril snapshot.."
+    "${MITHRILBIN}" -v --aggregator-endpoint ${AGGREGATOR_ENDPOINT} snapshot download --download-dir ${CNODE_HOME} ${SNAPSHOT_DIGEST}
+  else
+    echo "INFO: Skipping snapshot download.."
+  fi
+}
+
+
+#####################
+# Execution         #
+#####################
+
+# Parse command line options
+while getopts :du opt; do
+  case ${opt} in
+    d ) MITHRIL_DOWNLOAD="Y" ;;
+    u ) UPDATE_ENVIRONMENT="Y" ;;
+    \? ) usage ;;
+  esac
+done
+
+#Deploy systemd if -d argument was specified
+if [[ "${UPDATE_ENVIRONMENT}" == "Y" ]] && [[ "${MITHRIL_DOWNLOAD}" != "Y" ]]; then
+  set_defaults
+elif [[ "${MITHRIL_DOWNLOAD}" == "Y" ]]; then
+  set_defaults
+  check_db_dir
+  remove_db_dir
+  download_snapshot
+elif [[ "${UPDATE_ENVIRONMENT}" == "Y" ]] && [[ "${MITHRIL_DOWNLOAD}" == "Y" ]]; then
+  set_defaults
+  check_db_dir
+  remove_db_dir
+  download_snapshot
+else
+    usage
+    exit 1
+fi
+
+exit 0

--- a/scripts/cnode-helper-scripts/mithril-client.sh
+++ b/scripts/cnode-helper-scripts/mithril-client.sh
@@ -34,9 +34,9 @@ usage() {
 
 
 generate_environment_file() {
-  export ERA_READER_ADDRESS=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/era.addr
-  export ERA_READER_VKEY=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/era.vkey
   if [[ -n "${POOL_NAME}" ]] && [[ "${POOL_NAME}" != "CHANGE_ME" ]]; then
+    export ERA_READER_ADDRESS=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/era.addr
+    export ERA_READER_VKEY=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/era.vkey
     bash -c "cat <<-'EOF' > ${CNODE_HOME}/mithril/mithril.env
 		KES_SECRET_KEY_PATH=${POOL_DIR}/${POOL_HOTKEY_SK_FILENAME}
 		OPERATIONAL_CERTIFICATE_PATH=${POOL_DIR}/${POOL_OPCERT_FILENAME}

--- a/scripts/cnode-helper-scripts/mithril-relay.sh
+++ b/scripts/cnode-helper-scripts/mithril-relay.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+
+# Default values
+BLOCK_PRODUCER_IP=()
+RELAY_LISTENING_IP=()
+RELAY_LISTENING_PORT=3132
+
+# Usage menu
+usage() {
+	echo "Usage: $0 [-d] [-l]"
+	echo "  -d  Install squid and configure as a relay"
+	echo "  -l  Install nginx and configure as a load balancer"
+}
+
+generate_nginx_conf() {
+	sudo bash -c "cat > /etc/nginx/nginx.conf <<'EOF'
+worker_processes 1;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    upstream mithril_relays {
+        $(for ip in "${RELAY_LISTENING_IP[@]}"; do
+		echo -e "            server ${ip}:${RELAY_LISTENING_PORT};"
+	done)
+    }
+
+    server {
+        listen ${SIDECAR_LISTENING_IP}:${RELAY_LISTENING_PORT};
+        location / {
+            proxy_pass http://mithril_relays;
+            proxy_set_header Host \$host;
+            proxy_set_header X-Real-IP \$remote_addr;
+            proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        }
+    }
+}
+EOF"
+}
+
+generate_squid_conf() {
+	# Write the squid config file
+	sudo bash -c "cat <<-'EOF' > /etc/squid/squid.conf
+	# Listening port (port 3132 is recommended)
+	http_port ${RELAY_LISTENING_PORT}
+	
+	EOF"
+
+	# Write the ACLs for each relay IP address
+	sudo bash -c 'echo "# ACLs for IP of the block producers" >> /etc/squid/squid.conf'
+	for ip in "${BLOCK_PRODUCER_IP[@]}"; do
+		sudo bash -c "echo \"acl block_producer_ip src ${ip}\" >> /etc/squid/squid.conf"
+	done
+
+	# Write the rest of the squid config file
+	sudo bash -c "cat <<-'EOF' >> /etc/squid/squid.conf
+	# ACL for aggregator endpoint
+	acl aggregator_domain dstdomain .mithril.network
+	
+	# ACL for SSL port only
+	acl SSL_port port 443
+	
+	# Allowed traffic
+	http_access allow block_producer_ip aggregator_domain SSL_port
+	
+	# Do not disclose relay internal IP
+	forwarded_for delete
+	
+	# Turn off via header
+	via off
+	
+	# Deny request for original source of a request
+	follow_x_forwarded_for deny all
+	
+	# Anonymize request headers
+	request_header_access Authorization allow all
+	request_header_access Proxy-Authorization allow all
+	request_header_access Cache-Control allow all
+	request_header_access Content-Length allow all
+	request_header_access Content-Type allow all
+	request_header_access Date allow all
+	request_header_access Host allow all
+	request_header_access If-Modified-Since allow all
+	request_header_access Pragma allow all
+	request_header_access Accept allow all
+	request_header_access Accept-Charset allow all
+	request_header_access Accept-Encoding allow all
+	request_header_access Accept-Language allow all
+	request_header_access Connection allow all
+	request_header_access All deny all
+
+	# Disable cache
+	cache deny all
+
+	# Deny everything else
+	http_access deny all
+	EOF"
+}
+
+# Parse command line arguments
+while getopts ":dlh" opt; do
+	case ${opt} in
+	d)
+		# Install squid and make a backup of the config file
+		sudo apt-get update
+		sudo apt-get install -y squid
+		sudo cp /etc/squid/squid.conf /etc/squid/squid.conf.bak
+
+		# Read the listening IP addresses from user input
+		while true; do
+			read -p "Enter the IP address of your Block Producer: " ip
+			BLOCK_PRODUCER_IP+=("${ip}")
+			read -p "Are there more block producers? (y/n) " yn
+			case ${yn} in
+			[Nn]*) break ;;
+			*) continue ;;
+			esac
+		done
+
+		# Read the listening port from user input
+		read -p "Enter the relays listening port (only one port is supported, 3132 suggested): " RELAY_LISTENING_PORT
+		generate_squid_conf
+
+		# Restart squid and check status
+		sudo systemctl restart squid
+		sudo systemctl status squid
+
+		# Inform the user to create the appropriate firewall rule
+		for ip in "${RELAY_LISTENING_IP[@]}"; do
+			echo "Create the appropriate firewall rule: sudo ufw allow from ${ip} to any port ${RELAY_LISTENING_PORT} proto tcp"
+		done
+		;;
+	l)
+		# Install nginx and configure load balancing
+		sudo apt-get update
+		sudo apt-get install -y nginx
+
+		# Read the listening IP addresses from user input
+		while true; do
+			read -p "Enter the IP address of a relay: " ip
+			RELAY_LISTENING_IP+=("${ip}")
+			read -p "Are there more relays? (y/n) " yn
+			case ${yn} in
+			[Nn]*) break ;;
+			*) continue ;;
+			esac
+		done
+
+		# Read the listening IP for the load balancer
+		read -p "Enter the IP address of the load balancer: " SIDECAR_LISTENING_IP
+
+		# Read the listening port from user input
+		read -p "Enter the relays listening port (only one port is supported and will also be used for the local load balancer, 3132 suggested): " RELAY_LISTENING_PORT
+
+		# Generate the nginx configuration file
+		generate_nginx_conf
+		# Restart nginx and check status
+		sudo systemctl restart nginx
+		sudo systemctl status nginx
+		;;
+	h)
+		usage
+		exit 0
+		;;
+	\?)
+		echo "Invalid option: -${OPTARG}" >&2
+		usage
+		exit 1
+		;;
+	:)
+		echo "Option -${OPTARG} requires an argument." >&2
+		usage
+		exit 1
+		;;
+	esac
+done
+
+# Display usage menu if no flags are provided
+if [[ ${OPTIND} -eq 1 ]]; then
+	usage
+	exit 1
+fi

--- a/scripts/cnode-helper-scripts/mithril-relay.sh
+++ b/scripts/cnode-helper-scripts/mithril-relay.sh
@@ -1,9 +1,26 @@
 #!/bin/bash
 
-# Default values
+######################################
+# User Variables - Change as desired #
+# Common variables set in env file   #
+######################################
+
+RELAY_LISTENING_PORT=3132
+
+######################################
+# Do NOT modify code below           #
+######################################
+
+#####################
+# Constants         #
+#####################
+
 BLOCK_PRODUCER_IP=()
 RELAY_LISTENING_IP=()
-RELAY_LISTENING_PORT=3132
+
+#####################
+# Functions         #
+#####################
 
 # Usage menu
 usage() {
@@ -14,6 +31,7 @@ usage() {
 		Cardano Mithril relay wrapper script!!
 		-d  Install squid and configure as a relay
 		-l  Install nginx and configure as a load balancer
+		-h  Show this help text
 		
 		EOF
 }
@@ -106,7 +124,7 @@ generate_squid_conf() {
 }
 
 # Parse command line arguments
-while getopts ":dlh" opt; do
+while getopts :dlh opt; do
   case ${opt} in
     d)
       # Install squid and make a backup of the config file
@@ -117,9 +135,9 @@ while getopts ":dlh" opt; do
 
       # Read the listening IP addresses from user input
       while true; do
-        read -p "Enter the IP address of your Block Producer: " ip
+        read -r -p "Enter the IP address of your Block Producer: " ip
         BLOCK_PRODUCER_IP+=("${ip}")
-        read -p "Are there more block producers? (y/n) " yn
+        read -r -p "Are there more block producers? (y/n) " yn
         case ${yn} in
           [Nn]*) break ;;
               *) continue ;;
@@ -127,7 +145,7 @@ while getopts ":dlh" opt; do
       done
 
       # Read the listening port from user input
-      read -p "Enter the relay's listening port (press Enter to use default 3132): " RELAY_LISTENING_PORT
+      read -r -p "Enter the relay's listening port (press Enter to use default 3132): " RELAY_LISTENING_PORT
       RELAY_LISTENING_PORT=${RELAY_LISTENING_PORT:-3132}
       echo "Using port ${RELAY_LISTENING_PORT} for relay's listening port."
       generate_squid_conf
@@ -150,9 +168,9 @@ while getopts ":dlh" opt; do
 
       # Read the listening IP addresses from user input
       while true; do
-        read -p "Enter the IP address of a relay: " ip
+        read -r -p "Enter the IP address of a relay: " ip
         RELAY_LISTENING_IP+=("${ip}")
-        read -p "Are there more relays? (y/n) " yn
+        read -r -p "Are there more relays? (y/n) " yn
         case ${yn} in
           [Nn]*) break ;;
               *) continue ;;
@@ -160,12 +178,12 @@ while getopts ":dlh" opt; do
       done
 
       # Read the listening IP for the load balancer
-      read -p "Enter the IP address of the load balancer (press Enter to use default 127.0.0.1): " SIDECAR_LISTENING_IP
+      read -r -p "Enter the IP address of the load balancer (press Enter to use default 127.0.0.1): " SIDECAR_LISTENING_IP
       SIDECAR_LISTENING_IP=${SIDECAR_LISTENING_IP:-127.0.0.1}
       echo "Using IP address ${SIDECAR_LISTENING_IP} for the load balancer configuration."
 
       # Read the listening port from user input
-      read -p "Enter the relay's listening port (press Enter to use default 3132): " RELAY_LISTENING_PORT
+      read -r -p "Enter the relay's listening port (press Enter to use default 3132): " RELAY_LISTENING_PORT
       RELAY_LISTENING_PORT=${RELAY_LISTENING_PORT:-3132}
       echo "Using port ${RELAY_LISTENING_PORT} for relay's listening port."
 

--- a/scripts/cnode-helper-scripts/mithril-relay.sh
+++ b/scripts/cnode-helper-scripts/mithril-relay.sh
@@ -104,6 +104,7 @@ while getopts ":dlh" opt; do
 	case ${opt} in
 	d)
 		# Install squid and make a backup of the config file
+        echo -e "\nInstalling squid proxy"
 		sudo apt-get update
 		sudo apt-get install -y squid
 		sudo cp /etc/squid/squid.conf /etc/squid/squid.conf.bak
@@ -120,10 +121,13 @@ while getopts ":dlh" opt; do
 		done
 
 		# Read the listening port from user input
-		read -p "Enter the relays listening port (only one port is supported, 3132 suggested): " RELAY_LISTENING_PORT
+		read -p "Enter the relay's listening port (press Enter to use default 3132): " RELAY_LISTENING_PORT
+        RELAY_LISTENING_PORT=${RELAY_LISTENING_PORT:-3132}
+        echo "Using port ${RELAY_LISTENING_PORT} for relay's listening port."
 		generate_squid_conf
 
 		# Restart squid and check status
+        echo -e "\nStarting Mithril relay (squid proxy)"
 		sudo systemctl restart squid
 		sudo systemctl status squid
 
@@ -134,6 +138,7 @@ while getopts ":dlh" opt; do
 		;;
 	l)
 		# Install nginx and configure load balancing
+        echo -e "\nInstalling nginx load balancer"
 		sudo apt-get update
 		sudo apt-get install -y nginx
 
@@ -149,14 +154,19 @@ while getopts ":dlh" opt; do
 		done
 
 		# Read the listening IP for the load balancer
-		read -p "Enter the IP address of the load balancer: " SIDECAR_LISTENING_IP
+        read -p "Enter the IP address of the load balancer (press Enter to use default 127.0.0.1): " SIDECAR_LISTENING_IP
+        SIDECAR_LISTENING_IP=${SIDECAR_LISTENING_IP:-127.0.0.1}
+        echo "Using IP address ${SIDECAR_LISTENING_IP} for the load balancer configuration."
 
 		# Read the listening port from user input
-		read -p "Enter the relays listening port (only one port is supported and will also be used for the local load balancer, 3132 suggested): " RELAY_LISTENING_PORT
+		read -p "Enter the relay's listening port (press Enter to use default 3132): " RELAY_LISTENING_PORT
+        RELAY_LISTENING_PORT=${RELAY_LISTENING_PORT:-3132}
+        echo "Using port ${RELAY_LISTENING_PORT} for relay's listening port."
 
 		# Generate the nginx configuration file
 		generate_nginx_conf
 		# Restart nginx and check status
+        echo -e "\nStarting Mithril relay sidecar (nginx load balancer)"
 		sudo systemctl restart nginx
 		sudo systemctl status nginx
 		;;

--- a/scripts/cnode-helper-scripts/mithril-relay.sh
+++ b/scripts/cnode-helper-scripts/mithril-relay.sh
@@ -7,13 +7,19 @@ RELAY_LISTENING_PORT=3132
 
 # Usage menu
 usage() {
-	echo "Usage: $0 [-d] [-l]"
-	echo "  -d  Install squid and configure as a relay"
-	echo "  -l  Install nginx and configure as a load balancer"
+  cat <<-EOF
+		
+		$(basename "$0") [-d] [-l]
+		
+		Cardano Mithril relay wrapper script!!
+		-d  Install squid and configure as a relay
+		-l  Install nginx and configure as a load balancer
+		
+		EOF
 }
 
 generate_nginx_conf() {
-	sudo bash -c "cat > /etc/nginx/nginx.conf <<'EOF'
+  sudo bash -c "cat > /etc/nginx/nginx.conf <<'EOF'
 worker_processes 1;
 
 events {
@@ -41,21 +47,21 @@ EOF"
 }
 
 generate_squid_conf() {
-	# Write the squid config file
-	sudo bash -c "cat <<-'EOF' > /etc/squid/squid.conf
-	# Listening port (port 3132 is recommended)
-	http_port ${RELAY_LISTENING_PORT}
-	
-	EOF"
+  # Write the squid config file
+  sudo bash -c "cat <<-'EOF' > /etc/squid/squid.conf
+		# Listening port (port 3132 is recommended)
+		http_port ${RELAY_LISTENING_PORT}
+		
+		EOF"
 
-	# Write the ACLs for each relay IP address
-	sudo bash -c 'echo "# ACLs for IP of the block producers" >> /etc/squid/squid.conf'
-	for ip in "${BLOCK_PRODUCER_IP[@]}"; do
-		sudo bash -c "echo \"acl block_producer_ip src ${ip}\" >> /etc/squid/squid.conf"
-	done
+  # Write the ACLs for each relay IP address
+  sudo bash -c 'echo "# ACLs for IP of the block producers" >> /etc/squid/squid.conf'
+  for ip in "${BLOCK_PRODUCER_IP[@]}"; do
+    sudo bash -c "echo \"acl block_producer_ip src ${ip}\" >> /etc/squid/squid.conf"
+  done
 
-	# Write the rest of the squid config file
-	sudo bash -c "cat <<-'EOF' >> /etc/squid/squid.conf
+  # Write the rest of the squid config file
+  sudo bash -c "cat <<-'EOF' >> /etc/squid/squid.conf
 	# ACL for aggregator endpoint
 	acl aggregator_domain dstdomain .mithril.network
 	
@@ -101,94 +107,94 @@ generate_squid_conf() {
 
 # Parse command line arguments
 while getopts ":dlh" opt; do
-	case ${opt} in
-	d)
-		# Install squid and make a backup of the config file
-        echo -e "\nInstalling squid proxy"
-		sudo apt-get update
-		sudo apt-get install -y squid
-		sudo cp /etc/squid/squid.conf /etc/squid/squid.conf.bak
+  case ${opt} in
+    d)
+      # Install squid and make a backup of the config file
+      echo -e "\nInstalling squid proxy"
+      sudo apt-get update
+      sudo apt-get install -y squid
+      sudo cp /etc/squid/squid.conf /etc/squid/squid.conf.bak
 
-		# Read the listening IP addresses from user input
-		while true; do
-			read -p "Enter the IP address of your Block Producer: " ip
-			BLOCK_PRODUCER_IP+=("${ip}")
-			read -p "Are there more block producers? (y/n) " yn
-			case ${yn} in
-			[Nn]*) break ;;
-			*) continue ;;
-			esac
-		done
+      # Read the listening IP addresses from user input
+      while true; do
+        read -p "Enter the IP address of your Block Producer: " ip
+        BLOCK_PRODUCER_IP+=("${ip}")
+        read -p "Are there more block producers? (y/n) " yn
+        case ${yn} in
+          [Nn]*) break ;;
+              *) continue ;;
+        esac
+      done
 
-		# Read the listening port from user input
-		read -p "Enter the relay's listening port (press Enter to use default 3132): " RELAY_LISTENING_PORT
-        RELAY_LISTENING_PORT=${RELAY_LISTENING_PORT:-3132}
-        echo "Using port ${RELAY_LISTENING_PORT} for relay's listening port."
-		generate_squid_conf
+      # Read the listening port from user input
+      read -p "Enter the relay's listening port (press Enter to use default 3132): " RELAY_LISTENING_PORT
+      RELAY_LISTENING_PORT=${RELAY_LISTENING_PORT:-3132}
+      echo "Using port ${RELAY_LISTENING_PORT} for relay's listening port."
+      generate_squid_conf
 
-		# Restart squid and check status
-        echo -e "\nStarting Mithril relay (squid proxy)"
-		sudo systemctl restart squid
-		sudo systemctl status squid
+      # Restart squid and check status
+      echo -e "\nStarting Mithril relay (squid proxy)"
+      sudo systemctl restart squid
+      sudo systemctl status squid
 
-		# Inform the user to create the appropriate firewall rule
-		for ip in "${RELAY_LISTENING_IP[@]}"; do
-			echo "Create the appropriate firewall rule: sudo ufw allow from ${ip} to any port ${RELAY_LISTENING_PORT} proto tcp"
-		done
-		;;
-	l)
-		# Install nginx and configure load balancing
-        echo -e "\nInstalling nginx load balancer"
-		sudo apt-get update
-		sudo apt-get install -y nginx
+      # Inform the user to create the appropriate firewall rule
+      for ip in "${RELAY_LISTENING_IP[@]}"; do
+        echo "Create the appropriate firewall rule: sudo ufw allow from ${ip} to any port ${RELAY_LISTENING_PORT} proto tcp"
+      done
+      ;;
+    l)
+      # Install nginx and configure load balancing
+      echo -e "\nInstalling nginx load balancer"
+      sudo apt-get update
+      sudo apt-get install -y nginx
 
-		# Read the listening IP addresses from user input
-		while true; do
-			read -p "Enter the IP address of a relay: " ip
-			RELAY_LISTENING_IP+=("${ip}")
-			read -p "Are there more relays? (y/n) " yn
-			case ${yn} in
-			[Nn]*) break ;;
-			*) continue ;;
-			esac
-		done
+      # Read the listening IP addresses from user input
+      while true; do
+        read -p "Enter the IP address of a relay: " ip
+        RELAY_LISTENING_IP+=("${ip}")
+        read -p "Are there more relays? (y/n) " yn
+        case ${yn} in
+          [Nn]*) break ;;
+              *) continue ;;
+        esac
+      done
 
-		# Read the listening IP for the load balancer
-        read -p "Enter the IP address of the load balancer (press Enter to use default 127.0.0.1): " SIDECAR_LISTENING_IP
-        SIDECAR_LISTENING_IP=${SIDECAR_LISTENING_IP:-127.0.0.1}
-        echo "Using IP address ${SIDECAR_LISTENING_IP} for the load balancer configuration."
+      # Read the listening IP for the load balancer
+      read -p "Enter the IP address of the load balancer (press Enter to use default 127.0.0.1): " SIDECAR_LISTENING_IP
+      SIDECAR_LISTENING_IP=${SIDECAR_LISTENING_IP:-127.0.0.1}
+      echo "Using IP address ${SIDECAR_LISTENING_IP} for the load balancer configuration."
 
-		# Read the listening port from user input
-		read -p "Enter the relay's listening port (press Enter to use default 3132): " RELAY_LISTENING_PORT
-        RELAY_LISTENING_PORT=${RELAY_LISTENING_PORT:-3132}
-        echo "Using port ${RELAY_LISTENING_PORT} for relay's listening port."
+      # Read the listening port from user input
+      read -p "Enter the relay's listening port (press Enter to use default 3132): " RELAY_LISTENING_PORT
+      RELAY_LISTENING_PORT=${RELAY_LISTENING_PORT:-3132}
+      echo "Using port ${RELAY_LISTENING_PORT} for relay's listening port."
 
-		# Generate the nginx configuration file
-		generate_nginx_conf
-		# Restart nginx and check status
-        echo -e "\nStarting Mithril relay sidecar (nginx load balancer)"
-		sudo systemctl restart nginx
-		sudo systemctl status nginx
-		;;
-	h)
-		usage
-		exit 0
-		;;
-	\?)
-		echo "Invalid option: -${OPTARG}" >&2
-		usage
-		exit 1
-		;;
-	:)
-		echo "Option -${OPTARG} requires an argument." >&2
-		usage
-		exit 1
-		;;
-	esac
+      # Generate the nginx configuration file
+      generate_nginx_conf
+      # Restart nginx and check status
+      echo -e "\nStarting Mithril relay sidecar (nginx load balancer)"
+      sudo systemctl restart nginx
+      sudo systemctl status nginx
+      ;;
+    h)
+      usage
+      exit 0
+      ;;
+    \?)
+      echo "Invalid option: -${OPTARG}" >&2
+      usage
+      exit 1
+      ;;
+    :)
+      echo "Option -${OPTARG} requires an argument." >&2
+      usage
+      exit 1
+      ;;
+    esac
 done
 
 # Display usage menu if no flags are provided
 if [[ ${OPTIND} -eq 1 ]]; then
-	usage
-	exit 1
+  usage
+  exit 1
 fi

--- a/scripts/cnode-helper-scripts/mithril-signer.sh
+++ b/scripts/cnode-helper-scripts/mithril-signer.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2086
+#shellcheck source=/dev/null
+
+. "$(dirname $0)"/env offline
+
+######################################
+# User Variables - Change as desired #
+# Common variables set in env file   #
+######################################
+
+#MITHRILBIN="${HOME}"/.local/bin/mithril-signer # Path for mithril-signer binary, if not in $PATH
+#HOSTADDR=127.0.0.1                             # Default Listen IP/Hostname for Mithril Signer Server
+MITHRIL_HOME="/opt/mithril/mithril-signer"
+
+######################################
+# Do NOT modify code below           #
+######################################
+
+#####################
+# Functions         #
+#####################
+
+usage() {
+  cat <<-EOF
+		
+		Usage: $(basename "$0") [-d] [-u]
+		
+		Cardano Mithril signer wrapper script !!
+		-d    Deploy mithril-signer as a systemd service
+		-u    Update mithril-signer environment file
+		
+		EOF
+  exit 1
+}
+
+set_defaults() {
+  [[ -z "${MITHRILBIN}" ]] && MITHRILBIN="${HOME}"/.local/bin/mithril-signer
+  [[ -z "${MITHRIL_HOME}" ]] && MITHRIL_HOME=/opt/mithril/mithril-signer
+  if [[ -z "${NETWORK}" ]] || [[ -z "${POOL_NAME}" ]] || [[ "${POOL_NAME}" == "CHANGE_ME" ]]; then
+    echo "ERROR: The NETWORK and POOL_NAME must be set before deploying mithril-signer as a systemd service!!"
+    exit 1
+  else
+    case "${NETWORK}" in
+      mainnet|preprod)
+      RELEASE="release"
+      ;;
+      *)
+      RELEASE="pre-release"
+      ;;
+    esac
+  fi
+  [[ -z ${RELEASE} ]] && echo "ERROR: Failed to set RELEASE variable, please check NETWORK variable in env file!!" && exit 1
+}
+
+pre_startup_sanity() {
+  [[ ! -f "${MITHRILBIN}" ]] && MITHRILBIN="$(command -v mithril-signer)"
+  if [[ ! -S "${CARDANO_NODE_SOCKET_PATH}" ]]; then
+    echo "ERROR: Could not locate socket file at ${CARDANO_NODE_SOCKET_PATH}, the node may not have completed startup !!"
+    exit 1
+  fi
+  # Move logs to archive
+  [[ -f "${LOG_DIR}"/mithril-signer.log ]] && mv "${LOG_DIR}"/mithril-signer.log "${LOG_DIR}"/archive/
+}
+
+generate_environment_file() {
+  ERA_READER_ADDRESS=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK}/era.addr
+  ERA_READER_VKEY=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK}/era.vkey
+  sudo bash -c "cat <<-'EOF' > ${MITHRIL_HOME}/service.env
+  AGGREGATOR_ENDPOINT=https://aggregator.${RELEASE}-${NETWORK}.api.mithril.network/aggregator
+  KES_SECRET_KEY_PATH=${POOL_DIR}/${POOL_HOTKEY_SK_FILENAME}
+  OPERATIONAL_CERTIFICATE_PATH=${POOL_DIR}/${POOL_OPCERT_FILENAME}
+  PARTY_ID=$(cat ${POOL_DIR}/${POOL_ID_FILENAME})
+  DB_DIRECTORY=${CNODE_HOME}/db
+  CARDANO_CLI_PATH=${HOME}/.local/bin/cardano-cli
+  DATA_STORES_DIRECTORY=${MITHRIL_HOME}/data-stores
+  ERA_READER_ADAPTER_TYPE=cardano-chain
+  ERA_READER_ADDRESS=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK}/era.addr
+  ERA_READER_VKEY=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK}/era.vkey
+  ERA_READER_ADAPTER_PARAMS=$(jq -nc --arg address $(wget -q -O - "${ERA_READER_ADDRESS}") --arg verification_key $(wget -q -O - "${ERA_READER_VKEY}") '{"address": $address, "verification_key": $verification_key}')
+  GENESIS_VERIFICATION_KEY=$(curl -s https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK}/genesis.vkey)
+EOF"
+}
+
+deploy_systemd() {
+  echo "Creating ${CNODE_VNAME}-mithril-signer systemd service environment file.."
+  if [[ ! -f "${MITHRIL_HOME}"/service.env ]]; then
+    generate_environment_file && echo "Environment file created successfully!!"
+  fi
+
+  echo "Deploying ${CNODE_VNAME}-mithril-signer as systemd service.."
+  sudo bash -c "cat <<-'EOF' > /etc/systemd/system/${CNODE_VNAME}-mithril-signer.service
+    [Unit]
+    Description=Cardano Mithril signer service
+    StartLimitIntervalSec=0
+	Wants=network-online.target
+	After=network-online.target
+
+    [Service]
+    Type=simple
+    Restart=always
+    RestartSec=5
+    User=${USER}
+    EnvironmentFile=${MITHRIL_HOME}/service.env
+    ExecStart=/bin/bash -l -c \"exec ${HOME}/.local/bin/mithril-signer -vv
+	KillSignal=SIGINT
+	SuccessExitStatus=143
+	StandardOutput=syslog
+	StandardError=syslog
+	SyslogIdentifier=${CNODE_VNAME}-mithril-signer
+	TimeoutStopSec=5
+	KillMode=mixed
+
+    [Install]
+    WantedBy=multi-user.target
+EOF" && echo "${CNODE_VNAME}-mithril-signer.service deployed successfully!!" && sudo systemctl daemon-reload && sudo systemctl enable ${CNODE_VNAME}-mithril-signer.service
+}
+
+###################
+# Execution       #
+###################
+
+# Parse command line options
+while getopts :du opt; do
+  case ${opt} in
+    d ) DEPLOY_SYSTEMD="Y" ;;
+    u ) UPDATE_ENVIRONMENT="Y" ;;
+    \? ) usage ;;
+  esac
+done
+
+# Check if env file is missing in current folder (no update checks as will mostly run as daemon), source env if present
+[[ ! -f "$(dirname $0)"/env ]] && echo -e "\nCommon env file missing, please ensure latest guild-deploy.sh was run and this script is being run from ${CNODE_HOME}/scripts folder! \n" && exit 1
+. "$(dirname $0)"/env
+case $? in
+  1) echo -e "ERROR: Failed to load common env file\nPlease verify set values in 'User Variables' section in env file or log an issue on GitHub" && exit 1;;
+  2) clear ;;
+esac
+
+# Set defaults and do basic sanity checks
+set_defaults
+#Deploy systemd if -d argument was specified
+if [[ "${DEPLOY_SYSTEMD}" == "Y" ]]; then
+  deploy_systemd && exit 0
+  exit 2
+elif [[ "${UPDATE_ENVIRONMENT}" == "Y" ]]; then
+  generate_environment_file && echo "Environment file updated successfully!!" && exit 0
+  exit 2
+elif [[ "${UPDATE_ENVIRONMENT}" == "Y" ]] && [[ "${DEPLOY_SYSTEMD}" == "Y" ]]; then
+  generate_environment_file && deploy_systemd && exit 0
+  exit 2
+fi
+
+pre_startup_sanity
+
+# Run Mithril Signer Server
+echo "Sourcing the Mithril Signer environment file.."
+. "${MITHRIL_HOME}"/service.env
+echo "Starting Mithril Signer Server.."
+"${MITHRILBIN}" -vvv >> "${LOG_DIR}"/mithril-signer.log 2>&1

--- a/scripts/cnode-helper-scripts/mithril-signer.sh
+++ b/scripts/cnode-helper-scripts/mithril-signer.sh
@@ -28,9 +28,9 @@ usage() {
 		Cardano Mithril signer wrapper script !!
 		-d    Deploy mithril-signer as a systemd service
 		-u    Update mithril environment file
+		-h    Show this help text
 		
 		EOF
-  exit 1
 }
 
 set_defaults() {
@@ -148,11 +148,24 @@ deploy_systemd() {
 ###################
 
 # Parse command line options
-while getopts :du opt; do
+while getopts :duh opt; do
   case ${opt} in
     d ) DEPLOY_SYSTEMD="Y" ;;
     u ) UPDATE_ENVIRONMENT="Y" ;;
-    \? ) usage ;;
+    h)
+      usage
+      exit 0
+      ;;
+    \?)
+      echo "Invalid option: -${OPTARG}" >&2
+      usage
+      exit 1
+      ;;
+    :)
+      echo "Option -${OPTARG} requires an argument." >&2
+      usage
+      exit 1
+      ;;
   esac
 done
 

--- a/scripts/cnode-helper-scripts/mithril-signer.sh
+++ b/scripts/cnode-helper-scripts/mithril-signer.sh
@@ -77,7 +77,7 @@ generate_environment_file() {
 	ERA_READER_VKEY=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK}/era.vkey
 	ERA_READER_ADAPTER_PARAMS=$(jq -nc --arg address $(wget -q -O - "${ERA_READER_ADDRESS}") --arg verification_key $(wget -q -O - "${ERA_READER_VKEY}") '{"address": $address, "verification_key": $verification_key}')
 	GENESIS_VERIFICATION_KEY=$(curl -s https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK}/genesis.vkey)
-	EOF"
+	EOF" && sudo chown $USER:$USER "${CNODE_HOME}"/mithril-signer/service.env
 }
 
 deploy_systemd() {

--- a/scripts/cnode-helper-scripts/mithril-signer.sh
+++ b/scripts/cnode-helper-scripts/mithril-signer.sh
@@ -67,19 +67,19 @@ generate_environment_file() {
   ERA_READER_ADDRESS=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK}/era.addr
   ERA_READER_VKEY=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK}/era.vkey
   sudo bash -c "cat <<-'EOF' > ${MITHRIL_HOME}/service.env
-  AGGREGATOR_ENDPOINT=https://aggregator.${RELEASE}-${NETWORK}.api.mithril.network/aggregator
-  KES_SECRET_KEY_PATH=${POOL_DIR}/${POOL_HOTKEY_SK_FILENAME}
-  OPERATIONAL_CERTIFICATE_PATH=${POOL_DIR}/${POOL_OPCERT_FILENAME}
-  PARTY_ID=$(cat ${POOL_DIR}/${POOL_ID_FILENAME})
-  DB_DIRECTORY=${CNODE_HOME}/db
-  CARDANO_CLI_PATH=${HOME}/.local/bin/cardano-cli
-  DATA_STORES_DIRECTORY=${MITHRIL_HOME}/data-stores
-  ERA_READER_ADAPTER_TYPE=cardano-chain
-  ERA_READER_ADDRESS=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK}/era.addr
-  ERA_READER_VKEY=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK}/era.vkey
-  ERA_READER_ADAPTER_PARAMS=$(jq -nc --arg address $(wget -q -O - "${ERA_READER_ADDRESS}") --arg verification_key $(wget -q -O - "${ERA_READER_VKEY}") '{"address": $address, "verification_key": $verification_key}')
-  GENESIS_VERIFICATION_KEY=$(curl -s https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK}/genesis.vkey)
-EOF"
+	AGGREGATOR_ENDPOINT=https://aggregator.${RELEASE}-${NETWORK}.api.mithril.network/aggregator
+	KES_SECRET_KEY_PATH=${POOL_DIR}/${POOL_HOTKEY_SK_FILENAME}
+	OPERATIONAL_CERTIFICATE_PATH=${POOL_DIR}/${POOL_OPCERT_FILENAME}
+	PARTY_ID=$(cat ${POOL_DIR}/${POOL_ID_FILENAME})
+	DB_DIRECTORY=${CNODE_HOME}/db
+	CARDANO_CLI_PATH=${HOME}/.local/bin/cardano-cli
+	DATA_STORES_DIRECTORY=${MITHRIL_HOME}/data-stores
+	ERA_READER_ADAPTER_TYPE=cardano-chain
+	ERA_READER_ADDRESS=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK}/era.addr
+	ERA_READER_VKEY=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK}/era.vkey
+	ERA_READER_ADAPTER_PARAMS=$(jq -nc --arg address $(wget -q -O - "${ERA_READER_ADDRESS}") --arg verification_key $(wget -q -O - "${ERA_READER_VKEY}") '{"address": $address, "verification_key": $verification_key}')
+	GENESIS_VERIFICATION_KEY=$(curl -s https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK}/genesis.vkey)
+	EOF"
 }
 
 deploy_systemd() {
@@ -90,19 +90,19 @@ deploy_systemd() {
 
   echo "Deploying ${CNODE_VNAME}-mithril-signer as systemd service.."
   sudo bash -c "cat <<-'EOF' > /etc/systemd/system/${CNODE_VNAME}-mithril-signer.service
-    [Unit]
-    Description=Cardano Mithril signer service
-    StartLimitIntervalSec=0
+	[Unit]
+	Description=Cardano Mithril signer service
+	StartLimitIntervalSec=0
 	Wants=network-online.target
 	After=network-online.target
-
-    [Service]
-    Type=simple
-    Restart=always
-    RestartSec=5
-    User=${USER}
-    EnvironmentFile=${MITHRIL_HOME}/service.env
-    ExecStart=/bin/bash -l -c \"exec ${HOME}/.local/bin/mithril-signer -vv\"
+	
+	[Service]
+	Type=simple
+	Restart=always
+	RestartSec=5
+	User=${USER}
+	EnvironmentFile=${MITHRIL_HOME}/service.env
+	ExecStart=/bin/bash -l -c \"exec ${HOME}/.local/bin/mithril-signer -vv\"
 	KillSignal=SIGINT
 	SuccessExitStatus=143
 	StandardOutput=syslog
@@ -110,10 +110,10 @@ deploy_systemd() {
 	SyslogIdentifier=${CNODE_VNAME}-mithril-signer
 	TimeoutStopSec=5
 	KillMode=mixed
-
-    [Install]
-    WantedBy=multi-user.target
-EOF" && echo "${CNODE_VNAME}-mithril-signer.service deployed successfully!!" && sudo systemctl daemon-reload && sudo systemctl enable ${CNODE_VNAME}-mithril-signer.service
+	
+	[Install]
+	WantedBy=multi-user.target
+	EOF" && echo "${CNODE_VNAME}-mithril-signer.service deployed successfully!!" && sudo systemctl daemon-reload && sudo systemctl enable ${CNODE_VNAME}-mithril-signer.service
 }
 
 ###################

--- a/scripts/cnode-helper-scripts/mithril-signer.sh
+++ b/scripts/cnode-helper-scripts/mithril-signer.sh
@@ -63,15 +63,20 @@ pre_startup_sanity() {
 
 get_relay_endpoint() {
   read -p "Enter the IP address of the relay endpoint: " RELAY_ENDPOINT_IP
-  read -p "Enter the port of the relay endpoint: " RELAY_PORT
+  read -p "Enter the port of the relay endpoint (press Enter to use default 3132): " RELAY_PORT
+  RELAY_PORT=${RELAY_PORT:-3132}
+  echo "Using RELAY_ENDPOINT=${RELAY_ENDPOINT_IP}:${RELAY_PORT} for the Mithril signer relay endpoint."
 }
 
 generate_environment_file() {
   # Inquire about the relay endpoint
-  read -p "Are you using a relay endpoint? (y/n): " ENABLE_RELAY_ENDPOINT
-    if [[ "${ENABLE_RELAY_ENDPOINT}" == "y" ]]; then
-        get_relay_endpoint
-    fi
+  read -p "Are you using a relay endpoint? (y/n, press Enter to use default y): " ENABLE_RELAY_ENDPOINT
+  ENABLE_RELAY_ENDPOINT=${ENABLE_RELAY_ENDPOINT:-y}
+  if [[ "${ENABLE_RELAY_ENDPOINT}" == "y" ]]; then
+    get_relay_endpoint
+  else
+    echo "Using a naive Mithril configuration without a relay for testnets and devnets."
+  fi
 
   ERA_READER_ADDRESS=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK}/era.addr
   ERA_READER_VKEY=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK}/era.vkey

--- a/scripts/cnode-helper-scripts/mithril-signer.sh
+++ b/scripts/cnode-helper-scripts/mithril-signer.sh
@@ -102,7 +102,7 @@ deploy_systemd() {
     RestartSec=5
     User=${USER}
     EnvironmentFile=${MITHRIL_HOME}/service.env
-    ExecStart=/bin/bash -l -c \"exec ${HOME}/.local/bin/mithril-signer -vv
+    ExecStart=/bin/bash -l -c \"exec ${HOME}/.local/bin/mithril-signer -vv\"
 	KillSignal=SIGINT
 	SuccessExitStatus=143
 	StandardOutput=syslog

--- a/scripts/cnode-helper-scripts/mithril-signer.sh
+++ b/scripts/cnode-helper-scripts/mithril-signer.sh
@@ -65,18 +65,22 @@ generate_environment_file() {
   ERA_READER_ADDRESS=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK}/era.addr
   ERA_READER_VKEY=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK}/era.vkey
   sudo bash -c "cat <<-'EOF' > ${CNODE_HOME}/mithril-signer/service.env
-	AGGREGATOR_ENDPOINT=https://aggregator.${RELEASE}-${NETWORK}.api.mithril.network/aggregator
 	KES_SECRET_KEY_PATH=${POOL_DIR}/${POOL_HOTKEY_SK_FILENAME}
 	OPERATIONAL_CERTIFICATE_PATH=${POOL_DIR}/${POOL_OPCERT_FILENAME}
-	PARTY_ID=$(cat ${POOL_DIR}/${POOL_ID_FILENAME})
+	NETWORK=${NETWORK}
+	AGGREGATOR_ENDPOINT=https://aggregator.${RELEASE}-${NETWORK}.api.mithril.network/aggregator
+	RUN_INTERVAL=60000
 	DB_DIRECTORY=${CNODE_HOME}/db
+	CARDANO_NODE_SOCKET_PATH=${CARDANO_NODE_SOCKET_PATH}
 	CARDANO_CLI_PATH=${HOME}/.local/bin/cardano-cli
 	DATA_STORES_DIRECTORY=${CNODE_HOME}/mithril-signer/data-stores
+	STORE_RETENTION_LIMITS=5
 	ERA_READER_ADAPTER_TYPE=cardano-chain
 	ERA_READER_ADDRESS=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK}/era.addr
 	ERA_READER_VKEY=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK}/era.vkey
 	ERA_READER_ADAPTER_PARAMS=$(jq -nc --arg address $(wget -q -O - "${ERA_READER_ADDRESS}") --arg verification_key $(wget -q -O - "${ERA_READER_VKEY}") '{"address": $address, "verification_key": $verification_key}')
 	GENESIS_VERIFICATION_KEY=$(curl -s https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK}/genesis.vkey)
+	PARTY_ID=$(cat ${POOL_DIR}/${POOL_ID_FILENAME})
 	EOF" && sudo chown $USER:$USER "${CNODE_HOME}"/mithril-signer/service.env
 }
 

--- a/scripts/cnode-helper-scripts/mithril-signer.sh
+++ b/scripts/cnode-helper-scripts/mithril-signer.sh
@@ -97,6 +97,8 @@ deploy_systemd() {
 	StartLimitIntervalSec=0
 	Wants=network-online.target
 	After=network-online.target
+	BindsTo=${vname}.service
+	After=${vname}.service
 	
 	[Service]
 	Type=simple


### PR DESCRIPTION
Adds support to download, install, and set up a mithril-signer for the appropriate network. Includes changes to `deploy-as-systemd.sh` to provide an option to run it as a Systemd service. 

## New scripts

### `mithril-client.sh` 
* Opt `-d` downloads the latest mithril snapshot
  * If the environment file does not exist it will create it.
* Opt `-u` creates or updates the environment file.
  * If the POOL_NAME is undefined or **CHANGE_ME** will create a minimal environment suitable for mithril client
  * If the POOL_NAME is defined will create a complete environment suitable for mithril signer
    * Presumes a naive deployment without mithril relay for automated environment setup on first start
    * Use either `deploy-as-systemd.sh`, or `mithril-signer.sh -u` directly, to define a complex mithril environment with a mithril relay (or the sidecar)

### `mithril-signer.sh` 
* follows the `ogmios.sh` format such that it can be used to start the mithril signer.
* Opt `-d` sets up the Systemd service unit.
  * If the environment file does not exist it will create it.
* Opt `-u` creates or updates the environment file.
  * uses read to determine if naive deployment or use a mithril relay (or the sidecar) IP and port to set RELAY_ENDPOINT

### `mithril-relay.sh`
* Opt `-d`
  * installs squid
  * uses read to gather variables for block producer IP and relay port.
  * Creates a squid.conf for a reverse proxy.
    * applies an ACL in the config for each block producer.
  * Starts the squid systemd service.
* Opt `-l`
  * installs nginx
  * uses read to gather variables for relay IP address(es), relay port, and IP to bind sidecar  (Relay port shared between all relays and sidecar)
  * Creates an nginx.conf load balancing over relays.
  * starts nginx systems service.
## Additional Details
* Increases storage requirements for binaries by ~42MB.
* Currently uses a static `mithril_release` set to **2337.0**.
  * Includes a commented-out option to obtain the latest release via tag_name, similar to cardano-signer.
  * Open to the preferred method suggested.

The mithril relay and squid configuration comes from Mithril docs. The HA setup via an nginx sidecar is a Proof of Concept at the moment. I have tested with a single relay, but not yet with the sidecar and multiple relays.