### PR TITLE
Update premerge.yml

### DIFF
--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -30,6 +30,7 @@ jobs:
         swap-size-mb: 1024
         remove-dotnet: 'true'
         remove-android: 'true'
+        remove-haskell: ' true'
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:

--- a/.github/workflows/premerge.yml
+++ b/.github/workflows/premerge.yml
@@ -23,21 +23,13 @@ jobs:
       BRANCH: ${{ github.event.inputs.branch || '' }}
     if: github.event.pull_request.draft == false
     steps:
-    - name: Provide additional free space
-      run: |
-        # Workaround to provide additional free space for builds.
-        #   https://github.com/actions/virtual-environments/issues/2840
-        sudo apt-get update -y
-        sudo apt-get remove -y '^dotnet-.*'
-        sudo apt-get remove -y 'php.*'
-        sudo apt-get remove -y azure-cli google-cloud-sdk google-chrome-stable firefox powershell mono-devel
-        sudo apt-get autoremove -y
-        sudo apt-get clean
-        sudo rm -rf "/usr/share/dotnet"
-        sudo rm -rf "/usr/local/lib/android"
-        sudo rm -rf "/opt/ghc"
-        sudo rm -rf "/usr/local/share/boost"
-        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+    - name: Maximize build space
+      uses: easimon/maximize-build-space@master
+      with:
+        root-reserve-mb: 512
+        swap-size-mb: 1024
+        remove-dotnet: 'true'
+        remove-android: 'true'
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v2
       with:


### PR DESCRIPTION
The provide additional free space step fails. Subset of packages no longer installed with ubuntu-latest.

This PR will change from the manual space cleanup to the marketplace action [mazimize-build-disk-space](https://github.com/marketplace/actions/maximize-build-disk-space).

## Description
The branch migrates the cleanup of space for pre-merge into a published GitHub action.

## Where should the reviewer start?
Review the #1693 Checks that failed during the step to provide additional space, specifically when Google Cloud SDK is no longer found to be installed, causing the entire pre-merge workflow to fail.

## Motivation and context
Continue to check that changes to `guild-deploy.sh` do not break any supported OS.

## Which issue it fixes?
No issue opened, yet.

## How has this been tested?
With this workflow job https://github.com/cardano-community/guild-operators/actions/runs/6605316164 
