### PR TITLE
Minor bug fixes

### DIFF
--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -2041,7 +2041,7 @@ function main {
               echo
               pledge_ada=50000 # default pledge
               [[ -f "${pool_config}" ]] && pledge_ada=$(jq -r '.pledgeADA //0' "${pool_config}")
-              getAnswerAnyCust pledge_enter "Pledge (in ADA, default: $(formatLovelace "$(ADAToLovelace ${pledge_ada})")"
+              getAnswerAnyCust pledge_enter "Pledge (in ADA, default: $(formatLovelace "$(ADAToLovelace ${pledge_ada})"))"
               pledge_enter="${pledge_enter//,}"
               if [[ -n "${pledge_enter}" ]]; then
                 if ! ADAToLovelace "${pledge_enter}" >/dev/null; then

--- a/scripts/cnode-helper-scripts/cntools.sh
+++ b/scripts/cnode-helper-scripts/cntools.sh
@@ -5037,7 +5037,7 @@ function main {
                           [[ -z "${drep_id}" ]] && continue
                           parseDRepId "${drep_id}"
                           [[ -z ${drep_id} ]] && println ERROR "\n${FG_RED}ERROR${NC}: invalid DRep ID entered!" && waitToProceed && continue
-                          key_hashes[${drep_hash})]=1
+                          key_hashes[${drep_hash}]=1
                           ;;
                         2) break ;;
                         3) safeDel "${WALLET_FOLDER}/${ms_wallet_name}"; continue 2 ;;


### PR DESCRIPTION
### Fix1
- Missing closing parenthesis in pledge prompt:

![Screenshot](https://github.com/user-attachments/assets/f2095640-1735-408e-88f8-1360ad3d957d)

Fixes line 2044 in cntools.sh where the pledge input prompt was missing a closing parenthesis. Improves user experience by fixing prompt text.

Changes prompt from:
```Pledge (in ADA, default: 1000:```
 to:
```Pledge (in ADA, default: 1000):```


### Fix2
- Superfluous parenthesis

Fixes syntax error on line 5040 in cntools.sh.
Removes extra closing parenthesis from ```key_hashes[${drep_hash})]=1```.
Prevents script failure when creating MultiSig DRep configurations.


