### PR TITLE
Initialize LD_LIBRARY_PATH earlier

### DIFF
--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -911,14 +911,14 @@ if [[ -z "${CNCLI}" ]]; then
   CNCLI=$(command -v cncli) || CNCLI="${HOME}/.local/bin/cncli"
 fi
 
+[[ -f /usr/local/lib/libsodium.so ]] && export LD_LIBRARY_PATH=/usr/local/lib:"${LD_LIBRARY_PATH}" && PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:"${PKG_CONFIG_PATH}"
+
 node_version="$(${CNODEBIN} version | head -1 | cut -d' ' -f2)"
 cli_version="$(${CCLI} version | head -1 | cut -d' ' -f2)"
 if ! versionCheck "8.7.3" "${node_version}" || ! versionCheck "8.17.0.0" "${cli_version}"; then
   echo -e "\nKoios scripts have now been upgraded to support cardano-node 8.7.x ('${node_version}' found) / cardano-cli 8.17.x.x ('${cli_version}' found).\nPlease update cardano-node binaries (ensure to read release notes and update various configs using guild-deploy (use appropriate options to download/install/overwrite parts you need) or use tagged branches for older node version (eg: ./<script>.sh -b node-8.1.2 to switch scripts to an older branch).\n\n"
   return 1
 fi
-
-[[ -f /usr/local/lib/libsodium.so ]] && export LD_LIBRARY_PATH=/usr/local/lib:"${LD_LIBRARY_PATH}" && PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:"${PKG_CONFIG_PATH}"
 
 if [[ -z "${SOCKET}" ]]; then
   if [[ "$(ps -ef | grep "$(basename ${CNODEBIN}).*.port ${CNODE_PORT}" | grep -v grep)" =~ --socket-path[[:space:]]([^[:space:]]+) ]]; then


### PR DESCRIPTION
Move initialization of LD_LIBRARY_PATH to before node/cli version checks to address the issue of 'error while loading shared libraries: libsecp256k1.so.0: cannot open shared object file: No such file or directory' appearing in service logs on startup/shutdown.

## Description
<!--- Describe your changes -->

## Where should the reviewer start?
<!--- Describe where reviewer should start testing -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->

## Which issue it fixes?
<!--- Link to issue: Closes #issue-number -->

## How has this been tested?
<!--- Describe how you tested changes -->
