### PR TITLE
Update mithril.library to use testing for sanchonet

### DIFF
--- a/scripts/cnode-helper-scripts/mithril.library
+++ b/scripts/cnode-helper-scripts/mithril.library
@@ -83,8 +83,11 @@ set_defaults() {
       mainnet|preprod|guild)
       RELEASE="release"
       ;;
-      preview|sanchonet)
+      preview)
       RELEASE="pre-release"
+      ;;
+      sanchonet)
+      RELEASE="testing"
       ;;
       *)
       echo "ERROR: The NETWORK_NAME must be set to mainnet, preprod, preview, or sanchonet before $(basename "${0::-3}") can be deployed!!"


### PR DESCRIPTION
## Description
A new section for the case statement for sanchonet, setting the RELEASE to testing.

## Motivation and context
Mithril snapshot downloads do not work for sanchonet "out of the box" with the way the environment file is setup to use mithril pre-release naming.

## Which issue it fixes?
Closes #1790
Closes #1765
   * Part A: support for Sanchonet
   * Part B: handling a unique branch for sanchonet to test early mithril releases and early node releases which cntools does not yet support is not included. This part can be handled in a forked repository to not change behaviors intended by cardano-community/guild-operators, or potentially after additional discussions opened in a separate PR.

## How has this been tested?
Modifying mithril.library and running `mithril-client environment update` and examining the `mithril.env` file:

![image](https://github.com/user-attachments/assets/86b6e8fb-7063-4607-ad0d-ef3e9c61d592)

