### PR TITLE
[mithril] client script adjustments

### DIFF
--- a/scripts/cnode-helper-scripts/cnode.sh
+++ b/scripts/cnode-helper-scripts/cnode.sh
@@ -63,7 +63,7 @@ mithril_snapshot_download() {
   if [[ ! -f "${MITHRIL_CLIENT}" ]] || [[ ! -e "${MITHRIL_CLIENT}" ]]; then 
     echo "ERROR: Could not locate mithril-client.sh script or script is not executable. Skipping mithril cardano-db snapshot download!!"
   else
-    "${MITHRIL_CLIENT}" cardano-db download
+    "${MITHRIL_CLIENT}" -u cardano-db download
   fi
 }
 

--- a/scripts/cnode-helper-scripts/mithril-client.sh
+++ b/scripts/cnode-helper-scripts/mithril-client.sh
@@ -55,10 +55,12 @@ SKIP_UPDATE=N
 #####################
 
 function parse_opt_for_help() {
-  if [[ $1 == "-h" ]] || [[ $1 == "--help" ]] || [[ $@ =~ "-h" ]]; then
+  for value in "$@"; do
+    if [[ $value == "-h" ]] || [[ $value == "--help" ]]; then
       usage
       exit 0
-  fi
+    fi
+  done
 }
 
 function main() {

--- a/scripts/cnode-helper-scripts/mithril-client.sh
+++ b/scripts/cnode-helper-scripts/mithril-client.sh
@@ -20,10 +20,11 @@
 usage() {
   cat <<-EOF
         
-		Usage: $(basename "$0") [-u] <command> <subcommand> [<sub arg>]
+		Usage: $(basename "$0") [-h] [-u] <command> <subcommand> [<sub arg>]
 		A script to run Cardano Mithril Client
 		
-		-u          Skip script update check overriding UPDATE_CHECK value in env (must be first argument to script)
+		[ -h | --help]         Print this help
+		[ -u | --skip-update ] Skip script update check overriding UPDATE_CHECK value in env (must be first argument to script)
 		    
 			Commands:
 			environment           Manage mithril environment file
@@ -46,14 +47,23 @@ EOF
 }
 
 SKIP_UPDATE=N
-[[ $1 = "-u" ]] && export SKIP_UPDATE=Y && shift
+[[ $1 =~ "-u" ]] || [[ $1 =~ "--skip-update" ]] && export SKIP_UPDATE=Y && shift
 
 
 #####################
 # Execution/Main    #
 #####################
 
+function parse_opt_for_help() {
+  if [[ $1 == "-h" ]] || [[ $1 == "--help" ]] || [[ $@ =~ "-h" ]]; then
+      usage
+      exit 0
+  fi
+}
+
 function main() {
+  parse_opt_for_help "$@"
+
   . "$(dirname $0)"/mithril.library
 
   update_check "$@"
@@ -135,9 +145,7 @@ function main() {
       esac
       ;;
     *)
-      echo "Invalid $(basename "$0") command: $1" >&2
       usage
-      exit 1
       ;;
   esac
 

--- a/scripts/cnode-helper-scripts/mithril.library
+++ b/scripts/cnode-helper-scripts/mithril.library
@@ -235,16 +235,17 @@ set_node_minimum_version() {
 }
 
 update_check() {
-  # Check availability of checkUpdate function
-  if [[ ! $(command -v checkUpdate) ]]; then
-    echo -e "\nCould not find checkUpdate function in env, make sure you're using official guild docos for installation!"
-    exit 1
-  fi
-  # Check if flag is set by script to skip update check
-  [[ ${SKIP_UPDATE} == Y ]] && return 0
-  # Check if flag is set by user as a global (container environments etc.) to skip update check
-  if [[ ${UPDATE_CHECK} = Y ]]; then
+  # Check if flag is set by user as a global or script to skip update check
+  if [[ ${UPDATE_CHECK} = Y && ${SKIP_UPDATE} != Y ]]; then
+
     echo "Checking for script updates..."
+
+    # Check availability of checkUpdate function
+    if [[ ! $(command -v checkUpdate) ]]; then
+      echo -e "\nCould not find checkUpdate function in env, make sure you're using official guild docos for installation!"
+      exit 1
+    fi
+
     # check for env update
     ENV_UPDATED=${BATCH_AUTO_UPDATE}
     checkUpdate "${PARENT}"/env N N N
@@ -252,13 +253,14 @@ update_check() {
       1) ENV_UPDATED=Y ;;
       2) exit 1 ;;
     esac
+
     # check for mithril.library update
     checkUpdate "${PARENT}"/mithril.library N N N
-    # borrow ENV_UPDATED for mithril.library updates
     case $? in
       1) ENV_UPDATED=Y ;;
       2) exit 1 ;;
     esac
+
     # check the script update
     checkUpdate "${PARENT}"/"$(basename "$0")" ${ENV_UPDATED}
     case $? in

--- a/scripts/cnode-helper-scripts/mithril.library
+++ b/scripts/cnode-helper-scripts/mithril.library
@@ -14,7 +14,7 @@ CI_MODE='N'
 # setting it to an incompatible version with the currently suported cardano-node
 # version. There is no need to source the environment file in CI mode.
 if [[ ${CI_MODE} == 'N' ]] ; then
-    . "$(dirname $0)"/env
+    . "$(dirname $0)"/env offline
 fi
 
 #############################


### PR DESCRIPTION
## Description
@Scitz0 This  PR should address the three mithril-client comments we discussed.

1. NETWORK_NAME issue due to sourcing env in online mode, caused by change in commit 52e5f1a53

2. Non GUI mode calling for script update, cnode.sh now uses `-u` to ensure this is disabled outside of containers, which automatically used CHECK_UPDATE=N.

3. Help text parsed first from -h, or --help. Any time an invalid command or subcommand is provided should have already produced usage.


## Motivation and context
Comments/DM discussion from Telegram, no issues opened.

## How has this been tested?
Manual testing, would appreciate feedback and/or additional testing.

