### PR TITLE
Feature: mithril snapshot download command to include ledger snapshot db

### DIFF
--- a/scripts/cnode-helper-scripts/mithril-client.sh
+++ b/scripts/cnode-helper-scripts/mithril-client.sh
@@ -32,7 +32,8 @@ usage() {
 			  override            Override default variable in the mithril environment file
 			  update              Update mithril environment file
 			cardano-db            Interact with Cardano DB
-			  download            Download Cardano DB from Mithril snapshot
+			  immutable           Download Cardano DB from Mithril snapshot (Immutable db only requires ledger replay)
+			  full	              Download Cardano DB from Mithril snapshot (Includes ledger snapshot for fast bootstrap)
 			  snapshot            Interact with Mithril snapshots
 			    list              List available Mithril snapshots
 			      json            List availble Mithril snapshots in JSON format
@@ -96,9 +97,13 @@ function main() {
     cardano-db)
       mithril_init client || exit 1
       case $2 in
-        download)
+        immutable)
           check_db_dir
           download_snapshot
+          ;;
+        full)
+          check_db_dir
+          download_snapshot_withledger
           ;;
         snapshot)
           case $3 in

--- a/scripts/cnode-helper-scripts/mithril.library
+++ b/scripts/cnode-helper-scripts/mithril.library
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034,SC2086,SC2230,SC2206,SC2140,SC2059,SC2154
-# shellcheck source=/dev/null
+#shellcheck source=/dev/null
 
 ######################################
 # Do NOT modify code below           #
@@ -278,6 +278,7 @@ update_mithril_environment_for_client() {
 		RELEASE=${RELEASE}
 		AGGREGATOR_ENDPOINT=https://aggregator.${RELEASE}-${NETWORK_NAME,,}.api.mithril.network/aggregator
 		DB_DIRECTORY=${DB_DIR}
+		ANCILLARY_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/ancillary.vkey)
 		GENESIS_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/genesis.vkey)
 		SNAPSHOT_DIGEST=latest
 		EOF"
@@ -318,9 +319,22 @@ cleanup_db_directory() {
 # mithril client snapshot subcommand
 download_snapshot() {
   if [[ "${DOWNLOAD_SNAPSHOT}" == "Y" ]]; then
-    echo "INFO: Downloading latest mithril snapshot.."
+    echo "INFO: Downloading latest mithril snapshot (Immutable db only, requires ledger replay).."
     trap 'cleanup_db_directory' INT
     if ! "${MITHRILBIN}" -v --aggregator-endpoint ${AGGREGATOR_ENDPOINT} cardano-db download --download-dir "$(dirname ${DB_DIRECTORY})" --genesis-verification-key ${GENESIS_VERIFICATION_KEY} ${SNAPSHOT_DIGEST} ; then
+      cleanup_db_directory
+      exit 1
+    fi
+  else
+    echo "INFO: Skipping Cardano DB download.."
+  fi
+}
+
+download_snapshot_withledger() {
+  if [[ "${DOWNLOAD_SNAPSHOT}" == "Y" ]]; then
+    echo "INFO: Downloading latest mithril snapshot (Includes ledger snapshot for fast bootstrap).."
+    trap 'cleanup_db_directory' INT
+    if ! "${MITHRILBIN}" -v --aggregator-endpoint ${AGGREGATOR_ENDPOINT} cardano-db download --ancillary-verification-key ${ANCILLARY_VERIFICATION_KEY} --download-dir "$(dirname ${DB_DIRECTORY})" --genesis-verification-key ${GENESIS_VERIFICATION_KEY} --include-ancillary ${SNAPSHOT_DIGEST} ; then
       cleanup_db_directory
       exit 1
     fi
@@ -719,6 +733,7 @@ update_mithril_environment_for_signer() {
 		STORE_RETENTION_LIMITS=5
 		ERA_READER_ADAPTER_TYPE=cardano-chain
 		ERA_READER_ADAPTER_PARAMS=$(jq -nc --arg address "$(wget -q -O - "${ERA_READER_ADDRESS}")" --arg verification_key "$(wget -q -O - "${ERA_READER_VKEY}")" '{"address": $address, "verification_key": $verification_key}')
+		ANCILLARY_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/ancillary.vkey)
 		GENESIS_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/genesis.vkey)
 		PARTY_ID=$(cat ${POOL_DIR}/${POOL_ID_FILENAME}-bech32)
 		SNAPSHOT_DIGEST=latest


### PR DESCRIPTION
Hello CNTools/Koios Team,

The latest mithril-client v0.12.1 introduces the --include-ancillary option to include the ledger snapshot when downloading a snapshot, enabling faster node bootstrap.

In line with these recent changes, I would like to propose the following update to the mithril-client.sh script:

The current "download" command under mithril-client.sh cardano-db download would be replaced by two options: "immutable" and "full".

immutable – Download Cardano DB from Mithril snapshot (Immutable db only requires ledger replay)

full – Download Cardano DB from Mithril snapshot (Includes ledger snapshot for fast bootstrap)

The goal is to provide users with both choices:

Download only the immutable DB and let the node perform ledger replay

Download both the immutable and ledger snapshots for a faster bootstrap

Thank you,
Cheers,
Manuel