### PR TITLE
Update dockerfile_bin to use ${GUILD_DEPLOY_BRANCH} instead of master

### DIFF
--- a/files/docker/node/dockerfile_bin
+++ b/files/docker/node/dockerfile_bin
@@ -42,7 +42,7 @@ RUN adduser --disabled-password --gecos '' guild \
 RUN set -x && apt update \
     && apt-get update \
     && mkdir -p /root/.local/bin \
-    && wget https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/master/scripts/cnode-helper-scripts/guild-deploy.sh \
+    && wget https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/${GUILD_DEPLOY_BRANCH}/scripts/cnode-helper-scripts/guild-deploy.sh \
     && export SUDO='N' \
     && export UPDATE_CHECK='N' \
     && export SKIP_DBSYNC_DOWNLOAD='Y' \
@@ -89,15 +89,15 @@ RUN  curl -sL -H "Accept: application/vnd.github.everest-preview+json" -H "Conte
 
 
 # ENTRY SCRIPT
-ADD https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/master/files/docker/node/addons/banner.txt \
-    https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/master/files/docker/node/addons/guild-topology.sh \
-    https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/master/files/docker/node/addons/block_watcher.sh \
-    https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/master/files/docker/node/addons/healthcheck.sh /home/guild/.scripts/
-ADD https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/master/scripts/cnode-helper-scripts/guild-deploy.sh \
-    https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/master/scripts/cnode-helper-scripts/mithril-client.sh \
-    https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/master/scripts/cnode-helper-scripts/mithril-signer.sh \
-    https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/master/scripts/cnode-helper-scripts/mithril-relay.sh /opt/cardano/cnode/scripts/
-ADD https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/master/files/docker/node/addons/entrypoint.sh ./
+ADD https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/${GUILD_DEPLOY_BRANCH}/files/docker/node/addons/banner.txt \
+    https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/${GUILD_DEPLOY_BRANCH}/files/docker/node/addons/guild-topology.sh \
+    https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/${GUILD_DEPLOY_BRANCH}/files/docker/node/addons/block_watcher.sh \
+    https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/${GUILD_DEPLOY_BRANCH}/files/docker/node/addons/healthcheck.sh /home/guild/.scripts/
+ADD https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/${GUILD_DEPLOY_BRANCH}/scripts/cnode-helper-scripts/guild-deploy.sh \
+    https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/${GUILD_DEPLOY_BRANCH}/scripts/cnode-helper-scripts/mithril-client.sh \
+    https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/${GUILD_DEPLOY_BRANCH}/scripts/cnode-helper-scripts/mithril-signer.sh \
+    https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/${GUILD_DEPLOY_BRANCH}/scripts/cnode-helper-scripts/mithril-relay.sh /opt/cardano/cnode/scripts/
+ADD https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/${GUILD_DEPLOY_BRANCH}/files/docker/node/addons/entrypoint.sh ./
 
 RUN sudo chmod a+rx /home/guild/.scripts/*.sh /opt/cardano/cnode/scripts/*.sh /home/guild/entrypoint.sh \
     && sudo chown -R guild:guild /home/guild/.* $CNODE_HOME


### PR DESCRIPTION
## Description
Changes `files/docker/node/dockerfile_bin` to always rely on the GUILD_DEPLOY_BRANCH for the `guild-deploy.sh` file as well as the configuration files. 

## Where should the reviewer start?


## Motivation and context
Changes merged altering `config-mainnet.json` to `files/config/mainnet/config.json` leads to failures to build the image. Can be observed in [this job run](https://github.com/cardano-community/guild-operators/actions/runs/7690838700). 
Changing `dockerfile_bin` to use the **GUILD_DEPLOY_BRANCH** does work. It also ensures a container that is intended to test a specific set of changes obtains the **addons**, **scripts**, or **entrypoint.sh** for the container from the same branch intended for testing.


## Which issue it fixes?
Didn't open an issue, just created the branch and tested the fix. Can open one if we want the PR to track closing an issue.

## How has this been tested?
The working job from this branch can be observed in [this job run](https://github.com/cardano-community/guild-operators/actions/runs/7690854231).

