### PR TITLE
Mithril mkdir in scripts for existing deployments

### DIFF
--- a/scripts/cnode-helper-scripts/mithril-client.sh
+++ b/scripts/cnode-helper-scripts/mithril-client.sh
@@ -176,6 +176,10 @@ while getopts :duh opt; do
       usage
       exit 1
       ;;
+    *)
+      usage
+      exit 1
+      ;;
   esac
 done
 

--- a/scripts/cnode-helper-scripts/mithril-client.sh
+++ b/scripts/cnode-helper-scripts/mithril-client.sh
@@ -15,6 +15,9 @@
 # Do NOT modify code below           #
 ######################################
 
+U_ID=$(id -u)
+G_ID=$(id -g)
+
 #####################
 # Functions         #
 #####################
@@ -34,6 +37,10 @@ usage() {
 
 
 generate_environment_file() {
+  if [[ ! -d "${CNODE_HOME}/mithril/data-stores" ]]; then
+    sudo mkdir -p "${CNODE_HOME}"/mithril/data-stores
+    sudo chown -R "$U_ID":"$G_ID" "${CNODE_HOME}"/mithril 2>/dev/null
+  fi
   if [[ -n "${POOL_NAME}" ]] && [[ "${POOL_NAME}" != "CHANGE_ME" ]]; then
     export ERA_READER_ADDRESS=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/era.addr
     export ERA_READER_VKEY=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/era.vkey

--- a/scripts/cnode-helper-scripts/mithril-relay.sh
+++ b/scripts/cnode-helper-scripts/mithril-relay.sh
@@ -208,6 +208,10 @@ while getopts :dlh opt; do
       usage
       exit 1
       ;;
+    *)
+      usage
+      exit 1
+      ;;
     esac
 done
 

--- a/scripts/cnode-helper-scripts/mithril-signer.sh
+++ b/scripts/cnode-helper-scripts/mithril-signer.sh
@@ -16,6 +16,9 @@
 # Do NOT modify code below           #
 ######################################
 
+U_ID=$(id -u)
+G_ID=$(id -g)
+
 #####################
 # Functions         #
 #####################
@@ -71,6 +74,10 @@ get_relay_endpoint() {
 }
 
 generate_environment_file() {
+  if [[ ! -d "${CNODE_HOME}/mithril/data-stores" ]]; then
+    sudo mkdir -p "${CNODE_HOME}"/mithril/data-stores
+    sudo chown -R "$U_ID":"$G_ID" "${CNODE_HOME}"/mithril 2>/dev/null
+  fi
   # Inquire about the relay endpoint
   read -r -p "Are you using a relay endpoint? (y/n, press Enter to use default y): " ENABLE_RELAY_ENDPOINT
   ENABLE_RELAY_ENDPOINT=${ENABLE_RELAY_ENDPOINT:-y}


### PR DESCRIPTION
Both mithril-signer and mithril-client will check for directory existence before generating the mithril environment file. If the directory does not exist it will `mkdir -p` and `chown -R`. 