### PR TITLE
[Feature] - gLiveView - Mithril Signer Section

### DIFF
--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -950,6 +950,7 @@ set_default_vars() {
   [[ -z ${ASSET_POLICY_ID_FILENAME} ]] && ASSET_POLICY_ID_FILENAME="policy.id"
   [[ -z ${CIP0094_POLL_URL} ]] && CIP0094_POLL_URL="https://raw.githubusercontent.com/cardano-foundation/CIP-0094-polls/main/networks/polls.json"
   [[ -z ${MITHRIL_DOWNLOAD} ]] && MITHRIL_DOWNLOAD="N"
+  [[ -z ${MITHRIL_SIGNER_ENABLED} ]] && MITHRIL_SIGNER_ENABLED="N"
   [[ -z ${STRICT_VERSION_CHECK} ]] && STRICT_VERSION_CHECK="Y"
   FG_BLACK='\e[30m'
   FG_RED='\e[31m'

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -110,6 +110,7 @@
 #CIP0094_POLL_URL="https://raw.githubusercontent.com/cardano-foundation/CIP-0094-polls/main/networks/polls.json" # URL for polls to vote against
 
 #MITHRIL_DOWNLOAD="N"                                   # (Y|N) Download latest Mithril snapshot
+#MITHRIL_SIGNER_ENABLED="N"                             # (Y|N) Enable the gLiveView Mithril Signer Section
 
 #STRICT_VERSION_CHECK="Y"                               # (Y|N) Restrict operation to supported major.minor version leaving patch version open. If disabled, any version will be accepted (unsupported)
 

--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -261,6 +261,7 @@ if [[ ${LEGACY_MODE} = "true" ]]; then
   propdivider=$(printf "${NC}|- ${style_info}BLOCK PROPAGATION${NC} " && printf "%0.s-" $(seq $((width-21))) && printf "|")
   resourcesdivider=$(printf "${NC}|- ${style_info}NODE RESOURCE USAGE${NC} " && printf "%0.s-" $(seq $((width-23))) && printf "|")
   blockdivider=$(printf "${NC}|- ${style_info}BLOCK PRODUCTION${NC} " && printf "%0.s-" $(seq $((width-20))) && printf "|")
+  mithrildivider=$(printf "${NC}|- ${style_info}MITHRIL SIGNER${NC} " && printf "%0.s-" $(seq $((width-18))) && printf "|")
   blank_line=$(printf "${NC}|%$((width-1))s|" "")
 else
   VL=$(printf "${NC}\\u2502")
@@ -283,6 +284,7 @@ else
   propdivider=$(printf "${NC}\\u2502- ${style_info}BLOCK PROPAGATION${NC} " && printf "%0.s-" $(seq $((width-21))) && printf "\\u2502")
   resourcesdivider=$(printf "${NC}\\u2502- ${style_info}NODE RESOURCE USAGE${NC} " && printf "%0.s-" $(seq $((width-23))) && printf "\\u2502")
   blockdivider=$(printf "${NC}\\u2502- ${style_info}BLOCK PRODUCTION${NC} " && printf "%0.s-" $(seq $((width-20))) && printf "\\u2502")
+  mithrildivider=$(printf "${NC}\\u2502- ${style_info}MITHRIL SIGNER${NC} " && printf "%0.s-" $(seq $((width-18))) && printf "\\u2502")
   blank_line=$(printf "${NC}\\u2502%$((width-1))s\\u2502" "")
 fi
 
@@ -401,7 +403,7 @@ clrLine () {
 # Command    : clrScreen
 # Description: clear the screen, move to (0,0), and reset screen update counter
 clrScreen () {
-  clear
+  printf "\033[2J"
   screen_upd_cnt=0
 }
 
@@ -767,6 +769,21 @@ tcols=$(tput cols)   # set initial terminal columns
 printf "${NC}"       # reset and set default color
 
 unset cpu_now cpu_last
+
+####################################
+# Mithril Signer Section Variables #
+####################################
+
+# mithril.env sourcing needed to have values in ${METRICS_SERVER_IP} and ${METRICS_SERVER_PORT}
+. ${CNODE_HOME}/mithril/mithril.env
+
+serviceExists=$(systemctl list-units --type=service --all | grep -q ${CNODE_VNAME}-mithril-signer.service; echo $?)
+
+mithrilSignerVars() {
+signerServiceStatus=$(systemctl status ${CNODE_VNAME}-mithril-signer.service 2>/dev/null | grep 'Active:' | awk '{print $3}' | sed 's/[()]//g')
+metricsEnabled=$(grep -q "ENABLE_METRICS_SERVER=true" ${CNODE_HOME}/mithril/mithril.env && echo "true" || echo "false")
+mithrilSignerMetrics=$(curl -s "http://${METRICS_SERVER_IP}:${METRICS_SERVER_PORT}/metrics" 2>/dev/null | grep -v -E "HELP|TYPE" | sed 's/mithril_signer_//g')
+}
 
 #####################################
 # MAIN LOOP                         #
@@ -1428,6 +1445,70 @@ while true; do
       fi
     fi
   fi
+
+      # Mithril Signer Section
+      mithrilSignerVars
+
+      if [[ "$nodemode" = "Core" ]] && [[ "$serviceExists" -eq 0 ]] && [[ "$signerServiceStatus" == "running" ]] && [[ "$metricsEnabled" == "true" ]]; then
+
+        printf "${mithrildivider}\n" && ((line++))
+
+        get_metric_value() {
+            local metric_name="$1"
+            local metric_value
+            while IFS= read -r line; do
+                if [[ $line =~ $metric_name[[:space:]]+([0-9]+) ]]; then
+                    metric_value="${BASH_REMATCH[1]}"
+                    echo "$metric_value"
+                    return
+                fi
+            done <<< "$mithrilSignerMetrics"
+        }
+
+        metrics=(
+            "runtime_cycle_total_since_startup"
+            "signer_registration_success_last_epoch"
+            "signer_registration_success_since_startup"
+            "signer_registration_total_since_startup"
+            "signature_registration_success_last_epoch"
+            "signature_registration_success_since_startup"
+            "signature_registration_total_since_startup"
+        )
+
+        cycle_total_VAL=$(get_metric_value "runtime_cycle_total_since_startup")
+        signer_reg_epoch_VAL=$(get_metric_value "signer_registration_success_last_epoch")
+        signer_reg_success_VAL=$(get_metric_value "signer_registration_success_since_startup")
+        signer_reg_total_VAL=$(get_metric_value "signer_registration_total_since_startup")
+        signatures_epoch_VAL=$(get_metric_value "signature_registration_success_last_epoch")
+        signatures_reg_success_VAL=$(get_metric_value "signature_registration_success_since_startup")
+        signatures_reg_total_VAL=$(get_metric_value "signature_registration_total_since_startup")
+
+        if [[ ${VERBOSE} = "Y" ]]; then
+          printf "${VL} Status     : ${style_values_2}%-${three_col_1_value_width}s${NC}" "$signerServiceStatus"
+          printf "           : Registered Epoch     : ${style_values_1}%-${three_col_1_value_width}s${NC}" "$signer_reg_epoch_VAL"
+          closeRow
+          printf "${VL} Cycles     : ${style_values_1}%-${three_col_1_value_width}s${NC}" "$cycle_total_VAL"
+          printf "           : Signing in Epoch     : ${style_values_2}%-${three_col_1_value_width}s${NC}" "$signatures_epoch_VAL"
+          closeRow
+          printf "${VL} Signatures : ${style_values_2}%-${three_col_1_value_width}s${NC}" "$signatures_reg_success_VAL"
+          printf "           : Total Signatures     : ${style_values_1}%-${three_col_1_value_width}s${NC}" "$signatures_reg_total_VAL"
+          closeRow
+          printf "${VL} Registered : ${style_values_1}%-${three_col_1_value_width}s${NC}" "$signer_reg_success_VAL"
+          printf "           : Registered Total     : ${style_values_1}%-${three_col_1_value_width}s${NC}" "$signer_reg_total_VAL"
+          closeRow
+        else
+          printf "${VL} Status     : ${style_values_2}%-${three_col_1_value_width}s${NC}" "$signerServiceStatus"
+          printf "           : Registered Epoch     : ${style_values_1}%-${three_col_1_value_width}s${NC}" "$signer_reg_epoch_VAL"
+          closeRow
+          printf "${VL} Cycles     : ${style_values_1}%-${three_col_1_value_width}s${NC}" "$cycle_total_VAL"
+          printf "           : Signing in Epoch     : ${style_values_2}%-${three_col_1_value_width}s${NC}" "$signatures_epoch_VAL"
+          closeRow
+          printf "${VL} Signatures : ${style_values_2}%-${three_col_1_value_width}s${NC}" "$signatures_reg_success_VAL"
+          printf "           : Total Signatures     : ${style_values_1}%-${three_col_1_value_width}s${NC}" "$signatures_reg_total_VAL"
+          closeRow
+        fi
+      fi
+
 
   [[ ${check_peers} = "true" ]] && check_peers=false && show_peers=true && clrScreen && continue
 

--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -1461,7 +1461,7 @@ while true; do
       # Mithril Signer Section
       mithrilSignerVars
 
-      if [[ "$nodemode" = "Core" ]] && [[ "$serviceExists" -eq 0 ]] && [[ "$signerServiceStatus" == "running" ]] && [[ "$metricsEnabled" == "true" ]]; then
+      if [[ "${MITHRIL_SIGNER_ENABLED}" == "Y" ]] ; then
 
         printf "${mithrildivider}\n" && ((line++))
 

--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -774,9 +774,6 @@ unset cpu_now cpu_last
 # Mithril Signer Section Variables #
 ####################################
 
-# mithril.env sourcing needed to have values in ${METRICS_SERVER_IP} and ${METRICS_SERVER_PORT}
-. ${CNODE_HOME}/mithril/mithril.env
-
 mithrilSignerVars() {
   # Require MITHRIL_SIGNER_ENABLED or do not proceed to source files or check ports.
   if [[ "${MITHRIL_SIGNER_ENABLED}" == "Y" ]] ; then

--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -403,7 +403,7 @@ clrLine () {
 # Command    : clrScreen
 # Description: clear the screen, move to (0,0), and reset screen update counter
 clrScreen () {
-  printf "\033[2J"
+  clear
   screen_upd_cnt=0
 }
 

--- a/scripts/cnode-helper-scripts/gLiveView.sh
+++ b/scripts/cnode-helper-scripts/gLiveView.sh
@@ -1469,7 +1469,7 @@ while true; do
             local metric_name="$1"
             local metric_value
             while IFS= read -r line; do
-                if [[ $line =~ $metric_name[[:space:]]+([0-9]+) ]]; then
+                if [[ $line =~ ${metric_name}[[:space:]]+([0-9]+) ]]; then
                     metric_value="${BASH_REMATCH[1]}"
                     echo "$metric_value"
                     return

--- a/scripts/cnode-helper-scripts/mithril-signer.sh
+++ b/scripts/cnode-helper-scripts/mithril-signer.sh
@@ -196,7 +196,6 @@ update_check "$@"
 # Set defaults and do basic sanity checks
 set_defaults
 
-
 #Deploy systemd if -d argument was specified
 if [[ "${UPDATE_ENVIRONMENT}" == "Y" ]]; then
   generate_environment_file
@@ -225,9 +224,18 @@ else
     # Run Mithril Signer Server
     echo "Starting Mithril Signer Server.."
     trap 'user_interrupt_received' INT
-    if ! "${MITHRILBIN}" -vv | tee -a "${LOG_DIR}/$(basename "${0::-3}")".log 2>&1 ; then
-      echo "Failed to start Mithril Signer Server" | tee -a "${LOG_DIR}/$(basename "${0::-3}")".log 2>&1
-      exit 1
+
+    if grep -q "ENABLE_METRICS_SERVER=true" ${CNODE_HOME}/mithril/mithril.env; then
+      METRICS_SERVER_PARAMS="--enable-metrics-server --metrics-server-ip ${METRICS_SERVER_IP} --metrics-server-port ${METRICS_SERVER_PORT}"
+      if ! "${MITHRILBIN}" ${METRICS_SERVER_PARAMS} -vv | tee -a "${LOG_DIR}/$(basename "${0::-3}")".log 2>&1 ; then
+        echo "Failed to start Mithril Signer Server with metrics enabled" | tee -a "${LOG_DIR}/$(basename "${0::-3}")".log 2>&1
+        exit 1
+      fi
+    else
+      if ! "${MITHRILBIN}" -vv | tee -a "${LOG_DIR}/$(basename "${0::-3}")".log 2>&1 ; then
+        echo "Failed to start Mithril Signer Server" | tee -a "${LOG_DIR}/$(basename "${0::-3}")".log 2>&1
+        exit 1
+      fi
     fi
   fi
 fi

--- a/scripts/cnode-helper-scripts/mithril-signer.sh
+++ b/scripts/cnode-helper-scripts/mithril-signer.sh
@@ -227,6 +227,8 @@ else
 
     if grep -q "ENABLE_METRICS_SERVER=true" ${CNODE_HOME}/mithril/mithril.env; then
       METRICS_SERVER_PARAMS="--enable-metrics-server --metrics-server-ip ${METRICS_SERVER_IP} --metrics-server-port ${METRICS_SERVER_PORT}"
+      # If ENABLE_METRICS_SERVER is true, then an environment update will enable gLiveView automatically.
+      sudo sed -i 's/#MITHRIL_SIGNER_ENABLED="[YN]"/MITHRIL_SIGNER_ENABLED="Y"/' ${CNODE_HOME}/scripts/env
       if ! "${MITHRILBIN}" ${METRICS_SERVER_PARAMS} -vv | tee -a "${LOG_DIR}/$(basename "${0::-3}")".log 2>&1 ; then
         echo "Failed to start Mithril Signer Server with metrics enabled" | tee -a "${LOG_DIR}/$(basename "${0::-3}")".log 2>&1
         exit 1

--- a/scripts/cnode-helper-scripts/mithril.library
+++ b/scripts/cnode-helper-scripts/mithril.library
@@ -129,6 +129,14 @@ get_relay_endpoint() {
   echo "Using RELAY_ENDPOINT=${RELAY_ENDPOINT_IP}:${RELAY_PORT} for the Mithril signer relay endpoint."
 }
 
+get_metrics_endpoint() {
+  read -r -p "Enter the IP address of the metrics endpoint (press Enter to use default 0.0.0.0): " METRICS_SERVER_IP
+  METRICS_SERVER_IP=${METRICS_SERVER_IP:-0.0.0.0}
+  read -r -p "Enter the port of the metrics endpoint (press Enter to use default 9090): " METRICS_SERVER_PORT
+  METRICS_SERVER_PORT=${METRICS_SERVER_PORT:-9090}
+  echo "Using ${METRICS_SERVER_IP}:${METRICS_SERVER_PORT} for the Mithril signer metrics endpoint."
+}
+
 update_mithril_environment_for_signer() {
   echo "Info: Setting all environment variables, supporting the Mithril signer use case."
   # Inquire about the relay endpoint
@@ -139,6 +147,18 @@ update_mithril_environment_for_signer() {
   else
     echo "Using a naive Mithril configuration without a mithril relay."
   fi
+
+  # Inquire about metrics server
+  read -r -p "Do you want enable prometheus metrics to see mithril-signer information in gLiveView ? (y/n, press Enter to use default y): " ENABLE_MITHRIL_METRICS
+  ENABLE_MITHRIL_METRICS=${ENABLE_MITHRIL_METRICS:-y}
+  if [[ "${ENABLE_MITHRIL_METRICS}" == "y" ]]; then
+    get_metrics_endpoint
+  else
+    echo "Using Mithril configuration without prometheus metrics."
+  fi
+
+
+
   # Generate the full set of environment variables required by Mithril signer use case
   export ERA_READER_ADDRESS=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/era.addr
   export ERA_READER_VKEY=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/era.vkey
@@ -164,6 +184,13 @@ update_mithril_environment_for_signer() {
   if [[ "${ENABLE_RELAY_ENDPOINT}" == "y" ]]; then
     sudo bash -c "echo RELAY_ENDPOINT=http://${RELAY_ENDPOINT_IP}:${RELAY_PORT} >> ${CNODE_HOME}/mithril/mithril.env"
   fi
+
+  if [[ "${ENABLE_MITHRIL_METRICS}" == "y" ]]; then
+    sudo bash -c "echo ENABLE_METRICS_SERVER=true >> ${CNODE_HOME}/mithril/mithril.env"
+    sudo bash -c "echo METRICS_SERVER_IP=${METRICS_SERVER_IP} >> ${CNODE_HOME}/mithril/mithril.env"
+    sudo bash -c "echo METRICS_SERVER_PORT=${METRICS_SERVER_PORT} >> ${CNODE_HOME}/mithril/mithril.env"
+  fi
+
 }
 
 update_mithril_environment_for_client() {

--- a/scripts/cnode-helper-scripts/mithril.library
+++ b/scripts/cnode-helper-scripts/mithril.library
@@ -126,7 +126,7 @@ get_relay_endpoint() {
   read -r -p "Enter the IP address of the relay endpoint: " RELAY_ENDPOINT_IP
   read -r -p "Enter the port of the relay endpoint (press Enter to use default 3132): " RELAY_PORT
   RELAY_PORT=${RELAY_PORT:-3132}
-  echo "Using RELAY_ENDPOINT=${RELAY_ENDPOINT_IP}:${RELAY_PORT} for the Mithril signer relay endpoint."
+  echo "Using RELAY_ENDPOINT=http://${RELAY_ENDPOINT_IP}:${RELAY_PORT} for the Mithril signer relay endpoint."
 }
 
 get_metrics_endpoint() {


### PR DESCRIPTION
Hello CNTools/Koios Team,

I would like to propose the mithril-signer section I added in gLiveView, it can be useful signer monitoring.

All suggestions from previous PR #1786 have been applied.

1. Moving the Registered / Registered Total row to the bottom might make for a better UX experience...
2. Should make this a choice of user input, like ENABLE_RELAY_ENDPOINT...
   The METRICS_SERVER_PORT should also be a choice of user input.
   Also METRICS_SERVER_IP from user input... 
3. Though awk is fairly quick, using bash internal REMATCH is even faster....
4. Could be moved outside of loop to not have to check this on every refresh... 
5. Its also hardcoded for cnode name, please use ${CNODE_VNAME} instead...

gLiveView with new feature has been tested on a relay too.

Thank you,
kind regards,
Manuel

## Description
mithril-signer section for gLiveView

## Updated files:
gLiveView.sh
mithril-signer.sh
mithril.library

## Where should the reviewer start?
on a Block Producer:
- run ./mithril-signer.sh -e to recreate mithril.env with ENABLE_METRICS_SERVER=true and chosen IP:PORT for endpoint
- restart mithril-signer service
- run gLiveView.sh

## Motivation and context
Section has been added to have a clear view of mithril-signer status.

Compact view
![image](https://github.com/user-attachments/assets/3db4f44a-3912-4fe1-b370-fd498ff4f5c6)

Verbose view
![image](https://github.com/user-attachments/assets/862f9812-da22-4c30-938a-de3e3acf85f4)




