### PR TITLE
getProtocolParams use CNCLI if ENABLE_KOIOS=N

### DIFF
--- a/scripts/cnode-helper-scripts/cncli.sh
+++ b/scripts/cnode-helper-scripts/cncli.sh
@@ -210,7 +210,9 @@ cncliInit() {
     echo "sleeping for 10s and testing again..."
     sleep 10
   done
-  
+
+  test_koios
+
   TMP_DIR="${TMP_DIR}/cncli"
   if ! mkdir -p "${TMP_DIR}" 2>/dev/null; then echo "ERROR: Failed to create directory for temporary files: ${TMP_DIR}"; exit 1; fi
   

--- a/scripts/cnode-helper-scripts/cncli.sh
+++ b/scripts/cnode-helper-scripts/cncli.sh
@@ -25,7 +25,6 @@
 #CONFIRM_SLOT_CNT=600                     # CNCLI validate: require at least these many slots to have passed before validating
 #CONFIRM_BLOCK_CNT=15                     # CNCLI validate: require at least these many blocks on top of minted before validating
 #BATCH_AUTO_UPDATE=N                      # Set to Y to automatically update the script if a new version is available without user interaction
-#USE_KOIOS_API=Y                          # Use Koios API in cncli leaderlog instead of local stake-snapshot query to reduce system resources. (default true)
 #CNCLI_PROM_PORT=12799                    # Set Prometheus port for cncli block metrics available through metrics operation (default: 12799)
 
 ######################################
@@ -141,7 +140,6 @@ getConsensus() {
 }
 
 getKoiosData() {
-  [[ -z ${KOIOS_API} ]] && return 1
   if ! stake_snapshot=$(curl -sSL -f -d _pool_bech32=${POOL_ID_BECH32} "${KOIOS_API}/pool_stake_snapshot" 2>&1); then
     echo "ERROR: Koios pool_stake_snapshot query failed: curl -sSL -f -d _pool_bech32=${POOL_ID_BECH32} ${KOIOS_API}/pool_stake_snapshot"
     return 1
@@ -223,7 +221,6 @@ cncliInit() {
   [[ -z "${CNCLI_DIR}" ]] && CNCLI_DIR="${CNODE_HOME}/guild-db/cncli"
   if ! mkdir -p "${CNCLI_DIR}" 2>/dev/null; then echo "ERROR: Failed to create CNCLI DB directory: ${CNCLI_DIR}"; exit 1; fi
   CNCLI_DB="${CNCLI_DIR}/cncli.db"
-  [[ -z "${USE_KOIOS_API}" ]] && USE_KOIOS_API=Y
   [[ -z "${CNODE_HOST}" ]] && CNODE_HOST="127.0.0.1"
   [[ -z "${SLEEP_RATE}" ]] && SLEEP_RATE=60
   [[ -z "${CONFIRM_SLOT_CNT}" ]] && CONFIRM_SLOT_CNT=600
@@ -291,7 +288,7 @@ cncliLeaderlog() {
     echo "Leaderlogs already calculated for epoch ${curr_epoch}, skipping!"
   else
     echo "Running leaderlogs for epoch ${curr_epoch}"
-    if [[ ${USE_KOIOS_API} = Y ]]; then 
+    if [[ -n ${KOIOS_API} ]]; then 
       getKoiosData || exit 1
     else
       getLedgerData || exit 1
@@ -363,7 +360,7 @@ cncliLeaderlog() {
         else continue; fi
       fi
       echo "Running leaderlogs for next epoch[${next_epoch}]"
-      if [[ ${USE_KOIOS_API} = Y ]]; then
+      if [[ -n ${KOIOS_API} ]]; then
         if ! getKoiosData; then sleep 60; continue; fi # Sleep for 1 min before retrying to query koios again in case of error
       else
         if ! getLedgerData; then sleep 300; continue; fi # Sleep for 5 min before retrying to query stake snapshot in case of error


### PR DESCRIPTION
## Description
Disables KOIOS access from getProtocolParams if ENABLE_KOIOS is set to N.

## Motivation and context
Found unexpected KOIOS API access when trying to completely disable KOIOS. I had set both ENABLE_KOIOS and USE_KOIOS_API to N, but still found cases where traffic was hitting KOIOS endpoints.

## Which issue it fixes?
Closes #1807

## How has this been tested?
From inside a container using bash -x and capturing stderr to stdout and confirming the curl to cli_protocol_params API route no longer occurs when cncli.sh leaderlog is executed. Also using tcpdump to just examine traffic destined for the IP address of guild.koios.rest.
