### PR TITLE
Update cntools.sh to include n in getopts and case.

### DIFF
--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -103,7 +103,7 @@ arg_copy=("$@")
 
 while getopts :nolaub:v opt; do
   case ${opt} in
-    n ) : ;;
+    n ) CNTOOLS_MODE="LOCAL" ;;
     o ) CNTOOLS_MODE="OFFLINE" ;;
     l ) CNTOOLS_MODE="LIGHT" ;;
     a ) ADVANCED_MODE="true" ;;

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -101,8 +101,9 @@ PARENT="$(dirname $0)"
 # save launch params
 arg_copy=("$@")
 
-while getopts :olaub:v opt; do
+while getopts :nolaub:v opt; do
   case ${opt} in
+    n ) : ;;
     o ) CNTOOLS_MODE="OFFLINE" ;;
     l ) CNTOOLS_MODE="LIGHT" ;;
     a ) ADVANCED_MODE="true" ;;


### PR DESCRIPTION
## Description
Adds n to getopts and case statement

## Motivation and context
Align the getopts/case statment with the usage menu showing `-n` is an argument, but also the default behavior when no arguments are provided

## Which issue it fixes?
Closes #1802

## How has this been tested?
On a testnet node after adding the same values.
