### PR TITLE
Repo from input-output-hk to IntersectMBO

### DIFF
--- a/docs/Build/node-cli.md
+++ b/docs/Build/node-cli.md
@@ -9,19 +9,19 @@ Execute the below to clone the cardano-node repository to `$HOME/git` folder on 
 
 ``` bash
 cd ~/git
-git clone https://github.com/input-output-hk/cardano-node
+git clone https://github.com/IntersectMBO/cardano-node
 cd cardano-node
 ```
 
 #### Build Cardano Node
 
-You can use the instructions below to build the latest release of [cardano-node](https://github.com/input-output-hk/cardano-node). 
+You can use the instructions below to build the latest release of [cardano-node](https://github.com/IntersectMBO/cardano-node). 
 
 ``` bash
 git fetch --tags --all
 git pull
 # Replace tag against checkout if you do not want to build the latest released version
-git checkout $(curl -s https://api.github.com/repos/input-output-hk/cardano-node/releases/latest | jq -r .tag_name)
+git checkout $(curl -s https://api.github.com/repos/IntersectMBO/cardano-node/releases/latest | jq -r .tag_name)
 
 # Use `-l` argument if you'd like to use system libsodium instead of IOG fork of libsodium while compiling
 $CNODE_HOME/scripts/cabal-build-all.sh
@@ -32,7 +32,7 @@ The above would copy the binaries built into `~/.local/bin` folder.
 #### Download pre-compiled Binary from Node release
 
 While certain folks might want to build the node themselves (could be due to OS/arch compatibility, trust factor or customisations), for most it might not make sense to build the node locally.
-Instead, you can download the binaries using [cardano-node release notes](https://github.com/input-output-hk/cardano-node/releases), where-in you can find the download links for every version.
+Instead, you can download the binaries using [cardano-node release notes](https://github.com/IntersectMBO/cardano-node/releases), where-in you can find the download links for every version.
 Once downloaded, you would want to make it available to preferred `PATH` in your environment (if you're asking how - that'd mean you've skipped skillsets mentioned on homepage).
 
 ### Verify


### PR DESCRIPTION

## Description

Update doc to reflect the cardano-node move from input-output-hk to IntersectMBO

## Motivation and context

The main issue is the line
`
git checkout $(curl -s https://api.github.com/repos/input-output-hk/cardano-node/releases/latest | jq -r .tag_name)
`
silently failing. 

`
curl -s https://api.github.com/repos/input-output-hk/cardano-node/releases/latest
`
outputs:
`
{
  "message": "Moved Permanently",
  "url": "https://api.github.com/repositories/188299874/releases/latest",
  "documentation_url": "https://docs.github.com/rest/guides/best-practices-for-using-the-rest-api#follow-redirects"
}
`
which does not contain a tag_name.

`
curl -s https://api.github.com/repos/IntersectMBO/cardano-node/releases/latest | jq -r .tag_name
`
outputs correct tag name:
`8.7.2`


