### PR TITLE
remove (redundant) chmod in step 12, keep chmod in step 20

### DIFF
--- a/files/docker/node/dockerfile_bin
+++ b/files/docker/node/dockerfile_bin
@@ -64,8 +64,7 @@ RUN set -x && export SUDO='N' \
     && chmod 755 tcpping \
     && chown -R guild:guild $CNODE_HOME \
     && mv /root/.local/bin /home/guild/.local/ \
-    && chown -R guild:guild /home/guild/.* \
-    && chmod a+x /home/guild/.scripts/*.sh /opt/cardano/cnode/scripts/*.sh
+    && chown -R guild:guild /home/guild/.*
 
 # Add final tools in a separate layer to shrink the largest layer
 RUN apt-get update \


### PR DESCRIPTION
## Description
Removes the redundant `chown` from step 12, relying on the final chown in step 20.

## Where should the reviewer start?
Compare the two builds

## Motivation and context
An error in build process when no shell scripts exist in `/home/guild/.scripts/` when the operation occurs.

## Which issue it fixes?
Closes #1709

## How has this been tested?
Local build
