### PR TITLE
CRB repo installation for RHEL 9

### DIFF
--- a/scripts/cnode-helper-scripts/guild-deploy.sh
+++ b/scripts/cnode-helper-scripts/guild-deploy.sh
@@ -216,9 +216,9 @@ os_dependencies() {
       if [[ "${DISTRO}" =~ Rocky ]]; then
         #RockyLinux 8/9
         pkg_list="${pkg_list} --enablerepo=devel,crb libusbx ncurses-compat-libs pkgconf-pkg-config"
-      elif [[ "${DISTRO}" =~ "Red Hat" ]] || [[ "${VERSION_ID}" =~ "8" ]]; then
+      elif [[ "${DISTRO}" =~ "Red Hat" ]] && [[ "${VERSION_ID}" =~ "8" ]]; then
         pkg_list="${pkg_list} --enablerepo=codeready-builder-for-rhel-8-x86_64-rpms libusbx ncurses-compat-libs pkgconf-pkg-config"
-      elif [[ "${DISTRO}" =~ "Red Hat" ]] || [[ "${VERSION_ID}" =~ "9" ]]; then
+      elif [[ "${DISTRO}" =~ "Red Hat" ]] && [[ "${VERSION_ID}" =~ "9" ]]; then
         pkg_list="${pkg_list} --enablerepo=codeready-builder-for-rhel-9-x86_64-rpms libusbx ncurses-compat-libs pkgconf-pkg-config"
       fi
     elif [[ "${DISTRO}" =~ Fedora ]]; then

--- a/scripts/cnode-helper-scripts/guild-deploy.sh
+++ b/scripts/cnode-helper-scripts/guild-deploy.sh
@@ -216,10 +216,8 @@ os_dependencies() {
       if [[ "${DISTRO}" =~ Rocky ]]; then
         #RockyLinux 8/9
         pkg_list="${pkg_list} --enablerepo=devel,crb libusbx ncurses-compat-libs pkgconf-pkg-config"
-      elif [[ "${DISTRO}" =~ "Red Hat" ]] && [[ "${VERSION_ID}" =~ "8" ]]; then
-        pkg_list="${pkg_list} --enablerepo=codeready-builder-for-rhel-8-x86_64-rpms libusbx ncurses-compat-libs pkgconf-pkg-config"
-      elif [[ "${DISTRO}" =~ "Red Hat" ]] && [[ "${VERSION_ID}" =~ "9" ]]; then
-        pkg_list="${pkg_list} --enablerepo=codeready-builder-for-rhel-9-x86_64-rpms libusbx ncurses-compat-libs pkgconf-pkg-config"
+      elif [[ "${DISTRO}" =~ "Red Hat" ]]; then
+        pkg_list="${pkg_list} --enablerepo=codeready-builder-for-rhel-${VERSION_ID/.*/}-x86_64-rpms libusbx ncurses-compat-libs pkgconf-pkg-config"
       fi
     elif [[ "${DISTRO}" =~ Fedora ]]; then
       #Fedora


### PR DESCRIPTION
## Description
Changes the Line 219 and 221 tests from `||` to `&&`, making the test for rhel 9 reachable.

## Where should the reviewer start?
Line 219 & 221 changed. Full review requires a Red Hat subscription (developer subscriptions are fine too) and registering the system via `subscription-manager` before running `guild-deploy.sh`.

## Motivation and context
Fixing the codeready builder repository for RHEL 9. 

## Which issue it fixes?
Closes #1701 

## How has this been tested?
Fresh RHEL 9 VM created, registered w/ developer subscription enabling only the initial **rhel-9-for-x86_64-baseos-rpms** and **rhel-9-for-x86_64-appstream-rpms** default repositories. Then `./guild-deploy.sh -b rhel-9-crb-repo -s pld` used to test the branch.

```
[guild@rhel92 tmp]$ ./guild-deploy.sh -b rhel-9-crb-repo -s pld

Preparing OS dependency packages for "Red Hat Enterprise Linux" system

  Updating system packages...

  Enabling epel repository...

  Symlink updates not required for ncurse libs, skipping..

  Installing missing prerequisite packages, if any..
Importing GPG key 0x3228467C:
 Userid     : "Fedora (epel9) <epel@fedoraproject.org>"
 Fingerprint: FF8A D134 4597 106E CE81 3B91 8A38 72BF 3228 467C
 From       : /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-9

Installing Haskell build/compiler dependencies (if missing)...

Installing ghcup (The Haskell Toolchain installer) ..

[Re]-Install libsecp256k1 ...

libsecp256k1 installed to /usr/local/lib/

Building libsodium ...

IOG fork of libsodium installed to /usr/local/lib/

Creating Folder Structure ..

Setting up Environment Variable

Downloading files...

Downloading binaries..

  Downloading Cardano Node archive created from IO CI builds..

  Downloading Github release package for Cardano Wallet

  Downloading Cardano DB Sync archive created from IO CI Builds..
```
