### PR TITLE
Add new inputs to workflow summary and correct conditional statement.

### DIFF
--- a/.github/workflows/docker_bin.yml
+++ b/.github/workflows/docker_bin.yml
@@ -36,7 +36,7 @@ jobs:
           --file files/docker/node/dockerfile_bin \
           --compress \
           --build-arg G_ACCOUNT=${{ env.G_ACCOUNT }} \
-          --build-arg GUILD_DEPLOY_BRANCH=${{ env.guild_deploy_branch }} \
+          --build-arg GUILD_DEPLOY_BRANCH=${{ github.event.inputs.guild_deploy_branch }} \
           --tag ${{ env.REGISTRY }}/${{ secrets.DOCKER_USER }}/cardano-node:latest
         # Workaround to provide additional free space for builds.
         #   https://github.com/actions/virtual-environments/issues/2840
@@ -53,7 +53,7 @@ jobs:
         sudo rm -rf "/usr/local/share/boost"
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
     - name: docker push latest
-      if: env.testing == 'false' && env.guild_deploy_branch == 'master'
+      if: github.event.inputs.testing == 'false' && github.event.inputs.guild_deploy_branch == 'master'
       run: |
         CNVERSION=`cat files/docker/node/release-versions/cardano-node-latest.txt`
         docker push ${{ env.REGISTRY }}/${{ secrets.DOCKER_USER }}/cardano-node:latest
@@ -65,4 +65,6 @@ jobs:
         echo "## Summary Details" >> $GITHUB_STEP_SUMMARY
         echo "* Docker Image: ${{ env.REGISTRY }}/${{ secrets.DOCKER_USER }}/cardano-node:${{ env.CNVERSION }}" >> $GITHUB_STEP_SUMMARY
         echo "* G_ACCOUNT: ${GITHUB_REPOSITORY_OWNER}" >> $GITHUB_STEP_SUMMARY
+        echo "* GUILD_DEPLOY_BRANCH: ${{ github.event.inputs.guild_deploy_branch }}" >> $GITHUB_STEP_SUMMARY
+        echo "* Push to GA Registry: $(if [[ '${{ github.event.inputs.testing }}' == 'true' ]]; then echo 'false'; else echo 'true'; fi)" >> $GITHUB_STEP_SUMMARY
         echo "* CNVERSION: ${{ env.CNVERSION }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker_bin.yml
+++ b/.github/workflows/docker_bin.yml
@@ -30,6 +30,7 @@ jobs:
       run: |
         echo "G_ACCOUNT=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
         echo "CNVERSION=$(cat files/docker/node/release-versions/cardano-node-latest.txt)" >> $GITHUB_ENV
+        echo "PUSH_TO_GA=false" >> $GITHUB_ENV
     - name: Compiling new node software suite
       run: |
         DOCKER_BUILDKIT=1 docker build . \
@@ -56,6 +57,7 @@ jobs:
       if: github.event.inputs.testing == 'false' && github.event.inputs.guild_deploy_branch == 'master'
       run: |
         CNVERSION=`cat files/docker/node/release-versions/cardano-node-latest.txt`
+        echo "PUSH_TO_GA=true" >> $GITHUB_ENV
         docker push ${{ env.REGISTRY }}/${{ secrets.DOCKER_USER }}/cardano-node:latest
         docker tag ${{ env.REGISTRY }}/${{ secrets.DOCKER_USER }}/cardano-node:latest ${{ secrets.DOCKER_USER }}/cardano-node:${{ env.CNVERSION }}
         docker push ${{ env.REGISTRY }}/${{ secrets.DOCKER_USER }}/cardano-node:${{ env.CNVERSION }}
@@ -66,5 +68,5 @@ jobs:
         echo "* Docker Image: ${{ env.REGISTRY }}/${{ secrets.DOCKER_USER }}/cardano-node:${{ env.CNVERSION }}" >> $GITHUB_STEP_SUMMARY
         echo "* G_ACCOUNT: ${GITHUB_REPOSITORY_OWNER}" >> $GITHUB_STEP_SUMMARY
         echo "* GUILD_DEPLOY_BRANCH: ${{ github.event.inputs.guild_deploy_branch }}" >> $GITHUB_STEP_SUMMARY
-        echo "* Push to GA Registry: $(if [[ '${{ github.event.inputs.testing }}' == 'true' ]]; then echo 'false'; else echo 'true'; fi)" >> $GITHUB_STEP_SUMMARY
+        echo "* Push to GA Registry: ${{ env.PUSH_TO_GA }}" >> $GITHUB_STEP_SUMMARY
         echo "* CNVERSION: ${{ env.CNVERSION }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Description
Use correct syntax to access workflow input variables for Docker Image workflow. Adds GUILD_DEPLOY_BRANCH and Push to GA Registry as the inverse of **testing** boolean.

## Where should the reviewer start?
Check job summaries from the **How has this been tested?** section.

## Motivation and context
Fixes a mistake in the if condition for the push and adds the details to the summary output.

## Which issue it fixes?
N/A / CI

## How has this been tested?
Jobs: 
* Inputs: [branch:alpha, testing=true](https://github.com/cardano-community/guild-operators/actions/runs/7015236578) 
  * Step **docker push latest** not run
  * Summary **Push to GA Registry** False
* Inputs: [branch:alpha, testing=false](https://github.com/cardano-community/guild-operators/actions/runs/7015458964/job/19084816266)
  * Step **docker push latest** not run
  * Summary **Push to GA Registry** False
* Inputs: [branch:master, testing=true](https://github.com/cardano-community/guild-operators/actions/runs/7015459989)
  * Step **docker push latest** not run
  * Summary **Push to GA Registry** False
* Inputs: [branch:master, testing=false](https://github.com/cardano-community/guild-operators/actions/runs/7015483984)
  * Step **docker push latest** run
  * Summary **Push to GA Registry** True