### PR TITLE
Add socat

### DIFF
--- a/files/docker/node/dockerfile_bin
+++ b/files/docker/node/dockerfile_bin
@@ -64,7 +64,7 @@ RUN set -x && export SUDO='N' \
 
 # Add final tools in a separate layer to shrink the largest layer
 RUN apt-get update \
-    && apt-get install -y procps libcap2 libselinux1 libc6 libsodium-dev ncurses-bin iproute2 xz-utils netbase coreutils dnsutils net-tools procps tcptraceroute bc usbip sqlite3 python3 tmux ncurses-base libtool autoconf tcptraceroute util-linux less openssl bsdmainutils dialog vim \
+    && apt-get install -y procps libcap2 libselinux1 libc6 libsodium-dev ncurses-bin iproute2 xz-utils netbase coreutils dnsutils net-tools procps tcptraceroute bc usbip sqlite3 python3 tmux ncurses-base libtool autoconf tcptraceroute util-linux less openssl bsdmainutils dialog vim socat \
     && apt-get -y purge \
     && apt-get -y clean \
     && apt-get -y autoremove \


### PR DESCRIPTION
## Description
Add socat to the later tool dependencies installation step.


## Motivation and context
cncli.sh metrics serve requires socat, but cncli.sh deploy expects to install it w/o doing an update for apt metadata and to setup systemd services.

## Which issue it fixes?
Closes #1830 
