### PR TITLE
Update Mithril Documentation

### DIFF
--- a/docs/Mithril/mithril-overview.md
+++ b/docs/Mithril/mithril-overview.md
@@ -85,13 +85,19 @@ variables for the Mithril client.
    ./mithril-client.sh environment setup
    ```
 
+   * Override a default variable in the Mithril environment file: Run the script with the environment override <VARIABLE> <VALUE> command to override a default variable in the mithril.env file.
+
+     ```bash
+     ./mithril-client.sh environment override <VARIABLE> <VALUE>
+     ```
+
 3. **Download the latest Mithril snapshot:** Once the environment file is set up, you
 can download the latest Mithril snapshot by running the script with the `snapshot
 download` command. This snapshot contains the latest state of the Cardano blockchain db
 from a Mithril Aggregator.
 
    ```bash
-   ./mithril-client.sh snapshot download
+   ./mithril-client.sh cardano-db download
    ```
 
 ### Participating in Mithril Network

--- a/docs/Scripts/mithril-client.md
+++ b/docs/Scripts/mithril-client.md
@@ -8,7 +8,7 @@
 ## Usage
 
 ```bash
-Usage: bash [-u] <command> <subcommand> [<sub arg>]
+Usage: mithril-client.sh [-u] <command> <subcommand> [<sub arg>]
 A script to run Cardano Mithril Client
 
 -u          Skip script update check overriding UPDATE_CHECK value in env (must be first argument to script)
@@ -55,16 +55,15 @@ You can investigate the available snapshots by using the `snapshot list` and `sn
 - **List all available Mithril snapshots:** You can list all available Mithril snapshots by running the script with the `snapshot list` command. Add `json` at the end to get the output in JSON format.
 
   ```bash
-  ./mithril-client.sh cardano-dbsnapshot list
-  ./mithril-client.sh cardano-dbsnapshot list json
+  ./mithril-client.sh cardano-db snapshot list
+  ./mithril-client.sh cardano-db snapshot list json
   ```
 
 - **Show details of a specific Mithril snapshot:** You can show details of a specific Mithril snapshot by running the script with the `snapshot show <DIGEST>` command, where `<DIGEST>` is the digest of the snapshot. Add `json` at the end to get the output in JSON format.
 
   ```bash
-  ./mithril-client.sh cardano-dbsnapshot show <DIGEST>
-  ./mithril-client.sh cardano-dbsnapshot show <DIGEST> json
-  ./mithril-client.sh cardano-dbsnapshot show json <DIGEST>
+  ./mithril-client.sh cardano-db snapshot show <DIGEST>
+  ./mithril-client.sh cardano-db snapshot show <DIGEST> json
   ```
 
 ## Managing Stake Distributions

--- a/docs/Scripts/mithril-relay.md
+++ b/docs/Scripts/mithril-relay.md
@@ -7,12 +7,13 @@ loadbalancer. It provides functionalities such as:
 ## Usage
 
 ```bash
-bash [-d] [-l] [-u] [-h]
+mithril-relay.sh [-d] [-l] [-u] [-h]
 A script to setup Cardano Mithril relays
 
 -d  Install squid and configure as a relay
 -l  Install nginx and configure as a load balancer
 -u  Skip update check
+-s  Stop relays
 -h  Show this help text
 ```
 

--- a/docs/Scripts/mithril-signer.md
+++ b/docs/Scripts/mithril-signer.md
@@ -5,7 +5,7 @@ environment file to contain variables specific to the Mithril Signer.
 ## Usage
 
 ```bash
-Usage: bash [-d] [-D] [-e] [-k] [-r] [-s] [-u] [-h]
+Usage: mithril-signer.sh [-d] [-D] [-e] [-k] [-r] [-s] [-u] [-h]
 A script to setup, run and verify Cardano Mithril Signer
 
 -d    Deploy mithril-signer as a systemd service

--- a/scripts/cnode-helper-scripts/mithril-relay.sh
+++ b/scripts/cnode-helper-scripts/mithril-relay.sh
@@ -35,6 +35,7 @@ usage() {
 		-d  Install squid and configure as a relay
 		-l  Install nginx and configure as a load balancer
 		-u  Skip update check
+		-s  Stop relays
 		-h  Show this help text
 		
 		EOF


### PR DESCRIPTION
## Description
- Aligns the docs with the current version of mithril-client.sh script and upstream client binary where cardano-db replaced the snapshot subcommand.
- Adds details for optional environment override.
- Adds the stop relays flag to usage and docs
- Fixes mithril script names in documentation usage examples.

## Where should the reviewer start?


## Motivation and context
Docs were out of sync after scripts were updated to fix breaking changes in upstream binaries.

## Which issue it fixes?
Closes #1840
