### PR TITLE
Update protectionPreRequisites For Use w/o CHATTR

### DIFF
--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -149,6 +149,7 @@ protectionPreRequisites() {
     fi
     rm -f "${TMP_DIR}"/test
   fi
+  return 0
 }
 
 # Command     : safeDel [path]


### PR DESCRIPTION
## Description
Update protectionPreRequisites For Use w/o CHATTR command available
Adds a return 0 if we reach eventually the end of the func.

## Where should the reviewer start?
cntools.sh -o w/o chattr and ENABLE_CHATTR false

## Motivation and context
cntools.sh -o w/o chattr and ENABLE_CHATTR false does not work
protectionPreRequisites returns non ZERO code if 
- ENABLE_CHATTR false
 - chattr not available  Because [ false == true ] (L139) will return a non zero rc. 

## Which issue it fixes?
n/a

## How has this been tested?
[cntools.sh -o w/o chattr and ENABLE_CHATTR false] is launching OK up to the main menu.
