### PR TITLE
feat(env): add support for cardano-tracer with legacy fallback (#1879)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
     - name: SH Lint Check
       uses: ludeeus/action-shellcheck@master
       env:
-        SHELLCHECK_OPTS: -e SC2089 -e SC2090 -e SC2034
+        SHELLCHECK_OPTS: -e SC2089 -e SC2090 -e SC2034 -e SC2327 -e SC2328
       with:
         scandir: "./scripts"
         severity: "warning"

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -600,7 +600,7 @@ getNodeMetrics() {
   CNODE_PID=$(pgrep -fn "$(basename ${CNODEBIN}).*.--port ${CNODE_PORT}") # Define again - as node could be restarted since last attempt of sourcing env
   [[ -n ${CNODE_PID} ]] && uptimes=$(( $(date -u +%s) - $(date -d "$(ps -p ${CNODE_PID} -o lstart=)" +%s) )) || uptimes=0
   if [[ ${USE_EKG} = 'Y' ]]; then
-    node_metrics=$(curl -s -m ${EKG_TIMEOUT} -H 'Accept: application/json' "http://${EKG_HOST}:${EKG_PORT}/${TRACE_NODE_NAME}" 2>/dev/null)
+    node_metrics=$(curl -s -m ${EKG_TIMEOUT} -H 'Accept: application/json' "http://${EKG_HOST}:${EKG_PORT}${TRACE_NODE_NAME}" 2>/dev/null)
     node_metrics_tsv=$(jq -r '[
     .cardano.node.metrics.blockNum.int.val // .cardano.node.metrics.blockNum_int.val // 0,
     .cardano.node.metrics.epoch.int.val // .cardano.node.metrics.epoch_int.val // 0,
@@ -663,7 +663,7 @@ getNodeMetrics() {
     [[ ${node_metrics_arr[35]} =~ ,revision=\"([0-9a-f]*)\" ]] && running_node_rev=${BASH_REMATCH[1]:0:8} || running_node_rev="?"
     inbound_governor_warm=${node_metrics_arr[36]}; inbound_governor_hot=${node_metrics_arr[37]};
   else
-    node_metrics=$(curl -s -m ${EKG_TIMEOUT} "http://${PROM_HOST}:${PROM_PORT}/${TRACE_NODE_NAME}/metrics" | grep -v '^# ' 2>/dev/null)
+    node_metrics=$(curl -s -m ${EKG_TIMEOUT} "http://${PROM_HOST}:${PROM_PORT}${TRACE_NODE_NAME}/metrics" | grep -v '^# ' 2>/dev/null)
     [[ ${node_metrics} =~ cardano_node_metrics_blockNum_int[[:space:]]([^[:space:]]*) ]] && blocknum=${BASH_REMATCH[1]} || blocknum=0
     [[ ${node_metrics} =~ cardano_node_metrics_epoch_int[[:space:]]([^[:space:]]*) ]] && epochnum=${BASH_REMATCH[1]} || epochnum=0
     [[ ${node_metrics} =~ cardano_node_metrics_slotInEpoch_int[[:space:]]([^[:space:]]*) ]] && slot_in_epoch=${BASH_REMATCH[1]} || slot_in_epoch=0
@@ -927,6 +927,26 @@ telegramSend() {
   fi
 }
 
+check_valid_host() {
+    local host="$1"
+    local name="$2"
+
+    if [[ -z "$host" ]] || { ! isValidIPv4 "$host" && ! isValidHostnameOrDomain "$host"; }; then
+        echo "Not a valid IP or hostname set for ${name} host, please check the env file (currently it is \"${host})\"!"
+        return 1
+    fi
+}
+
+check_valid_port() {
+    local port="$1"
+    local name="$2"
+
+    if [[ -z "port" ]] || ! [[ "$port" =~ ^[0-9]+$ ]] || (( port < 1 || port > 65535 )); then
+        echo "Please set a valid ${name} port number! Current value is \"${port}\"!"
+        return 1
+    fi
+}
+
 set_default_vars() {
 
   [[ "${USESYSVARS}" != "Y" ]] && unset CNODE_HOME
@@ -1166,8 +1186,22 @@ if ! command -v "jq" &>/dev/null; then
   return 1
 fi
 
-read -ra CONFIG_CONTENTS <<<"$(jq -r '[ .AlonzoGenesisFile //"null", .ByronGenesisFile //"null", .ShelleyGenesisFile //"null", .Protocol //"Cardano", .TraceChainDb // (if .UseTraceDispatcher == true then "tracer" else "null" end), .EnableP2P //"false", .ConwayGenesisFile //"null"]| @tsv' "${CONFIG}" 2>/dev/null)"
-if [[ ${CONFIG_CONTENTS[4]} == "null" ]]; then
+read -ra CONFIG_CONTENTS <<<"$(jq -r '[ .AlonzoGenesisFile //"null", .ByronGenesisFile //"null", .ShelleyGenesisFile //"null", .Protocol //"Cardano",
+if (.UseTraceDispatcher == true) then
+    if ([.TraceOptions[].backends[]? // ""] | any(test("(?i)forwarder"))) then
+      "forwarder"
+    else
+      "non-forwarder"
+    end
+  elif (.TraceChainDb == true) then
+    "legacy"
+  else
+    "invalid"
+  end,
+.EnableP2P //"false",
+.ConwayGenesisFile //"null"]| @tsv' "${CONFIG}" 2>/dev/null)"
+
+if [[ ${CONFIG_CONTENTS[4]} == "invalid" ]]; then
   echo "Could not find TraceChainDb or new tracing system is not enabled when attempting to parse ${CONFIG} file in JSON format, please double-check the syntax of your config, or simply download it from guild-operators repository!"
   return 1
 else
@@ -1190,63 +1224,95 @@ else
   P2P_ENABLED="${CONFIG_CONTENTS[5]}"
 
   # New tracer system settings.
-  USING_TRACER=false
-  [[ "${CONFIG_CONTENTS[4]}" == "tracer" ]] && USING_TRACER=true
+  TRACING_MODE="${CONFIG_CONTENTS[4]}"
 
   # If using the new tracer then tracer config must be set
-  if [[ $USING_TRACER == "true" && -z "$TRACER_CONFIG" ]]; then
+  if [[ "$TRACING_MODE" == "forwarder" && -z "$TRACER_CONFIG" ]]; then
     echo "Set TRACER_CONFIG to the tracer config file when using cardano-tracer."
     return 1
   fi
 
-  $USING_TRACER || TRACER_CONFIG=${CONFIG}
+  # Set the trace option node name for the tracer. it defaults to the /<hostname>-<CNODE_PORT>
+  # removing the dots if it's an FQDN e.g. hostname.domain to /hostnamedomain-PORT
+  [[ "$TRACING_MODE" == "forwarder" ]] && TRACE_NODE_NAME=$(jq -r '"/" + (.TraceOptionNodeName // "'${HOSTNAME//./}'_'"$CNODE_PORT"'")' "$CONFIG" 2>/dev/null)
 
-  # Set the trace otpion node name for the tracer. it defaults to the <hostname>_<CNODE_PORT> 
-  $USING_TRACER && TRACE_NODE_NAME=$(jq -r '.TraceOptionNodeName // "'$(hostname)'_'"$CNODE_PORT"'"' "$CONFIG" 2>/dev/null)
+fi
+
+if [[ -z "$PROM_HOST" || -z "$PROM_PORT" ]]; then
+    if [[ "$TRACING_MODE" == "legacy" ]]; then
+        PROM_CONFIG="$CONFIG"
+        PROM_HOST=$(jq -er '.hasPrometheus[0] // ""' "$PROM_CONFIG")
+        PROM_PORT=$(jq -er '.hasPrometheus[1] // ""' "$PROM_CONFIG")
+    else
+        # non-forwarder or forwarder
+        PROM_CONFIG="$CONFIG"
+        PROM_PORT=$(jq -er '
+          (.TraceOptions."".backends // [])
+          | .[]
+          | select(test("(?i)PrometheusSimple"))
+          | split(" ")
+          | ( last // "")
+        ' "$PROM_CONFIG")
+
+        PROM_HOST=$(jq -er '
+          (.TraceOptions."".backends // [])
+          | .[]
+          | select(test("(?i)PrometheusSimple"))
+          | split(" ")
+          | (.[-2] // "")
+          | if test("^[0-9]{1,3}(\\.[0-9]{1,3}){3}$") then . else "127.0.0.1"  end
+        ' "$PROM_CONFIG")
+
+        if [[ "$TRACING_MODE" == "forwarder" && ( -z "$PROM_HOST" || -z "$PROM_PORT" ) ]]; then
+            PROM_CONFIG="$TRACER_CONFIG"
+            PROM_HOST=$(jq -er '.hasPrometheus.epHost // ""' "$PROM_CONFIG")
+            PROM_PORT=$(jq -er '.hasPrometheus.epPort // ""' "$PROM_CONFIG")
+        fi
+    fi
+fi
+
+if [[ -n "$PROM_HOST" && -n "$PROM_PORT" ]]; then
+    check_valid_host "$PROM_HOST" "PROM" || return 1
+    check_valid_port "$PROM_PORT" "PROM" || return 1
+
+    # Prometheus should be preferred unless the USE_EKG is already set manually.
+    USE_EKG=${USE_EKG:="N"}
+else
+    USE_EKG="Y"
+fi
+
+if [[ "$USE_EKG" == "Y" ]]; then
+    EKG_HOST="${EKG_HOST:-}"
+    EKG_PORT="${EKG_PORT:-}"
+
+    if [[ -z "$EKG_HOST" || -z "$EKG_PORT" ]]; then
+        if [[ "$TRACING_MODE" == "forwarder" ]]; then
+            EKG_CONFIG="$TRACER_CONFIG"
+            EKG_HOST=$(jq -er '.hasEKG.epHost // ""' "$EKG_CONFIG")
+            EKG_PORT=$(jq -er '.hasEKG.epPort // ""' "$EKG_CONFIG")
+        else
+            EKG_CONFIG="$CONFIG"
+            EKG_HOST="127.0.0.1"
+            EKG_PORT=$(jq -er '.hasEKG // ""' "$EKG_CONFIG")
+        fi
+    fi
+
+    check_valid_host "$EKG_HOST" "EKG" || return 1
+    check_valid_port "$EKG_PORT" "EKG" || return 1
 fi
 
 [[ -z ${EKG_TIMEOUT} ]] && EKG_TIMEOUT=3
-[[ -z ${EKG_HOST} ]] && EKG_HOST=127.0.0.1
-if ! isValidIPv4 "${EKG_HOST}" && ! isValidHostnameOrDomain "${EKG_HOST}"; then
-  echo "Not a valid IP or hostname set for EKG host, please check the env file (currently it is ${EKG_HOST})!"
-  return 1
-fi
 
-if [[ -z ${EKG_PORT} ]]; then
-  if ! EKG_PORT=$(jq -er '.hasEKG | if .|type=="number" or type=="string" then . else .epPort // . end' "${TRACER_CONFIG}" 2>/dev/null); then
-    if [[ ${OFFLINE_MODE} = "N" ]]; then
-      echo "Could not get 'hasEKG' port in ${TRACER_CONFIG}"
-      return 1
-    fi
-  fi
-elif [[ ! ${EKG_PORT} =~ ^[0-9]+$ ]]; then
-  echo "Please set a valid EKG port number in env file! Current value is ${EKG_PORT} !"
-  return 1
-fi
+#echo "PROM_HOST: $PROM_HOST"
+#echo "PROM_PORT: $PROM_PORT"
+#echo "USE_EKG: $USE_EKG"
+#echo "EKG_HOST: $EKG_HOST"
+#echo "EKG_PORT: $EKG_PORT"
+#echo "CONFIG $CONFIG"
+#echo "TRACER_CONFIG: $TRACER_CONFIG"
+# return 1
 
-if [[ -z ${PROM_HOST} ]]; then PROM_HOST=$(jq -er '.hasPrometheus | if .|type=="array" then .[0] else .epHost // .  end' "${TRACER_CONFIG}" 2>/dev/null) || PROM_HOST=127.0.0.1; fi
 
-if [[ ${PROM_HOST} =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-  IFS='.' read -ra PROM_OCTETS <<< ${PROM_HOST}
-  if ! [[ ${PROM_OCTETS[0]} -le 255 && ${PROM_OCTETS[1]} -le 255 && ${PROM_OCTETS[2]} -le 255 && ${PROM_OCTETS[3]} -le 255 ]]; then
-    echo "Not a valid IP range set for Prometheus host, please check env file for value of PROM_HOST (currently it is set to ${PROM_HOST} )!"
-    return 1
-  fi
-else
-  echo "Not a valid IP format set for Prometheus host, please check env file!"
-  return 1
-fi
-if [[ -z ${PROM_PORT} ]]; then
-  if ! PROM_PORT=$(jq -er '.hasPrometheus | if .|type=="array" then .[1] else .epPort // .  end' "${TRACER_CONFIG}" 2>/dev/null); then
-    if [[ ${OFFLINE_MODE} = "N" ]]; then
-      echo "Could not get 'hasPrometheus' port in ${TRACER_CONFIG}"
-      return 1
-    fi
-  fi
-elif [[ ! ${PROM_PORT} =~ ^[0-9]+$ ]]; then
-  echo "Please set a valid Prometheus port number in env file! Current value is ${PROM_PORT} !"
-  return 1
-fi
 
 [[ -z ${BLOCKLOG_DIR} ]] && BLOCKLOG_DIR="${CNODE_HOME}/guild-db/blocklog"
 BLOCKLOG_DB="${BLOCKLOG_DIR}/blocklog.db"
@@ -1254,19 +1320,18 @@ BLOCKLOG_DB="${BLOCKLOG_DIR}/blocklog.db"
 [[ -z ${CNODE_PORT} ]] && CNODE_PORT=6000
 [[ -z "${IP_VERSION}" ]] && IP_VERSION=4
 IP_VERSION=$(tr '[:upper:]' '[:lower:]' <<< "${IP_VERSION}")
-[[ -z ${USE_EKG} ]] && USE_EKG='Y'
 
 # Avoid using cardano-node PID as EKG and Prometheus are listening on the cardano-tracer's ports.
 $USING_TRACER || CNODE_PID=$(pgrep -fn "$(basename ${CNODEBIN}).*.--port ${CNODE_PORT}")
 
-if [[ ${OFFLINE_MODE} = "N" && -n "${CNODE_PID}" ]]; then
+if [[ ${OFFLINE_MODE} == "N" && -n "${CNODE_PID}" ]]; then
   if [[ "${USE_EKG}" == "N" ]]; then
-    if { [[ "${use_lsof}" != 'Y' && -z "$(ss -lnpt | grep "pid=${CNODE_PID}," | awk -v port=":${PROM_PORT}" '$4 ~ port {print $4}')" ]]; } || { [[ "${use_lsof}" == 'Y' && -z "$(lsof -Pnl -i4 +M | grep LISTEN | awk -v pid="${CNODE_PID}" -v port=":${PROM_PORT}" '$2 == pid && $9 ~ port {print $9}')" ]]; }; then
+    if { [[ "${use_lsof}" != 'Y' && -z "$(ss -lnpt | grep "pid=${CNODE_PID}," | awk -v port=":${PROM_PORT}" '$4 ~ port {print $6}')" ]]; } || { [[ "${use_lsof}" == 'Y' && -z "$(lsof -Pnl -i4 +M | grep LISTEN | awk -v pid="${CNODE_PID}" -v port=":${PROM_PORT}" '$2 == pid && $9 ~ port {print $9}')" ]]; }; then
       echo "ERROR: You specified ${PROM_PORT} as your Prometheus port, but it looks like the cardano-node (PID: ${CNODE_PID} ) is not listening on this port. Please update the config or kill the conflicting process first."
       return 1
     fi
   else
-    if { [[ "${use_lsof}" != 'Y' && -z "$(ss -lnpt | grep "pid=${CNODE_PID}," | awk -v port=":${EKG_PORT}" '$4 ~ port {print $4}')" ]]; } || { [[ "${use_lsof}" == 'Y' && -z "$(lsof -Pnl -i4 +M | grep LISTEN | awk -v pid="${CNODE_PID}" -v port=":${EKG_PORT}" '$2 == pid && $9 ~ port {print $9}')" ]]; }; then
+    if { [[ "${use_lsof}" != 'Y' && -z "$(ss -lnpt | grep "pid=${CNODE_PID}," | awk -v port=":${EKG_PORT}" '$4 ~ port {print $6}')" ]]; } || { [[ "${use_lsof}" == 'Y' && -z "$(lsof -Pnl -i4 +M | grep LISTEN | awk -v pid="${CNODE_PID}" -v port=":${EKG_PORT}" '$2 == pid && $9 ~ port {print $9}')" ]]; }; then
       echo "ERROR: You specified ${EKG_PORT} as your EKG port, but it looks like the cardano-node (PID: ${CNODE_PID} ) is not listening on this port. Please update the config or kill the conflicting process first."
       return 1
     fi
@@ -1277,7 +1342,7 @@ read_genesis
 
 [[ ${NWMAGIC} == "764824073" ]] && NETWORK_IDENTIFIER="--mainnet" || NETWORK_IDENTIFIER="--testnet-magic ${NWMAGIC}"
 case ${NWMAGIC} in
-  764824073) 
+  764824073)
     [[ -z ${NETWORK_NAME} ]] && NETWORK_NAME="Mainnet"
     [[ -z ${SHELLEY_TRANS_EPOCH} ]] && SHELLEY_TRANS_EPOCH=208
     [[ -z ${KOIOS_API} ]] && KOIOS_API="https://api.koios.rest/api/v1" ;;
@@ -1297,7 +1362,7 @@ case ${NWMAGIC} in
     [[ -z ${NETWORK_NAME} ]] && NETWORK_NAME="Sanchonet"
     [[ -z ${SHELLEY_TRANS_EPOCH} ]] && SHELLEY_TRANS_EPOCH=0
     [[ -z ${KOIOS_API} ]] && KOIOS_API="https://sancho.koios.rest/api/v1";;
-  *) 
+  *)
     [[ -z ${NETWORK_NAME} ]] && NETWORK_NAME="Custom"
     [[ -z ${SHELLEY_TRANS_EPOCH} ]] && SHELLEY_TRANS_EPOCH=0
 esac

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -600,53 +600,53 @@ getNodeMetrics() {
   CNODE_PID=$(pgrep -fn "$(basename ${CNODEBIN}).*.--port ${CNODE_PORT}") # Define again - as node could be restarted since last attempt of sourcing env
   [[ -n ${CNODE_PID} ]] && uptimes=$(( $(date -u +%s) - $(date -d "$(ps -p ${CNODE_PID} -o lstart=)" +%s) )) || uptimes=0
   if [[ ${USE_EKG} = 'Y' ]]; then
-    node_metrics=$(curl -s -m ${EKG_TIMEOUT} -H 'Accept: application/json' "http://${EKG_HOST}:${EKG_PORT}/" 2>/dev/null)
+    node_metrics=$(curl -s -m ${EKG_TIMEOUT} -H 'Accept: application/json' "http://${EKG_HOST}:${EKG_PORT}/${TRACE_NODE_NAME}" 2>/dev/null)
     node_metrics_tsv=$(jq -r '[
-    .cardano.node.metrics.blockNum.int.val //0,
-    .cardano.node.metrics.epoch.int.val //0,
-    .cardano.node.metrics.slotInEpoch.int.val //0,
-    .cardano.node.metrics.slotNum.int.val //0,
-    .cardano.node.metrics.density.real.val //"-",
-    .cardano.node.metrics.txsProcessedNum.int.val //0,
-    .cardano.node.metrics.txsInMempool.int.val //0,
-    .cardano.node.metrics.mempoolBytes.int.val //0,
-    .cardano.node.metrics.currentKESPeriod.int.val //0,
-    .cardano.node.metrics.remainingKESPeriods.int.val //0,
-    .cardano.node.metrics.Forge["node-is-leader"].int.val //0,
-    .cardano.node.metrics.Forge.adopted.int.val //0,
-    .cardano.node.metrics.Forge["didnt-adopt"].int.val //0,
-    .cardano.node.metrics.Forge["forge-about-to-lead"].int.val //0,
-    .cardano.node.metrics.slotsMissedNum.int.val //0,
-    .cardano.node.metrics.RTS.gcLiveBytes.int.val //0,
-    .cardano.node.metrics.RTS.gcHeapBytes.int.val //0,
-    .cardano.node.metrics.RTS.gcMinorNum.int.val //0,
-    .cardano.node.metrics.RTS.gcMajorNum.int.val //0,
-    .cardano.node.metrics.forks.int.val //0,
-    .cardano.node.metrics.blockfetchclient.blockdelay.s.val //0,
-    .cardano.node.metrics.served.block.count.int.val //0,
-    .cardano.node.metrics.blockfetchclient.lateblocks.val //0,
-    .cardano.node.metrics.blockfetchclient.blockdelay.cdfOne.val //0,
-    .cardano.node.metrics.blockfetchclient.blockdelay.cdfThree.val //0,
-    .cardano.node.metrics.blockfetchclient.blockdelay.cdfFive.val //0,
-    .cardano.node.metrics.peerSelection.cold.val //0,
-    .cardano.node.metrics.peerSelection.warm.val //0,
-    .cardano.node.metrics.peerSelection.hot.val //0,
-    .cardano.node.metrics.connectionManager.incomingConns.val //0,
-    .cardano.node.metrics.connectionManager.outgoingConns.val //0,
-    .cardano.node.metrics.connectionManager.unidirectionalConns.val //0,
-    .cardano.node.metrics.connectionManager.duplexConns.val //0,
-    .cardano.node.metrics.connectionManager.fullDuplexConns.val //0,
-    .cardano.node.metrics.forging_enabled.val //0,
-    .cardano.node.metrics.cardano_build_info.val //"-",
-    .cardano.node.metrics.inboundGovernor.warm.val //0,
-    .cardano.node.metrics.inboundGovernor.hot.val //0
+    .cardano.node.metrics.blockNum.int.val // .cardano.node.metrics.blockNum_int.val // 0,
+    .cardano.node.metrics.epoch.int.val // .cardano.node.metrics.epoch_int.val // 0,
+    .cardano.node.metrics.slotInEpoch.int.val // .cardano.node.metrics.slotInEpoch_int.val // 0,
+    .cardano.node.metrics.slotNum.int.val // .cardano.node.metrics.slotNum_int.val // 0,
+    .cardano.node.metrics.density.real.val // .cardano.node.metrics.density_real.val // "-",
+    .cardano.node.metrics.txsProcessedNum.int.val // .cardano.node.metrics.txsProcessedNum_counter.val // 0,
+    .cardano.node.metrics.txsInMempool.int.val // .cardano.node.metrics.txsInMempool_int.val // 0,
+    .cardano.node.metrics.mempoolBytes.int.val // .cardano.node.metrics.mempoolBytes_int.val // 0,
+    .cardano.node.metrics.currentKESPeriod.int.val // .cardano.node.metrics.currentKESPeriod_int.val // 0,
+    .cardano.node.metrics.remainingKESPeriods.int.val // .cardano.node.metrics.remainingKESPeriods_int.val // 0,
+    .cardano.node.metrics.Forge["node-is-leader"].int.val // .cardano.node.metrics.Forge["node-is-leader_counter"].val // 0,
+    .cardano.node.metrics.Forge.adopted.int.val // .cardano.node.metrics.Forge["adopted_counter"].val // 0,
+    .cardano.node.metrics.Forge.forged.int.val // .cardano.node.metrics.Forge.["forged_counter"].val // 0,
+    .cardano.node.metrics.Forge["forge-about-to-lead"].int.val // .cardano.node.metrics.Forge["about-to-lead_counter"].val // 0,
+    .cardano.node.metrics.slotsMissedNum.int.val // .cardano.node.metrics.slotsMissed_int.val // 0,
+    .cardano.node.metrics.RTS.gcLiveBytes.int.val // .cardano.node.metrics.RTS.gcLiveBytes_int.val // 0,
+    .cardano.node.metrics.RTS.gcHeapBytes.int.val // .cardano.node.metrics.RTS.gcHeapBytes_int.val // 0,
+    .cardano.node.metrics.RTS.gcMinorNum.int.val // .cardano.node.metrics.RTS.gcMinorNum_int.val // 0,
+    .cardano.node.metrics.RTS.gcMajorNum.int.val // .cardano.node.metrics.RTS.gcMajorNum_int.val // 0,
+    .cardano.node.metrics.forks.int.val // .cardano.node.metrics.forks_counter.val // 0,
+    .cardano.node.metrics.blockfetchclient.blockdelay.s.val // .cardano.node.metrics.blockfetchclient.blockdelay_real.val // 0,
+    .cardano.node.metrics.served.block.count.int.val // .cardano.node.metrics.served.block_counter.val // 0,
+    .cardano.node.metrics.blockfetchclient.lateblocks.val // .cardano.node.metrics.blockfetchclient.lateblocks_counter.val // 0,
+    .cardano.node.metrics.blockfetchclient.blockdelay.cdfOne.val // .cardano.node.metrics.blockfetchclient.blockdelay.cdfOne_real.val // 0,
+    .cardano.node.metrics.blockfetchclient.blockdelay.cdfThree.val // .cardano.node.metrics.blockfetchclient.blockdelay.cdfThree_real.val // 0,
+    .cardano.node.metrics.blockfetchclient.blockdelay.cdfFive.val // .cardano.node.metrics.blockfetchclient.blockdelay.cdfFive_real.val // 0,
+    .cardano.node.metrics.peerSelection.cold.val // .cardano.node.metrics.peerSelection.Cold_int.val // 0,
+    .cardano.node.metrics.peerSelection.warm.val // .cardano.node.metrics.peerSelection.Warm_int.val // 0,
+    .cardano.node.metrics.peerSelection.hot.val // .cardano.node.metrics.peerSelection.Hot_int.val // 0,
+    .cardano.node.metrics.connectionManager.incomingConns.val // .cardano.node.metrics.connectionManager.inboundConns_int.val // 0,
+    .cardano.node.metrics.connectionManager.outgoingConns.val // .cardano.node.metrics.connectionManager.outboundConns_int.val // 0,
+    .cardano.node.metrics.connectionManager.unidirectionalConns.val // .cardano.node.metrics.connectionManager.unidirectionalConns_int.val // 0,
+    .cardano.node.metrics.connectionManager.duplexConns.val // .cardano.node.metrics.connectionManager.duplexConns_int.val // 0,
+    .cardano.node.metrics.connectionManager.fullDuplexConns.val // .cardano.node.metrics.connectionManager.fullDuplexConns_int.val // 0,
+    .cardano.node.metrics.forging_enabled.val // .cardano.node.metrics.forging_enabled_int.val // 0,
+    .cardano.node.metrics.cardano_build_info.val // .cardano.node.metrics.cardano_build_info.val // "-",
+    .cardano.node.metrics.inboundGovernor.warm.val // .cardano.node.metrics.inboundGovernor.warm_int.val // 0,
+    .cardano.node.metrics.inboundGovernor.hot.val // .cardano.node.metrics.inboundGovernor.hot_int.val // 0
     ] | @tsv' <<< "${node_metrics}")
     read -ra node_metrics_arr <<< ${node_metrics_tsv}
     blocknum=${node_metrics_arr[0]}; epochnum=${node_metrics_arr[1]}; slot_in_epoch=${node_metrics_arr[2]}; slotnum=${node_metrics_arr[3]}
     [[ ${node_metrics_arr[4]} != '-' ]] && density=$(bc <<< "scale=3;$(printf '%3.5f' "${node_metrics_arr[4]}")*100/1") || density=0.0
     tx_processed=${node_metrics_arr[5]}; mempool_tx=${node_metrics_arr[6]}; mempool_bytes=${node_metrics_arr[7]}
     kesperiod=${node_metrics_arr[8]}; remaining_kes_periods=${node_metrics_arr[9]}
-    isleader=${node_metrics_arr[10]}; adopted=${node_metrics_arr[11]}; didntadopt=${node_metrics_arr[12]}; about_to_lead=${node_metrics_arr[13]}
+    isleader=${node_metrics_arr[10]}; adopted=${node_metrics_arr[11]}; didntadopt=$(( ${node_metrics_arr[12]} - $adopted)); about_to_lead=${node_metrics_arr[13]}
     missed_slots=${node_metrics_arr[14]}
     mem_live=${node_metrics_arr[15]}; mem_heap=${node_metrics_arr[16]}
     gc_minor=${node_metrics_arr[17]}; gc_major=${node_metrics_arr[18]}
@@ -663,47 +663,47 @@ getNodeMetrics() {
     [[ ${node_metrics_arr[35]} =~ ,revision=\"([0-9a-f]*)\" ]] && running_node_rev=${BASH_REMATCH[1]:0:8} || running_node_rev="?"
     inbound_governor_warm=${node_metrics_arr[36]}; inbound_governor_hot=${node_metrics_arr[37]};
   else
-    node_metrics=$(curl -s -m ${EKG_TIMEOUT} "http://${PROM_HOST}:${PROM_PORT}/metrics" 2>/dev/null)
+    node_metrics=$(curl -s -m ${EKG_TIMEOUT} "http://${PROM_HOST}:${PROM_PORT}/${TRACE_NODE_NAME}/metrics" | grep -v '^# ' 2>/dev/null)
     [[ ${node_metrics} =~ cardano_node_metrics_blockNum_int[[:space:]]([^[:space:]]*) ]] && blocknum=${BASH_REMATCH[1]} || blocknum=0
     [[ ${node_metrics} =~ cardano_node_metrics_epoch_int[[:space:]]([^[:space:]]*) ]] && epochnum=${BASH_REMATCH[1]} || epochnum=0
     [[ ${node_metrics} =~ cardano_node_metrics_slotInEpoch_int[[:space:]]([^[:space:]]*) ]] && slot_in_epoch=${BASH_REMATCH[1]} || slot_in_epoch=0
     [[ ${node_metrics} =~ cardano_node_metrics_slotNum_int[[:space:]]([^[:space:]]*) ]] && slotnum=${BASH_REMATCH[1]} || slotnum=0
-    [[ ${node_metrics} =~ cardano_node_metrics_density_real[[:space:]]([^[:space:]]*) ]] && density=$(bc <<< "scale=3;$(printf '%3.5f' "${BASH_REMATCH[1]}")*100/1") || density=0.0
-    [[ ${node_metrics} =~ cardano_node_metrics_txsProcessedNum_int[[:space:]]([^[:space:]]*) ]] && tx_processed=${BASH_REMATCH[1]} || tx_processed=0
+    [[ ${node_metrics} =~ cardano_node_metrics_density_real[[:space:]]([^[:space:]]*) ]] && density=$(bc <<< "scale=3;$(printf '%3.5f' ${BASH_REMATCH[1]})*100/2") || density=0.0
+    [[ ${node_metrics} =~ cardano_node_metrics_txsProcessedNum_(int|counter)[[:space:]]([^[:space:]]*) ]] && tx_processed=${BASH_REMATCH[2]} || tx_processed=0
     [[ ${node_metrics} =~ cardano_node_metrics_txsInMempool_int[[:space:]]([^[:space:]]*) ]] && mempool_tx=${BASH_REMATCH[1]} || mempool_tx=0
     [[ ${node_metrics} =~ cardano_node_metrics_mempoolBytes_int[[:space:]]([^[:space:]]*) ]] && mempool_bytes=${BASH_REMATCH[1]} || mempool_bytes=0
     [[ ${node_metrics} =~ cardano_node_metrics_currentKESPeriod_int[[:space:]]([^[:space:]]*) ]] && kesperiod=${BASH_REMATCH[1]} || kesperiod=0
     [[ ${node_metrics} =~ cardano_node_metrics_remainingKESPeriods_int[[:space:]]([^[:space:]]*) ]] && remaining_kes_periods=${BASH_REMATCH[1]} || remaining_kes_periods=0
-    [[ ${node_metrics} =~ cardano_node_metrics_Forge_node_is_leader_int[[:space:]]([^[:space:]]*) ]] && isleader=${BASH_REMATCH[1]} || isleader=0
-    [[ ${node_metrics} =~ cardano_node_metrics_Forge_adopted_int[[:space:]]([^[:space:]]*) ]] && adopted=${BASH_REMATCH[1]} || adopted=0
-    [[ ${node_metrics} =~ cardano_node_metrics_Forge_didnt_adopt_int[[:space:]]([^[:space:]]*) ]] && didntadopt=${BASH_REMATCH[1]} || didntadopt=0
-    [[ ${node_metrics} =~ cardano_node_metrics_Forge_forge_about_to_lead_int[[:space:]]([^[:space:]]*) ]] && about_to_lead=${BASH_REMATCH[1]} || about_to_lead=0
-    [[ ${node_metrics} =~ cardano_node_metrics_slotsMissedNum_int[[:space:]]([^[:space:]]*) ]] && missed_slots=${BASH_REMATCH[1]} || missed_slots=0
+    [[ ${node_metrics} =~ cardano_node_metrics_Forge_node_is_leader_(int|counter)[[:space:]]([^[:space:]]*) ]] && isleader=${BASH_REMATCH[2]} || isleader=0
+    [[ ${node_metrics} =~ cardano_node_metrics_Forge_adopted_(int|counter)[[:space:]]([^[:space:]]*) ]] && adopted=${BASH_REMATCH[2]} || adopted=0
+    [[ ${node_metrics} =~ cardano_node_metrics_Forge_forged_(int|counter)[[:space:]]([^[:space:]]*) ]] && didntadopt=$(( ${BASH_REMATCH[2]} - $adopted ))  || dintadopt=0
+    [[ ${node_metrics} =~ cardano_node_metrics_Forge(_forge|)_about_to_lead_(int|counter)[[:space:]]([^[:space:]]*) ]] && about_to_lead=${BASH_REMATCH[3]} || about_to_lead=0
+    [[ ${node_metrics} =~ cardano_node_metrics_slotsMissed(Num|)_int[[:space:]]([^[:space:]]*) ]] && missed_slots=${BASH_REMATCH[2]} || missed_slots=0
     [[ ${node_metrics} =~ cardano_node_metrics_RTS_gcLiveBytes_int[[:space:]]([^[:space:]]*) ]] && mem_live=${BASH_REMATCH[1]} || mem_live=0
     [[ ${node_metrics} =~ cardano_node_metrics_RTS_gcHeapBytes_int[[:space:]]([^[:space:]]*) ]] && mem_heap=${BASH_REMATCH[1]} || mem_heap=0
     [[ ${node_metrics} =~ cardano_node_metrics_RTS_gcMinorNum_int[[:space:]]([^[:space:]]*) ]] && gc_minor=${BASH_REMATCH[1]} || gc_minor=0
     [[ ${node_metrics} =~ cardano_node_metrics_RTS_gcMajorNum_int[[:space:]]([^[:space:]]*) ]] && gc_major=${BASH_REMATCH[1]} || gc_major=0
-    [[ ${node_metrics} =~ cardano_node_metrics_forks_int[[:space:]]([^[:space:]]*) ]] && forks=${BASH_REMATCH[1]} || forks=0
-    [[ ${node_metrics} =~ cardano_node_metrics_blockfetchclient_blockdelay_s[[:space:]]([^[:space:]]*) ]] && block_delay=${BASH_REMATCH[1]} || block_delay=0
-    [[ ${node_metrics} =~ cardano_node_metrics_served_block_count_int[[:space:]]([^[:space:]]*) ]] && blocks_served=${BASH_REMATCH[1]} || blocks_served=0
-    [[ ${node_metrics} =~ cardano_node_metrics_blockfetchclient_lateblocks[[:space:]]([^[:space:]]*) ]] && blocks_late=${BASH_REMATCH[1]} || blocks_late=0
-    [[ ${node_metrics} =~ cardano_node_metrics_blockfetchclient_blockdelay_cdfOne[[:space:]]([^[:space:]]*) ]] && printf -v blocks_w1s "%.6f" ${BASH_REMATCH[1]} || blocks_w1s=0
-    [[ ${node_metrics} =~ cardano_node_metrics_blockfetchclient_blockdelay_cdfThree[[:space:]]([^[:space:]]*) ]] && printf -v blocks_w3s "%.6f" ${BASH_REMATCH[1]} || blocks_w3s=0
-    [[ ${node_metrics} =~ cardano_node_metrics_blockfetchclient_blockdelay_cdfFive[[:space:]]([^[:space:]]*) ]] && printf -v blocks_w5s "%.6f" ${BASH_REMATCH[1]} || blocks_w5s=0
-    [[ ${node_metrics} =~ cardano_node_metrics_peerSelection_cold[[:space:]]([^[:space:]]*) ]] && peer_selection_cold=${BASH_REMATCH[1]} || peer_selection_cold=0
-    [[ ${node_metrics} =~ cardano_node_metrics_peerSelection_warm[[:space:]]([^[:space:]]*) ]] && peer_selection_warm=${BASH_REMATCH[1]} || peer_selection_warm=0
-    [[ ${node_metrics} =~ cardano_node_metrics_peerSelection_hot[[:space:]]([^[:space:]]*) ]] && peer_selection_hot=${BASH_REMATCH[1]} || peer_selection_hot=0
-    [[ ${node_metrics} =~ cardano_node_metrics_connectionManager_incomingConns[[:space:]]([^[:space:]]*) ]] && conn_incoming=${BASH_REMATCH[1]} || conn_incoming=0
-    [[ ${node_metrics} =~ cardano_node_metrics_connectionManager_outgoingConns[[:space:]]([^[:space:]]*) ]] && conn_outgoing=${BASH_REMATCH[1]} || conn_outgoing=0
-    [[ ${node_metrics} =~ cardano_node_metrics_connectionManager_unidirectionalConns[[:space:]]([^[:space:]]*) ]] && conn_uni_dir=${BASH_REMATCH[1]} || conn_uni_dir=0
-    [[ ${node_metrics} =~ cardano_node_metrics_connectionManager_duplexConns[[:space:]]([^[:space:]]*) ]] && conn_bi_dir=${BASH_REMATCH[1]} || conn_bi_dir=0
-    [[ ${node_metrics} =~ cardano_node_metrics_connectionManager_fullDuplexConns[[:space:]]([^[:space:]]*) ]] && conn_duplex=${BASH_REMATCH[1]} || conn_duplex=0
-    [[ ${node_metrics} =~ cardano_node_metrics_forging_enabled[[:space:]]([^[:space:]]*) ]] && forging_enabled=${BASH_REMATCH[1]} || forging_enabled=0
-    [[ ${node_metrics} =~ cardano_node_metrics_cardano_build_info[[:space:]].*,version=\"([0-9.]*)\" ]] && running_node_version=${BASH_REMATCH[1]} || running_node_version="?"
-    [[ ${node_metrics} =~ cardano_node_metrics_cardano_build_info[[:space:]].*,revision=\"([0-9a-f]*)\" ]] && running_node_rev=${BASH_REMATCH[1]:0:8} || running_node_rev="?"
-    [[ ${node_metrics} =~ cardano_node_metrics_inboundGovernor_warm[[:space:]]([^[:space:]]*) ]] && inbound_governor_warm=${BASH_REMATCH[1]} || inbound_governor_warm=0
-    [[ ${node_metrics} =~ cardano_node_metrics_inboundGovernor_hot[[:space:]]([^[:space:]]*) ]] && inbound_governor_hot=${BASH_REMATCH[1]} || inbound_governor_hot=0
-  fi
+    [[ ${node_metrics} =~ cardano_node_metrics_forks_(int|counter)[[:space:]]([^[:space:]]*) ]] && forks=${BASH_REMATCH[2]} || forks=0
+    [[ ${node_metrics} =~ cardano_node_metrics_blockfetchclient_blockdelay_(s|real)[[:space:]]([^[:space:]]*) ]] && block_delay=${BASH_REMATCH[2]} || block_delay=0
+    [[ ${node_metrics} =~ cardano_node_metrics_served_block_count(er|_int)[[:space:]]([^[:space:]]*) ]] && blocks_served=${BASH_REMATCH[2]} || blocks_served=0
+    [[ ${node_metrics} =~ cardano_node_metrics_blockfetchclient_lateblocks(_counter|)[[:space:]]([^[:space:]]*) ]] && blocks_late=${BASH_REMATCH[2]} || blocks_late=0
+    [[ ${node_metrics} =~ cardano_node_metrics_blockfetchclient_blockdelay_cdfOne(_real|)[[:space:]]([^[:space:]]*) ]] && printf -v blocks_w1s "%.6f" ${BASH_REMATCH[2]} || blocks_w1s=0
+    [[ ${node_metrics} =~ cardano_node_metrics_blockfetchclient_blockdelay_cdfThree(_real|)[[:space:]]([^[:space:]]*) ]] && printf -v blocks_w3s "%.6f" ${BASH_REMATCH[2]} || blocks_w3s=0
+    [[ ${node_metrics} =~ cardano_node_metrics_blockfetchclient_blockdelay_cdfFive(_real|)[[:space:]]([^[:space:]]*) ]] && printf -v blocks_w5s "%.6f" ${BASH_REMATCH[2]} || blocks_w5s=0
+    [[ ${node_metrics} =~ cardano_node_metrics_peerSelection_[cC]old(_int|)[[:space:]]([^[:space:]]*) ]] && peer_selection_cold=${BASH_REMATCH[2]} || peer_selection_cold=0
+    [[ ${node_metrics} =~ cardano_node_metrics_peerSelection_[wW]arm(_int|)[[:space:]]([^[:space:]]*) ]] && peer_selection_warm=${BASH_REMATCH[2]} || peer_selection_warm=0
+    [[ ${node_metrics} =~ cardano_node_metrics_peerSelection_[hH]ot(_int|)[[:space:]]([^[:space:]]*) ]] && peer_selection_hot=${BASH_REMATCH[2]} || peer_selection_hot=0
+    [[ ${node_metrics} =~ cardano_node_metrics_connectionManager_(incoming|inbound)Conns(_int|)[[:space:]]([^[:space:]]*) ]] && conn_incoming=${BASH_REMATCH[3]} || conn_incoming=0
+    [[ ${node_metrics} =~ cardano_node_metrics_connectionManager_(outgoing|outbound)Conns(_int|)[[:space:]]([^[:space:]]*) ]] && conn_outgoing=${BASH_REMATCH[3]} || conn_outgoing=0
+    [[ ${node_metrics} =~ cardano_node_metrics_connectionManager_unidirectionalConns(_int|)[[:space:]]([^[:space:]]*) ]] && conn_uni_dir=${BASH_REMATCH[2]} || conn_uni_dir=0
+    [[ ${node_metrics} =~ cardano_node_metrics_connectionManager_duplexConns(_int|)[[:space:]]([^[:space:]]*) ]] && conn_bi_dir=${BASH_REMATCH[2]} || conn_bi_dir=0
+    [[ ${node_metrics} =~ cardano_node_metrics_connectionManager_fullDuplexConns(_int|)[[:space:]]([^[:space:]]*) ]] && conn_duplex=${BASH_REMATCH[2]} || conn_duplex=0
+    [[ ${node_metrics} =~ cardano_node_metrics_forging_enabled(_int|)[[:space:]]([^[:space:]]*) ]] && forging_enabled=${BASH_REMATCH[2]} || forging_enabled=0
+    [[ ${node_metrics} =~ cardano_node_metrics_cardano_build_info[[:space:]]*.*,version=\"([0-9.]*)\" ]] && running_node_version=${BASH_REMATCH[1]} || running_node_version="?"
+    [[ ${node_metrics} =~ cardano_node_metrics_cardano_build_info[[:space:]]*.*,revision=\"([0-9a-f]*)\" ]] && running_node_rev=${BASH_REMATCH[1]:0:8} || running_node_rev="?"
+    [[ ${node_metrics} =~ cardano_node_metrics_inboundGovernor_warm(_int|)[[:space:]]([^[:space:]]*) ]] && inbound_governor_warm=${BASH_REMATCH[2]} || inbound_governor_warm=0
+    [[ ${node_metrics} =~ cardano_node_metrics_inboundGovernor_hot(_int|)[[:space:]]([^[:space:]]*) ]] && inbound_governor_hot=${BASH_REMATCH[2]} || inbound_governor_hot=0
+ fi
 }
 
 # Description : Get shelley transition epoch for non-predefined networks
@@ -1166,9 +1166,9 @@ if ! command -v "jq" &>/dev/null; then
   return 1
 fi
 
-read -ra CONFIG_CONTENTS <<<"$(jq -r '[ .AlonzoGenesisFile //"null", .ByronGenesisFile //"null", .ShelleyGenesisFile //"null", .Protocol //"Cardano", .TraceChainDb //"null", .EnableP2P //"false", .ConwayGenesisFile //"null"]| @tsv' "${CONFIG}" 2>/dev/null)"
-if [[ ${CONFIG_CONTENTS[4]} != "true" ]]; then
-  echo "Could not find TraceChainDb when attempting to parse ${CONFIG} file in JSON format, please double-check the syntax of your config, or simply download it from guild-operators repository!"
+read -ra CONFIG_CONTENTS <<<"$(jq -r '[ .AlonzoGenesisFile //"null", .ByronGenesisFile //"null", .ShelleyGenesisFile //"null", .Protocol //"Cardano", .TraceChainDb // if (.UseTraceDispatcher == true) then "tracer" end // "null", .EnableP2P //"false", .ConwayGenesisFile //"null"]| @tsv' "${CONFIG}" 2>/dev/null)"
+if [[ ${CONFIG_CONTENTS[4]} == "null" ]]; then
+  echo "Could not find TraceChainDb or new tracing system is not enabled when attempting to parse ${CONFIG} file in JSON format, please double-check the syntax of your config, or simply download it from guild-operators repository!"
   return 1
 else
   CONWAY_GENESIS_JSON="${CONFIG_CONTENTS[6]}"
@@ -1188,6 +1188,21 @@ else
   GENESIS_HASH="$(${CCLI} hash genesis-file --genesis "${GENESIS_JSON}")"
   PROTOCOL="${CONFIG_CONTENTS[3]}"
   P2P_ENABLED="${CONFIG_CONTENTS[5]}"
+
+  # New tracer system settings.
+  USING_TRACER=false
+  [[ "${CONFIG_CONTENTS[4]}" == "tracer" ]] && USING_TRACER=true
+
+  # If using the new tracer then tracer config must be set
+  if [[ $USING_TRACER && -z "$TRACER_CONFIG" ]]; then
+    echo "Set TRACER_CONFIG to the tracer config file when using cardano-tracer."
+    return 1
+  fi
+
+  $USING_TRACER || TRACER_CONFIG=${CONFIG}
+
+  # Set the trace otpion node name for the tracer. it defaults to the <hostname>_<CNODE_PORT> 
+  $USING_TRACER && TRACE_NODE_NAME=$(jq -r '.TraceOptionNodeName // "'$(hostname)'_'"$CNODE_PORT"'"' "$CONFIG" 2>/dev/null)
 fi
 
 [[ -z ${EKG_TIMEOUT} ]] && EKG_TIMEOUT=3
@@ -1198,9 +1213,9 @@ if ! isValidIPv4 "${EKG_HOST}" && ! isValidHostnameOrDomain "${EKG_HOST}"; then
 fi
 
 if [[ -z ${EKG_PORT} ]]; then
-  if ! EKG_PORT=$(jq -er '.hasEKG | if .|type=="array" then .[1] else . end' "${CONFIG}" 2>/dev/null); then
+  if ! EKG_PORT=$(jq -er '.hasEKG | if .|type=="array" then .[1] else .epPort // . end' "${TRACER_CONFIG}" 2>/dev/null); then
     if [[ ${OFFLINE_MODE} = "N" ]]; then
-      echo "Could not get 'hasEKG' port in ${CONFIG}"
+      echo "Could not get 'hasEKG' port in ${TRACER_CONFIG}"
       return 1
     fi
   fi
@@ -1209,7 +1224,7 @@ elif [[ ! ${EKG_PORT} =~ ^[0-9]+$ ]]; then
   return 1
 fi
 
-if [[ -z ${PROM_HOST} ]]; then PROM_HOST=$(jq -er '.hasPrometheus[0]' "${CONFIG}" 2>/dev/null) || PROM_HOST=127.0.0.1; fi
+if [[ -z ${PROM_HOST} ]]; then PROM_HOST=$(jq -er '.hasPrometheus | if .|type=="array" then .[1] else .epHost // .  end' "${TRACER_CONFIG}" 2>/dev/null) || PROM_HOST=127.0.0.1; fi
 
 if [[ ${PROM_HOST} =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
   IFS='.' read -ra PROM_OCTETS <<< ${PROM_HOST}
@@ -1222,9 +1237,9 @@ else
   return 1
 fi
 if [[ -z ${PROM_PORT} ]]; then
-  if ! PROM_PORT=$(jq -er '.hasPrometheus[1]' "${CONFIG}" 2>/dev/null); then
+  if ! PROM_PORT=$(jq -er '.hasPrometheus | if .|type=="array" then .[1] else .epPort // .  end' "${TRACER_CONFIG}" 2>/dev/null); then
     if [[ ${OFFLINE_MODE} = "N" ]]; then
-      echo "Could not get 'hasPrometheus' port in ${CONFIG}"
+      echo "Could not get 'hasPrometheus' port in ${TRACER_CONFIG}"
       return 1
     fi
   fi
@@ -1240,7 +1255,9 @@ BLOCKLOG_DB="${BLOCKLOG_DIR}/blocklog.db"
 [[ -z "${IP_VERSION}" ]] && IP_VERSION=4
 IP_VERSION=$(tr '[:upper:]' '[:lower:]' <<< "${IP_VERSION}")
 [[ -z ${USE_EKG} ]] && USE_EKG='Y'
-CNODE_PID=$(pgrep -fn "$(basename ${CNODEBIN}).*.--port ${CNODE_PORT}")
+
+# Avoid using cardano-node PID as EKG and Prometheus are listening on the cardano-tracer's ports.
+$USING_TRACER || CNODE_PID=$(pgrep -fn "$(basename ${CNODEBIN}).*.--port ${CNODE_PORT}")
 
 if [[ ${OFFLINE_MODE} = "N" && -n "${CNODE_PID}" ]]; then
   if [[ "${USE_EKG}" == "N" ]]; then

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -646,7 +646,7 @@ getNodeMetrics() {
     [[ ${node_metrics_arr[4]} != '-' ]] && density=$(bc <<< "scale=3;$(printf '%3.5f' "${node_metrics_arr[4]}")*100/1") || density=0.0
     tx_processed=${node_metrics_arr[5]}; mempool_tx=${node_metrics_arr[6]}; mempool_bytes=${node_metrics_arr[7]}
     kesperiod=${node_metrics_arr[8]}; remaining_kes_periods=${node_metrics_arr[9]}
-    isleader=${node_metrics_arr[10]}; adopted=${node_metrics_arr[11]}; didntadopt=$(( ${node_metrics_arr[12]} - $adopted)); about_to_lead=${node_metrics_arr[13]}
+    isleader=${node_metrics_arr[10]}; adopted=${node_metrics_arr[11]}; didntadopt=$(( node_metrics_arr[12] - adopted)); about_to_lead=${node_metrics_arr[13]}
     missed_slots=${node_metrics_arr[14]}
     mem_live=${node_metrics_arr[15]}; mem_heap=${node_metrics_arr[16]}
     gc_minor=${node_metrics_arr[17]}; gc_major=${node_metrics_arr[18]}
@@ -676,7 +676,7 @@ getNodeMetrics() {
     [[ ${node_metrics} =~ cardano_node_metrics_remainingKESPeriods_int[[:space:]]([^[:space:]]*) ]] && remaining_kes_periods=${BASH_REMATCH[1]} || remaining_kes_periods=0
     [[ ${node_metrics} =~ cardano_node_metrics_Forge_node_is_leader_(int|counter)[[:space:]]([^[:space:]]*) ]] && isleader=${BASH_REMATCH[2]} || isleader=0
     [[ ${node_metrics} =~ cardano_node_metrics_Forge_adopted_(int|counter)[[:space:]]([^[:space:]]*) ]] && adopted=${BASH_REMATCH[2]} || adopted=0
-    [[ ${node_metrics} =~ cardano_node_metrics_Forge_forged_(int|counter)[[:space:]]([^[:space:]]*) ]] && didntadopt=$(( ${BASH_REMATCH[2]} - $adopted ))  || dintadopt=0
+    [[ ${node_metrics} =~ cardano_node_metrics_Forge_forged_(int|counter)[[:space:]]([^[:space:]]*) ]] && didntadopt=$(( BASH_REMATCH[2] - adopted ))  || dintadopt=0
     [[ ${node_metrics} =~ cardano_node_metrics_Forge(_forge|)_about_to_lead_(int|counter)[[:space:]]([^[:space:]]*) ]] && about_to_lead=${BASH_REMATCH[3]} || about_to_lead=0
     [[ ${node_metrics} =~ cardano_node_metrics_slotsMissed(Num|)_int[[:space:]]([^[:space:]]*) ]] && missed_slots=${BASH_REMATCH[2]} || missed_slots=0
     [[ ${node_metrics} =~ cardano_node_metrics_RTS_gcLiveBytes_int[[:space:]]([^[:space:]]*) ]] && mem_live=${BASH_REMATCH[1]} || mem_live=0
@@ -941,7 +941,7 @@ check_valid_port() {
     local port="$1"
     local name="$2"
 
-    if [[ -z "port" ]] || ! [[ "$port" =~ ^[0-9]+$ ]] || (( port < 1 || port > 65535 )); then
+    if [[ -z "$port" ]] || ! [[ "$port" =~ ^[0-9]+$ ]] || (( port < 1 || port > 65535 )); then
         echo "Please set a valid ${name} port number! Current value is \"${port}\"!"
         return 1
     fi

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -1166,7 +1166,7 @@ if ! command -v "jq" &>/dev/null; then
   return 1
 fi
 
-read -ra CONFIG_CONTENTS <<<"$(jq -r '[ .AlonzoGenesisFile //"null", .ByronGenesisFile //"null", .ShelleyGenesisFile //"null", .Protocol //"Cardano", .TraceChainDb // if (.UseTraceDispatcher == true) then "tracer" end // "null", .EnableP2P //"false", .ConwayGenesisFile //"null"]| @tsv' "${CONFIG}" 2>/dev/null)"
+read -ra CONFIG_CONTENTS <<<"$(jq -r '[ .AlonzoGenesisFile //"null", .ByronGenesisFile //"null", .ShelleyGenesisFile //"null", .Protocol //"Cardano", .TraceChainDb // (if .UseTraceDispatcher == true then "tracer" else "null" end), .EnableP2P //"false", .ConwayGenesisFile //"null"]| @tsv' "${CONFIG}" 2>/dev/null)"
 if [[ ${CONFIG_CONTENTS[4]} == "null" ]]; then
   echo "Could not find TraceChainDb or new tracing system is not enabled when attempting to parse ${CONFIG} file in JSON format, please double-check the syntax of your config, or simply download it from guild-operators repository!"
   return 1
@@ -1194,7 +1194,7 @@ else
   [[ "${CONFIG_CONTENTS[4]}" == "tracer" ]] && USING_TRACER=true
 
   # If using the new tracer then tracer config must be set
-  if [[ $USING_TRACER && -z "$TRACER_CONFIG" ]]; then
+  if [[ $USING_TRACER == "true" && -z "$TRACER_CONFIG" ]]; then
     echo "Set TRACER_CONFIG to the tracer config file when using cardano-tracer."
     return 1
   fi
@@ -1213,7 +1213,7 @@ if ! isValidIPv4 "${EKG_HOST}" && ! isValidHostnameOrDomain "${EKG_HOST}"; then
 fi
 
 if [[ -z ${EKG_PORT} ]]; then
-  if ! EKG_PORT=$(jq -er '.hasEKG | if .|type=="array" then .[1] else .epPort // . end' "${TRACER_CONFIG}" 2>/dev/null); then
+  if ! EKG_PORT=$(jq -er '.hasEKG | if .|type=="number" or type=="string" then . else .epPort // . end' "${TRACER_CONFIG}" 2>/dev/null); then
     if [[ ${OFFLINE_MODE} = "N" ]]; then
       echo "Could not get 'hasEKG' port in ${TRACER_CONFIG}"
       return 1
@@ -1224,7 +1224,7 @@ elif [[ ! ${EKG_PORT} =~ ^[0-9]+$ ]]; then
   return 1
 fi
 
-if [[ -z ${PROM_HOST} ]]; then PROM_HOST=$(jq -er '.hasPrometheus | if .|type=="array" then .[1] else .epHost // .  end' "${TRACER_CONFIG}" 2>/dev/null) || PROM_HOST=127.0.0.1; fi
+if [[ -z ${PROM_HOST} ]]; then PROM_HOST=$(jq -er '.hasPrometheus | if .|type=="array" then .[0] else .epHost // .  end' "${TRACER_CONFIG}" 2>/dev/null) || PROM_HOST=127.0.0.1; fi
 
 if [[ ${PROM_HOST} =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
   IFS='.' read -ra PROM_OCTETS <<< ${PROM_HOST}

--- a/scripts/cnode-helper-scripts/env
+++ b/scripts/cnode-helper-scripts/env
@@ -1303,17 +1303,6 @@ fi
 
 [[ -z ${EKG_TIMEOUT} ]] && EKG_TIMEOUT=3
 
-#echo "PROM_HOST: $PROM_HOST"
-#echo "PROM_PORT: $PROM_PORT"
-#echo "USE_EKG: $USE_EKG"
-#echo "EKG_HOST: $EKG_HOST"
-#echo "EKG_PORT: $EKG_PORT"
-#echo "CONFIG $CONFIG"
-#echo "TRACER_CONFIG: $TRACER_CONFIG"
-# return 1
-
-
-
 [[ -z ${BLOCKLOG_DIR} ]] && BLOCKLOG_DIR="${CNODE_HOME}/guild-db/blocklog"
 BLOCKLOG_DB="${BLOCKLOG_DIR}/blocklog.db"
 [[ -z ${BLOCKLOG_TZ} ]] && BLOCKLOG_TZ="UTC"


### PR DESCRIPTION
### Summary

This PR introduces partial support for the new tracing system available in `cardano-node` 10.5.1+, which uses a standalone `cardano-tracer` binary. The implementation ensures backward compatibility with legacy telemetry (built-in EKG and Prometheus endpoints), allowing `gLiveView.sh` and related tools to work seamlessly across different node versions.

### Key Changes

- Enhanced `env` file with optional config flags to support `cardano-tracer`
- Compatible parsing logic for both legacy and tracer-based telemetry
- Maintains seamless usage of tools across versions (pre-10.5.1 and 10.5.1+)
- No changes required to `gLiveView.sh` logic directly — all handled via `env`

### Notes

- The new system will be **mandatory** from node version 10.6.0 onward.
- Prometheus is supported in both systems but with different structures and endpoints.
- EKG is no longer directly exposed by the node in the new system; only via `cardano-tracer` forwarding.
- This is a preparatory enhancement and does not yet finalize full tracer support.

### Testing

- Tested against both legacy and new telemetry configurations
- `gLiveView.sh` confirmed to load metrics and operate without error in both modes

Refs #1879
