### PR TITLE
Remove single quotes from headers array.

### DIFF
--- a/scripts/cnode-helper-scripts/cntools.library
+++ b/scripts/cnode-helper-scripts/cntools.library
@@ -765,7 +765,7 @@ isPoolRegistered() {
     [[ -f "${POOL_FOLDER}/${1}/${POOL_REGCERT_FILENAME}" ]] && return 2 || return 1
   else
     getPoolID "$1"
-    HEADERS=("${KOIOS_API_HEADERS[@]}" -H "'Content-Type: application/json'")
+    HEADERS=("${KOIOS_API_HEADERS[@]}" -H "Content-Type: application/json")
     println ACTION "curl -sSL -f -X POST ${HEADERS[*]} -d '{\"_pool_bech32_ids\":[\"${pool_id_bech32}\"]}' ${KOIOS_API}/pool_info"
     ! pool_info=$(curl -sSL -f -X POST "${HEADERS[@]}" -d '{"_pool_bech32_ids":["'${pool_id_bech32}'"]}' "${KOIOS_API}/pool_info" 2>&1) && error_msg=${pool_info} && return 0
     if [[ ${pool_info} = '[]' ]]; then
@@ -1000,7 +1000,7 @@ verifyTx() {
       return 1
     fi
     if [[ -n ${KOIOS_API} ]]; then
-      HEADERS=("${KOIOS_API_HEADERS[@]}" -H "'Content-Type: application/json'" -H "'accept: text/csv'")
+      HEADERS=("${KOIOS_API_HEADERS[@]}" -H "Content-Type: application/json" -H "accept: text/csv")
       println ACTION "curl -sSL -f -X POST ${HEADERS[*]} -d '{\"_tx_hashes\":[\"${tx_id}\"]' ${KOIOS_API}/tx_status?select=num_confirmations"
       ! num_confirmations=$(curl -sSL -f -X POST "${HEADERS[@]}" -d '{"_tx_hashes":["'${tx_id}'"]}' "${KOIOS_API}/tx_status?select=num_confirmations" 2>&1) && println "ERROR" "\n${FG_RED}KOIOS_API ERROR${NC}: ${num_confirmations}\n" && return 1 # print error and return
       result=$(tail -n +2 <<< ${num_confirmations})
@@ -1505,7 +1505,7 @@ getBalanceKoios() {
   if [[ -n ${KOIOS_API} && -n ${addr_list+x} ]]; then
     printf -v addr_list_joined '\"%s\",' "${addr_list[@]}"
     [[ $1 != false ]] && extended=true || extended=false
-    HEADERS=("${KOIOS_API_HEADERS[@]}" -H "'Content-Type: application/json'" -H "'accept: text/csv'")
+    HEADERS=("${KOIOS_API_HEADERS[@]}" -H "Content-Type: application/json" -H "accept: text/csv")
     println ACTION "curl -sSL -f -X POST ${HEADERS[*]} -d '{\"_addresses\":[${addr_list_joined%,}],\"_extended\":${extended}}' ${KOIOS_API}/address_utxos?select=address,tx_hash,tx_index,value,asset_list"
     ! address_utxo_list=$(curl -sSL -f -X POST "${HEADERS[@]}" -d '{"_addresses":['${addr_list_joined%,}'],"_extended":'${extended}'}' "${KOIOS_API}/address_utxos?select=address,tx_hash,tx_index,value,asset_list" 2>&1) && println "ERROR" "\n${FG_RED}KOIOS_API ERROR${NC}: ${address_utxo_list}\n" && return 1 # print error and return
     [[ -z ${address_utxo_list} ]] && return
@@ -1687,7 +1687,7 @@ getRewardInfoKoios() {
 
   if [[ -n ${KOIOS_API} && -n ${reward_addr_list+x} ]]; then
     printf -v addr_list_joined '\"%s\",' "${reward_addr_list[@]}"
-    HEADERS=("${KOIOS_API_HEADERS[@]}" -H "'Content-Type: application/json'" -H "'accept: text/csv'")
+    HEADERS=("${KOIOS_API_HEADERS[@]}" -H "Content-Type: application/json" -H "accept: text/csv")
     println ACTION "curl -sSL -f -X POST ${HEADERS[*]} -d '{\"_stake_addresses\":[${addr_list_joined%,}]}' ${KOIOS_API}/account_info?select=stake_address,status,delegated_pool,rewards_available,deposit"
     ! account_info_list=$(curl -sSL -f -X POST "${HEADERS[@]}" -d '{"_stake_addresses":['${addr_list_joined%,}']}' "${KOIOS_API}/account_info?select=stake_address,status,delegated_pool,rewards_available,deposit" 2>&1) && println "ERROR" "\n${FG_RED}KOIOS_API ERROR${NC}: ${account_info_list}\n" && return 1 # print error and return
     [[ -z ${account_info_list} ]] && return
@@ -3347,7 +3347,7 @@ rotatePoolKeys() {
     fi
   elif [[ -n ${KOIOS_API} ]]; then
     ! getPoolID "${pool_name}" && println "ERROR" "\n${FG_RED}ERROR${NC}: failed to get pool ID!\n" && return 1
-    HEADERS=("${KOIOS_API_HEADERS[@]}" -H "'Content-Type: application/json'")
+    HEADERS=("${KOIOS_API_HEADERS[@]}" -H "Content-Type: application/json")
     println ACTION "curl -sSL -f -X POST ${HEADERS[*]} -d '{\"_pool_bech32_ids\":[\"${pool_id_bech32}\"]}' ${KOIOS_API}/pool_info"
     ! pool_info=$(curl -sSL -f -X POST "${HEADERS[@]}" -d '{"_pool_bech32_ids":["'${pool_id_bech32}'"]}' "${KOIOS_API}/pool_info" 2>&1) && println "ERROR" "\n${FG_RED}KOIOS_API ERROR${NC}: ${pool_info}\n" && p_opcert="" # print error but ignore
     if old_counter_nbr=$(jq -er '.[0].op_cert_counter' <<< "${pool_info}" 2>/dev/null); then
@@ -4475,7 +4475,7 @@ submitTxKoiosSubmitAPI() {
   cborHex=$(jq -er '.cborHex' "$1" 2>/dev/null) || { println ERROR "\n${FG_RED}ERROR${NC}: Invalid tx file format, 'cborHex' missing in: $1"; return 1; }
   txdata="$(mktemp "${TMP_DIR}/tx.signed_XXXXXXXXXX")"
   xxd -p -r <<< ${cborHex} > ${txdata}
-  HEADERS=("${KOIOS_API_HEADERS[@]}" -H "'Content-Type: application/cbor'")
+  HEADERS=("${KOIOS_API_HEADERS[@]}" -H "Content-Type: application/cbor")
   println ACTION "curl -sfSL -X POST ${HEADERS[*]} --data-binary @${txdata} \"${KOIOS_API}/submittx\""
   if ! stdout=$(curl -sfSL -X POST "${HEADERS[@]}" --data-binary @${txdata} "${KOIOS_API}/submittx" 2>&1); then
     println ERROR "\n${FG_RED}ERROR${NC}: Transaction submit failed !!\n${stdout}"; return 1
@@ -4491,7 +4491,7 @@ submitTxKoiosOgmios() {
   cborHex=$(jq -er '.cborHex' "$1" 2>/dev/null) || { println ERROR "\n${FG_RED}ERROR${NC}: Invalid tx file format, 'cborHex' missing in: $1"; return 1; }
   jsonrpc=$(jq -n -c --arg cbor "${cborHex}" '{jsonrpc: "2.0", method: "submitTransaction", params: {transaction: {cbor: $cbor}}}')
   unset ogmios_error
-  HEADERS=("${KOIOS_API_HEADERS[@]}" -H "'accept: application/json'" -H "'Content-Type: application/json'")
+  HEADERS=("${KOIOS_API_HEADERS[@]}" -H "accept: application/json" -H "Content-Type: application/json")
   println ACTION "curl -sSL -X POST ${HEADERS[*]} -d \"${jsonrpc}\" \"${KOIOS_API}/ogmios/\""
   stdout=$(curl -sSL -X POST "${HEADERS[@]}" -d "${jsonrpc}" "${KOIOS_API}/ogmios/" 2>&1)
   if [[ -z ${stdout} ]] || ogmios_error=$(jq -er '.error //empty' <<< "${stdout}") || ! jq -er '.result //empty' <<< "${stdout}" &>/dev/null; then


### PR DESCRIPTION
## Description
Removes the single quote wrapping from the KOIOS_API_HEADERS array

## Motivation and context
Even though manual testing w/ curl and koios shows including single quotes wrapped in double persists the string encapsulation expected by curl for headers, this is leading to errors in cntools.sh usage.

## Which issue it fixes?
Closes #1817

## How has this been tested?
Running wallet list, wallet show, pool list and pool show in light mode when ENABLE_KOIOS=Y.
