### PR TITLE
Mithril latest releases

### DIFF
--- a/.github/workflows/docker_bin.yml
+++ b/.github/workflows/docker_bin.yml
@@ -15,6 +15,7 @@ on:
   push:
     paths:
       - 'files/docker/node/release-versions/cardano-node-latest.txt'
+      - 'files/docker/node/release-versions/mithril-latest.txt'
       
 jobs:
   build:

--- a/.github/workflows/mithril-latest.yml
+++ b/.github/workflows/mithril-latest.yml
@@ -1,0 +1,30 @@
+name: Get latest Mithril release version
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 0 * * *'
+jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.REPO_SCOPED_TOKEN }}
+          fetch-depth: 0
+          ref: alpha
+      - name: Fetch Mithril release version
+        run: |
+          curl -sL https://api.github.com/repos/input-output-hk/mithril/releases/latest | jq -r '.tag_name' tag_name > files/docker/node/release-versions/mithril-latest.txt
+      - name: Assigns release version
+        run: |
+          VERSION=$(cat ./files/docker/node/release-versions/mithril-latest.txt)
+      - name: Check for modified files
+        id: git-check
+        run: echo ::set-output name=modified::$([ -z "`git status --porcelain`" ] && echo "false" || echo "true")
+      - name: Commit latest release version
+        if: steps.git-check.outputs.modified == 'true'
+        run: |
+          git config --global user.name ${{ secrets.REPO_SCOPED_USER }}
+          git config --global user.email ${{ secrets.REPO_SCOPED_EMAIL }}
+          git commit -am "New mithril release version ${VERSION}"
+          git push

--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -59,7 +59,7 @@ setTheme() {
 # Do NOT modify code below           #
 ######################################
 
-GLV_VERSION=v1.28.1
+GLV_VERSION=v1.28.2
 
 PARENT="$(dirname $0)"
 
@@ -823,7 +823,7 @@ while true; do
       cpu_util="0.0"
     fi
     if [[ ${about_to_lead} -gt 0 ]]; then
-      [[ ${nodemode} != "Core" ]] && clrScreen && nodemode="Core"
+      [[ ${nodemode} != "Core" ]] && nodemode="Core" && getOpCert && clrScreen
     else
       [[ ${nodemode} != "Relay" ]] && clrScreen && nodemode="Relay"
     fi

--- a/scripts/cnode-helper-scripts/guild-deploy.sh
+++ b/scripts/cnode-helper-scripts/guild-deploy.sh
@@ -493,10 +493,7 @@ download_cardanosigner() {
 download_mithril() {
     echo -e "\nDownloading Mithril..."
     pushd "${HOME}"/tmp >/dev/null || err_exit
-    # dynamic latest release updated automatically, uncomment and comment out the hardcoded release below if needed
-    # mithril_release="$(curl -s https://api.github.com/repos/input-output-hk/mithril/releases/latest | jq -r '.tag_name')"
-    # hardcoded latest release requiring a bump
-    mithril_release="2342.0"
+    mithril_release="$(curl -s https://api.github.com/repos/input-output-hk/mithril/releases/latest | jq -r '.tag_name')"
     echo -e "\n  Downloading Mithril Signer/Client ${mithril_release}..."
     rm -f mithril-signer mithril-client
     curl -m 200 -sfL https://github.com/input-output-hk/mithril/releases/download/${mithril_release}/mithril-${mithril_release}-linux-x64.tar.gz -o mithril.tar.gz || err_exit " Could not download mithril's latest release archive from IO github!"


### PR DESCRIPTION
## Description
1. Creates a workflow to obtain the latest mithril release `mithril-latest.yml`
2. Changes `guild-deploy.sh` from the static version bump for mithril to obtaining the latest release.
3. Triggers the **Docker Image** workflow (`dockerfile_bin.yml`) when a push changes `files/docker/node/release-versions/mithril-latest.txt`.

## Where should the reviewer start?
Testing via `./guild-deploy.sh -b mithril-latest-releases -s m` should update the `mithril-client --version` output to `0.5.5+0780dfa`

## Motivation and context
Breaking changes between mithril release v2342.0 and v2347.0. Once the latest snaphot is signed by v2347.0 the v2342.0 client no longer works (for the latest snapshot).

## Which issue it fixes?
Closes #1714

## How has this been tested?
Running the current guild cardano-node:latest container, running `/opt/cardano/cnode/scripts/guild-deploy.sh -b mithril-latest-releases -s m` twice, once to update script the second to install Mithril's latest release. Then 
```
./mithril-client.sh -d
INFO: The db directory does not exist..
INFO: Downloading latest mithril snapshot..
1/6 - Checking local disk info…
2/6 - Fetching the certificate's information…
3/6 - Verifying the certificate chain…
4/6 - Downloading and unpacking the snapshot…
⠁ [00:02:13] [###########>----------------------------------------------------------------------------------------------------------------------------------------] 3.17 GiB/39.08 GiB (1468.8s)
```
confirming the download starts without certificate errors.
