### PR TITLE
[mithril-client.sh] Use the DB_DIR instead of CNODE_HOME/db

### DIFF
--- a/scripts/cnode-helper-scripts/mithril-client.sh
+++ b/scripts/cnode-helper-scripts/mithril-client.sh
@@ -104,7 +104,7 @@ download_snapshot() {
   if [[ "${DOWNLOAD_SNAPSHOT}" == "Y" ]]; then
     echo "INFO: Downloading latest mithril snapshot.."
     trap 'cleanup_db_directory' INT
-    if ! "${MITHRILBIN}" -v --aggregator-endpoint ${AGGREGATOR_ENDPOINT} cardano-db download --download-dir ${CNODE_HOME} --genesis-verification-key ${GENESIS_VERIFICATION_KEY} ${SNAPSHOT_DIGEST} ; then
+    if ! "${MITHRILBIN}" -v --aggregator-endpoint ${AGGREGATOR_ENDPOINT} cardano-db download --download-dir ${DB_DIRECTORY%/*} --genesis-verification-key ${GENESIS_VERIFICATION_KEY} ${SNAPSHOT_DIGEST} ; then
       cleanup_db_directory
       exit 1
     fi

--- a/scripts/cnode-helper-scripts/mithril-client.sh
+++ b/scripts/cnode-helper-scripts/mithril-client.sh
@@ -104,7 +104,7 @@ download_snapshot() {
   if [[ "${DOWNLOAD_SNAPSHOT}" == "Y" ]]; then
     echo "INFO: Downloading latest mithril snapshot.."
     trap 'cleanup_db_directory' INT
-    if ! "${MITHRILBIN}" -v --aggregator-endpoint ${AGGREGATOR_ENDPOINT} cardano-db download --download-dir ${DB_DIRECTORY%/*} --genesis-verification-key ${GENESIS_VERIFICATION_KEY} ${SNAPSHOT_DIGEST} ; then
+    if ! "${MITHRILBIN}" -v --aggregator-endpoint ${AGGREGATOR_ENDPOINT} cardano-db download --download-dir $(dirname ${DB_DIRECTORY}) --genesis-verification-key ${GENESIS_VERIFICATION_KEY} ${SNAPSHOT_DIGEST} ; then
       cleanup_db_directory
       exit 1
     fi

--- a/scripts/cnode-helper-scripts/mithril-signer.sh
+++ b/scripts/cnode-helper-scripts/mithril-signer.sh
@@ -80,7 +80,7 @@ deploy_systemd() {
 stop_signer() {
   CNODE_PID=$(pgrep -fn "$(basename ${CNODEBIN}).*.--port ${CNODE_PORT}" 2>/dev/null) # env was only called in offline mode
   kill -2 ${CNODE_PID} 2>/dev/null
-  # touch clean "${CNODE_HOME}"/db/clean # Disabled as it's a bit hacky, but only runs when SIGINT is passed to node process. Should not be needed if node does it's job
+  # touch clean "${DB_DIRECTORY}"/clean # Disabled as it's a bit hacky, but only runs when SIGINT is passed to node process. Should not be needed if node does it's job
   echo "  Sending SIGINT to $(basename "${0::-3}") process.."
   sleep 5
   exit 0

--- a/scripts/cnode-helper-scripts/mithril.library
+++ b/scripts/cnode-helper-scripts/mithril.library
@@ -172,7 +172,7 @@ update_mithril_environment_for_signer() {
 		RELEASE=${RELEASE}
 		AGGREGATOR_ENDPOINT=https://aggregator.${RELEASE}-${NETWORK_NAME,,}.api.mithril.network/aggregator
 		RUN_INTERVAL=60000
-		DB_DIRECTORY=${CNODE_HOME}/db
+		DB_DIRECTORY=${DB_DIR}
 		CARDANO_NODE_SOCKET_PATH=${CARDANO_NODE_SOCKET_PATH}
 		CARDANO_CLI_PATH=${HOME}/.local/bin/cardano-cli
 		DATA_STORES_DIRECTORY=${CNODE_HOME}/mithril/data-stores
@@ -202,7 +202,7 @@ update_mithril_environment_for_client() {
 		NETWORK=${NETWORK_NAME,,}
 		RELEASE=${RELEASE}
 		AGGREGATOR_ENDPOINT=https://aggregator.${RELEASE}-${NETWORK_NAME,,}.api.mithril.network/aggregator
-		DB_DIRECTORY=${CNODE_HOME}/db
+		DB_DIRECTORY=${DB_DIR}
 		GENESIS_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/genesis.vkey)
 		SNAPSHOT_DIGEST=latest
 		EOF"


### PR DESCRIPTION
Updates mithril.library to use env DB_DIR value instead of CNODE_HOME/db when creating the mithril.env, and mithril-client.sh to use the DB_DIRECTORY value from the mithril.env file per upstream mithril documentation.