### PR TITLE
Trace default for ChainSync.Client update

### DIFF
--- a/files/configs/guild/config.json
+++ b/files/configs/guild/config.json
@@ -55,7 +55,7 @@
       "severity": "Silence"
     },
     "ChainSync.Client": {
-      "severity": "Warning"
+      "severity": "Info"
     },
     "Net.ConnectionManager.Remote": {
       "severity": "Info"

--- a/files/configs/mainnet/config.json
+++ b/files/configs/mainnet/config.json
@@ -55,7 +55,7 @@
       "severity": "Silence"
     },
     "ChainSync.Client": {
-      "severity": "Warning"
+      "severity": "Info"
     },
     "Net.ConnectionManager.Remote": {
       "severity": "Info"

--- a/files/configs/preprod/config.json
+++ b/files/configs/preprod/config.json
@@ -54,7 +54,7 @@
       "severity": "Silence"
     },
     "ChainSync.Client": {
-      "severity": "Warning"
+      "severity": "Info"
     },
     "Net.ConnectionManager.Remote": {
       "severity": "Info"

--- a/files/configs/preview/config.json
+++ b/files/configs/preview/config.json
@@ -58,7 +58,7 @@
       "severity": "Silence"
     },
     "ChainSync.Client": {
-      "severity": "Warning"
+      "severity": "Info"
     },
     "Net.ConnectionManager.Remote": {
       "severity": "Info"


### PR DESCRIPTION
## Description
Change ChainSync.Client trace default from Warning to Info to get needed cardano_node_metrics_blockfetchclient_* metrics for gLiveView

