### PR TITLE
Mithril: Follow GitHub redirects when fetching release data and `networks.json`

### DIFF
--- a/scripts/cnode-helper-scripts/guild-deploy.sh
+++ b/scripts/cnode-helper-scripts/guild-deploy.sh
@@ -797,7 +797,7 @@ download_mithril() {
     [[ -z ${ARCH##*aarch64*} ]] && mthrl_arch="arm64" || mthrl_arch="x64"
     pushd "${HOME}"/tmp >/dev/null || err_exit "Could not enter temporary directory: ${HOME}/tmp"
     log_progress "Resolving Mithril release"
-    mithril_release="$(curl -s https://api.github.com/repos/input-output-hk/mithril/releases/latest | jq -r '.tag_name' 2>/dev/null)"
+    mithril_release="$(curl -sL https://api.github.com/repos/input-output-hk/mithril/releases/latest | jq -r '.tag_name' 2>/dev/null)"
     [[ -n "${mithril_release}" && "${mithril_release}" != "null" ]] || err_exit "Could not resolve Mithril release from GitHub."
     log_progress "Downloading Mithril signer/client" "${mithril_release}"
     rm -f mithril-signer mithril-client

--- a/scripts/cnode-helper-scripts/mithril.library
+++ b/scripts/cnode-helper-scripts/mithril.library
@@ -219,7 +219,7 @@ check_mithril_upgrade_safe() {
 
 set_node_minimum_version() {
   response_file=$(mktemp)
-  status_code=$(curl -s -o "$response_file" -w "%{http_code}" https://raw.githubusercontent.com/input-output-hk/mithril/${MITHRIL_LATEST_VERSION}/networks.json)
+  status_code=$(curl -sL -o "$response_file" -w "%{http_code}" https://raw.githubusercontent.com/input-output-hk/mithril/${MITHRIL_LATEST_VERSION}/networks.json)
 
   if [[ "${status_code}" -gt 200 ]]; then
     echo "ERROR: Failed to download the networks.json file from the mithril repository! curl status code: ${status_code}."


### PR DESCRIPTION
## Description

This PR includes a **hardening of the Mithril GitHub fetches to make them future proof with upcoming updates of the URLs**, which may be served through redirects:

- Add `-L` to the curl call resolving the latest Mithril release in `guild-deploy.sh` (`download_mithril`)
- Add `-L` to the curl call fetching `networks.json` in `mithril.library` (`set_node_minimum_version`)

