### PR TITLE
Ensure CNVERSION matches  GUILD_DEPLOY_BRANCH regardless of the workflow branch.

### DIFF
--- a/.github/workflows/docker_bin.yml
+++ b/.github/workflows/docker_bin.yml
@@ -24,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.inputs.guild_deploy_branch }}
     - name: docker login
       run: |
         docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/docker_bin.yml
+++ b/.github/workflows/docker_bin.yml
@@ -41,7 +41,7 @@ jobs:
         echo "G_ACCOUNT=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
         echo "CNVERSION=$(cat files/docker/node/release-versions/cardano-node-latest.txt)" >> $GITHUB_ENV
         echo "PUSH_TO_GA=false" >> $GITHUB_ENV
-    - name: Compiling new node software suite
+    - name: Docker build container image
       run: |
         DOCKER_BUILDKIT=1 docker build . \
           --file files/docker/node/dockerfile_bin \

--- a/.github/workflows/docker_bin.yml
+++ b/.github/workflows/docker_bin.yml
@@ -77,6 +77,6 @@ jobs:
         echo "## Summary Details" >> $GITHUB_STEP_SUMMARY
         echo "* Docker Image: ${{ env.REGISTRY }}/${{ secrets.DOCKER_USER }}/cardano-node:${{ env.CNVERSION }}" >> $GITHUB_STEP_SUMMARY
         echo "* G_ACCOUNT: ${GITHUB_REPOSITORY_OWNER}" >> $GITHUB_STEP_SUMMARY
-        echo "* GUILD_DEPLOY_BRANCH: ${{ github.event.inputs.guild_deploy_branch }}" >> $GITHUB_STEP_SUMMARY
+        echo "* GUILD_DEPLOY_BRANCH: ${{ env.GUILD_DEPLOY_BRANCH }}" >> $GITHUB_STEP_SUMMARY
         echo "* Push to GA Registry: ${{ env.PUSH_TO_GA }}" >> $GITHUB_STEP_SUMMARY
         echo "* CNVERSION: ${{ env.CNVERSION }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker_bin.yml
+++ b/.github/workflows/docker_bin.yml
@@ -23,9 +23,16 @@ jobs:
       REGISTRY: docker.io
     runs-on: ubuntu-latest
     steps:
+    - name: Set branch name
+      id: vars
+      run: echo ::set-output name=branch::${GITHUB_REF#refs/heads/}
+    - name: Set GUILD_DEPLOY_BRANCH
+      run: echo "GUILD_DEPLOY_BRANCH=${{ github.event_name == 'push' && steps.vars.outputs.branch || github.event.inputs.guild_deploy_branch }}" >> $GITHUB_ENV
+    - name: Set TESTING
+      run: echo "TESTING=${{ github.event_name == 'push' && (steps.vars.outputs.branch != 'master') || github.event.inputs.testing }}" >> $GITHUB_ENV
     - uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.inputs.guild_deploy_branch }}
+        ref: ${{ env.GUILD_DEPLOY_BRANCH }}
     - name: docker login
       run: |
         docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
@@ -40,7 +47,7 @@ jobs:
           --file files/docker/node/dockerfile_bin \
           --compress \
           --build-arg G_ACCOUNT=${{ env.G_ACCOUNT }} \
-          --build-arg GUILD_DEPLOY_BRANCH=${{ github.event.inputs.guild_deploy_branch }} \
+          --build-arg GUILD_DEPLOY_BRANCH=${{ env.GUILD_DEPLOY_BRANCH }} \
           --tag ${{ env.REGISTRY }}/${{ secrets.DOCKER_USER }}/cardano-node:latest
         # Workaround to provide additional free space for builds.
         #   https://github.com/actions/virtual-environments/issues/2840
@@ -57,7 +64,7 @@ jobs:
         sudo rm -rf "/usr/local/share/boost"
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
     - name: docker push latest
-      if: github.event.inputs.testing == 'false' && github.event.inputs.guild_deploy_branch == 'master'
+      if: env.TESTING == 'false' && env.GUILD_DEPLOY_BRANCH == 'master'
       run: |
         CNVERSION=`cat files/docker/node/release-versions/cardano-node-latest.txt`
         echo "PUSH_TO_GA=true" >> $GITHUB_ENV

--- a/.github/workflows/docker_bin.yml
+++ b/.github/workflows/docker_bin.yml
@@ -11,7 +11,7 @@ on:
         description: Testing workflow
         required: false
         type: boolean
-        default: false
+        default: true
   push:
     paths:
       - 'files/docker/node/release-versions/cardano-node-latest.txt'


### PR DESCRIPTION
This change addresses the root cause (edge case) where the tag of the image can drift from the binary version the image contains.

The contained changes result in:
* The worflow dispatch input defaults to testing=True
* CNVERSION should always match the branch the container is being built from.
* When a push occurs:
  * On a testing/feature branch
    * GUILD_DEPLOY_VERSION is set to the testing/feature branch
    * TESTING variable is True
    * Container image is not pushed to docker hub
  * On the master branch (should include merges from alpha to master)
    * GUILD_DEPLOY_VERSION is set to "master"
    * TESTING variable will be False
    * Container image is automatically pushed to docker hub, removing the need for maintainers to do this manually.
* When a workflow dispatch occurs
  * CNVERSION will match the branch from the workflow input guild_deploy_branch, correcting edge case of incorrect image tags.
  * GUILD_DEPLOY_VERSION is set from the workflow input.
  * TESTING is set from the workflow input.
  * Maintainers mist uncheck the **Testing workflow** option to push a container to docker hub, even when **Branch to deploy** is set to master.

closes #1748