### PR TITLE
Add Contributing Style Guidelines and Development Environment Setup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# Editor config helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# EditorConfig is awesome: http://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing Guidelines
+
+Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great. Contributions to this project covered by this contributing guideline are released to
+the public under open source license.
+
+Please note that projects on [cardano-community] are released with a [Contributor Code of Conduct.](coc)
+By participating in this project you agree to abide by its terms.
+
+[cardano-community]: https://cardano-community.github.io
+[coc]: repos/.github/.github/CODE_OF_CONDUCT.md
+
+## Submitting a pull request
+
+- Fork and clone the repository
+- Configure and install the dependencies
+- Make sure the prerequisites like tests pass on your machine
+- Make your change, add tests, and make sure the tests still pass
+- Push to your fork and submit a pull request *(Some repositories may require "sign-off" procedure)*
+- Pat your self on the back and wait for your pull request to be reviewed and merged.
+
+Here are a few things you can do that will increase the likelihood of your pull request being accepted:
+
+- Follow standards for style and code quality (see below).
+- Write tests.
+- Keep your change as focused as possible. If there are multiple changes you would like to make
+  that are not dependent upon each other, consider submitting them as separate pull requests.
+- Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+
+## Code Style Guidelines
+
+This project uses EditorConfig to maintain consistent coding styles across different editors and IDEs. This helps us to maintain consistent coding styles between different developers, editors and IDEs.
+
+The `.editorconfig` file in this repository defines the style rules. To get the most out of EditorConfig, make sure your editor is configured to use it. This will automatically apply the project's style rules when you edit/save files.
+
+
+## Resources
+
+- [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
+- [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "editorconfig.editorconfig",
+  ]
+}


### PR DESCRIPTION
## Summary
This PR adds code style guidelines and development environment configuration to improve the code quality and style consitency across the project. Should this be accepted, I will then go on to format/lint the exisiting codebase in alignment with the .editorconfig rules.

### Changes Made

#### Contributing Guidelines (`.github/CONTRIBUTING.md`)
- CONTRIBUTING.md template used [from here](https://github.com/cardano-community/.github/blob/main/.github/CONTRIBUTING.md)

- Included code style guidelines with EditorConfig explanation

#### Editor Configuration (`.editorconfig`)
- **Add .editorconfig file**. Enforce consistent coding standards across the project. Template .editorconfig file used [from here](https://github.com/cardano-community/.github/blob/main/.editorconfig)

- **Formatting**: 2-space indentation, UTF-8 encoding, Unix line endings etc.

- **Cross-Editor Compatibility**: Works with VS Code, Sublime Text, Vim, IntelliJ, and more

#### VS Code Extension (`.vscode/extensions.json`)
- Add .vscode/extensions.json to recommend the EditorConfig extension for VS Code users.

- While many modern editors support .editorconfig natively, VS Code requires an extension. Given VS Code's widespread usage, this extension should be suggested to ensure all contributors are submitting consistent code formatting, regardless of their editor choice.

### Testing
- Verified EditorConfig rules work correctly in VS Code