### PR TITLE
Container supports UPDATE_CHECK

### DIFF
--- a/files/docker/node/addons/entrypoint.sh
+++ b/files/docker/node/addons/entrypoint.sh
@@ -42,32 +42,22 @@ find /opt/cardano/cnode/files -name "*config*.json" -print0 | xargs -0 sed -i 's
 return 0
 }
 
+load_configs () {
+  cp -rf /conf/"${NETWORK}"/* "$CNODE_HOME"/files/
+}
 
-if [[ "$NETWORK" == "mainnet" ]]; then
-  $CNODE_HOME/scripts/guild-deploy.sh -n mainnet -u -s f > /dev/null 2>&1 \
-  && customise \
-  && exec $CNODE_HOME/scripts/cnode.sh
-elif [[ "$NETWORK" == "preprod" ]]; then
-  $CNODE_HOME/scripts/guild-deploy.sh -n preprod -u -s f > /dev/null 2>&1 \
-  && customise \
-  && exec $CNODE_HOME/scripts/cnode.sh
-elif [[ "$NETWORK" == "preview" ]]; then
-  $CNODE_HOME/scripts/guild-deploy.sh -n preview -u -s f > /dev/null 2>&1 \
-  && customise \
-  && exec $CNODE_HOME/scripts/cnode.sh
-elif [[ "$NETWORK" == "guild-mainnet" ]]; then
-  $CNODE_HOME/scripts/guild-deploy.sh -n mainnet -u -s f > /dev/null 2>&1 \
-  && bash /home/guild/.scripts/guild-topology.sh > /dev/null 2>&1 \
-  && export TOPOLOGY="${CNODE_HOME}/files/guildnet-topology.json" \
-  && customise \
-  && exec $CNODE_HOME/scripts/cnode.sh
-elif [[ "$NETWORK" == "guild" ]]; then
-  $CNODE_HOME/scripts/guild-deploy.sh -n guild -u -s f > /dev/null 2>&1 \
-  && customise \
-  && exec $CNODE_HOME/scripts/cnode.sh
+if [[ -n "${NETWORK}" ]] ; then
+  if [[ "${UPDATE_CHECK}" == "Y" ]] ; then
+    "$CNODE_HOME"/scripts/guild-deploy.sh -n "$NETWORK" -u -s f > /dev/null 2>&1
+  else
+    load_configs
+  fi
 else
   echo "Please set a NETWORK environment variable to one of: mainnet / preview / preprod / guild-mainnet / guild"
   echo "mount a '$CNODE_HOME/priv/files' volume containing: mainnet-config.json, mainnet-shelley-genesis.json, mainnet-byron-genesis.json, and mainnet-topology.json "
   echo "for active nodes set POOL_DIR environment variable where op.cert, hot.skey and vrf.skey files reside. (usually under '${CNODE_HOME}/priv/pool/$POOL_NAME' ) "
   echo "or just set POOL_NAME environment variable (for default path). "
 fi
+
+customise \
+&& exec "$CNODE_HOME"/scripts/cnode.sh

--- a/files/docker/node/addons/entrypoint.sh
+++ b/files/docker/node/addons/entrypoint.sh
@@ -42,7 +42,6 @@ find /opt/cardano/cnode/files -name "*config*.json" -print0 | xargs -0 sed -i 's
 return 0
 }
 
-export UPDATE_CHECK='N'
 
 if [[ "$NETWORK" == "mainnet" ]]; then
   $CNODE_HOME/scripts/guild-deploy.sh -n mainnet -u -s f > /dev/null 2>&1 \

--- a/files/docker/node/dockerfile_bin
+++ b/files/docker/node/dockerfile_bin
@@ -22,7 +22,7 @@ ENV \
     GIT_SSL_CAINFO=/etc/ssl/certs/ca-certificates.crt
 
 RUN apt-get update && apt-get install --no-install-recommends -y locales apt-utils sudo \
-    && apt install -y curl wget gnupg git udev \
+    && apt install -y curl wget gnupg git udev jq \
     && apt-get -y purge \
     && apt-get -y clean \
     && apt-get -y autoremove \
@@ -69,7 +69,7 @@ RUN set -x && export SUDO='N' \
 
 # Add final tools in a separate layer to shrink the largest layer
 RUN apt-get update \
-    && apt-get install -y procps libcap2 libselinux1 libc6 libsodium-dev ncurses-bin iproute2 xz-utils netbase coreutils dnsutils net-tools procps tcptraceroute bc usbip sqlite3 python3 tmux jq ncurses-base libtool autoconf tcptraceroute util-linux less openssl bsdmainutils dialog vim \
+    && apt-get install -y procps libcap2 libselinux1 libc6 libsodium-dev ncurses-bin iproute2 xz-utils netbase coreutils dnsutils net-tools procps tcptraceroute bc usbip sqlite3 python3 tmux ncurses-base libtool autoconf tcptraceroute util-linux less openssl bsdmainutils dialog vim \
     && apt-get -y purge \
     && apt-get -y clean \
     && apt-get -y autoremove \

--- a/files/docker/node/dockerfile_bin
+++ b/files/docker/node/dockerfile_bin
@@ -19,7 +19,8 @@ ENV \
     CNODE_HOME=/opt/cardano/cnode \
     CARDANO_NODE_SOCKET_PATH=$CNODE_HOME/sockets/node.socket \
     PATH=/opt/cardano/cnode/scripts:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/home/guild/.local/bin \
-    GIT_SSL_CAINFO=/etc/ssl/certs/ca-certificates.crt
+    GIT_SSL_CAINFO=/etc/ssl/certs/ca-certificates.crt \
+    UPDATE_CHECK=N
 
 RUN apt-get update && apt-get install --no-install-recommends -y locales apt-utils sudo \
     && apt install -y curl wget gnupg git udev jq \

--- a/files/docker/node/dockerfile_bin
+++ b/files/docker/node/dockerfile_bin
@@ -75,6 +75,15 @@ RUN apt-get update \
     && apt-get -y autoremove \
     && rm -rf /var/lib/apt/lists/*
 
+
+RUN bash -c 'networks=(guild mainnet preprod preview sanchonet); files=({alonzo,byron,conway,shelley}-genesis.json config.json db-sync-config.json topology.json); \
+    for network in "${networks[@]}"; do \
+        mkdir -pv /conf/${network} && \
+        for file in "${files[@]}"; do \
+            curl -s -o /conf/${network}/$file https://raw.githubusercontent.com/'${G_ACCOUNT}'/guild-operators/'${GUILD_DEPLOY_BRANCH}'/files/configs/${network}/${file}; \
+        done; \
+    done'
+
 USER guild
 WORKDIR /home/guild
 
@@ -99,8 +108,8 @@ ADD https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/${GUILD_DEPLO
     https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/${GUILD_DEPLOY_BRANCH}/scripts/cnode-helper-scripts/mithril-relay.sh /opt/cardano/cnode/scripts/
 ADD https://raw.githubusercontent.com/${G_ACCOUNT}/guild-operators/${GUILD_DEPLOY_BRANCH}/files/docker/node/addons/entrypoint.sh ./
 
-RUN sudo chmod a+rx /home/guild/.scripts/*.sh /opt/cardano/cnode/scripts/*.sh /home/guild/entrypoint.sh \
-    && sudo chown -R guild:guild /home/guild/.* $CNODE_HOME
+RUN sudo chmod -R a+rx /home/guild/.scripts/*.sh /opt/cardano/cnode/scripts/*.sh /home/guild/entrypoint.sh /conf \
+    && sudo chown -R guild:guild /home/guild/.* $CNODE_HOME /conf
 
 HEALTHCHECK --start-period=5m --interval=5m --timeout=100s CMD /home/guild/.scripts/healthcheck.sh
 


### PR DESCRIPTION
Implements the UPDATE_CHECK logic for containers.

* Containers are now built with static versions of the configuration files, by default they should always start and work with the built in configs for any network.
* To restore the original behavior and update configs and scripts from cardano-community master branch every time the container starts set the `UPDATE_CHECK=Y` environment variable for the container.

closes #1750