### PR TITLE
Mithril: Point GitHub URLs at the IntersectMBO repository

### DIFF
--- a/.github/workflows/mithril-latest.yml
+++ b/.github/workflows/mithril-latest.yml
@@ -14,7 +14,7 @@ jobs:
           ref: alpha
       - name: Fetch Mithril release version
         run: |
-          UPVERSION=$(curl -sL https://api.github.com/repos/input-output-hk/mithril/releases/latest | jq -r '.tag_name')
+          UPVERSION=$(curl -sL https://api.github.com/repos/IntersectMBO/mithril/releases/latest | jq -r '.tag_name')
           [[ "${UPVERSION}" != "null" ]] && echo ${UPVERSION} > files/docker/node/release-versions/mithril-latest.txt
       - name: Assigns release version
         run: |

--- a/scripts/cnode-helper-scripts/guild-deploy.sh
+++ b/scripts/cnode-helper-scripts/guild-deploy.sh
@@ -797,11 +797,11 @@ download_mithril() {
     [[ -z ${ARCH##*aarch64*} ]] && mthrl_arch="arm64" || mthrl_arch="x64"
     pushd "${HOME}"/tmp >/dev/null || err_exit "Could not enter temporary directory: ${HOME}/tmp"
     log_progress "Resolving Mithril release"
-    mithril_release="$(curl -sL https://api.github.com/repos/input-output-hk/mithril/releases/latest | jq -r '.tag_name' 2>/dev/null)"
+    mithril_release="$(curl -sL https://api.github.com/repos/IntersectMBO/mithril/releases/latest | jq -r '.tag_name' 2>/dev/null)"
     [[ -n "${mithril_release}" && "${mithril_release}" != "null" ]] || err_exit "Could not resolve Mithril release from GitHub."
     log_progress "Downloading Mithril signer/client" "${mithril_release}"
     rm -f mithril-signer mithril-client
-    curl -m 200 -sfL https://github.com/input-output-hk/mithril/releases/download/${mithril_release}/mithril-${mithril_release}-linux-${mthrl_arch}.tar.gz -o mithril.tar.gz || err_exit "Could not download Mithril release ${mithril_release} from GitHub."
+    curl -m 200 -sfL https://github.com/IntersectMBO/mithril/releases/download/${mithril_release}/mithril-${mithril_release}-linux-${mthrl_arch}.tar.gz -o mithril.tar.gz || err_exit "Could not download Mithril release ${mithril_release} from GitHub."
     tar zxf mithril.tar.gz mithril-signer mithril-client &>/dev/null
     rm -f mithril.tar.gz
     [[ -f mithril-signer ]] || err_exit "Mithril archive downloaded, but binary 'mithril-signer' was not found after extraction."

--- a/scripts/cnode-helper-scripts/mithril.library
+++ b/scripts/cnode-helper-scripts/mithril.library
@@ -174,7 +174,7 @@ set_defaults() {
     esac
   fi
   AGGREGATOR_ENDPOINT=https://aggregator.${RELEASE}-${NETWORK_NAME,,}.api.mithril.network/aggregator
-  GENESIS_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/genesis.vkey)
+  GENESIS_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/genesis.vkey)
 }
 
 set_env_file_ownership() {
@@ -219,7 +219,7 @@ check_mithril_upgrade_safe() {
 
 set_node_minimum_version() {
   response_file=$(mktemp)
-  status_code=$(curl -sL -o "$response_file" -w "%{http_code}" https://raw.githubusercontent.com/input-output-hk/mithril/${MITHRIL_LATEST_VERSION}/networks.json)
+  status_code=$(curl -sL -o "$response_file" -w "%{http_code}" https://raw.githubusercontent.com/IntersectMBO/mithril/${MITHRIL_LATEST_VERSION}/networks.json)
 
   if [[ "${status_code}" -gt 200 ]]; then
     echo "ERROR: Failed to download the networks.json file from the mithril repository! curl status code: ${status_code}."
@@ -275,8 +275,8 @@ update_mithril_environment_for_client() {
 		RELEASE=${RELEASE}
 		AGGREGATOR_ENDPOINT=https://aggregator.${RELEASE}-${NETWORK_NAME,,}.api.mithril.network/aggregator
 		DB_DIRECTORY=${DB_DIR}
-		ANCILLARY_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/ancillary.vkey)
-		GENESIS_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/genesis.vkey)
+		ANCILLARY_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/ancillary.vkey)
+		GENESIS_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/genesis.vkey)
 		SNAPSHOT_DIGEST=latest
 		EOF"
 }
@@ -714,8 +714,8 @@ update_mithril_environment_for_signer() {
 
 
   # Generate the full set of environment variables required by Mithril signer use case
-  export ERA_READER_ADDRESS=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/era.addr
-  export ERA_READER_VKEY=https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/era.vkey
+  export ERA_READER_ADDRESS=https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/era.addr
+  export ERA_READER_VKEY=https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/era.vkey
   ${sudo} bash -c "cat <<-'EOF' > ${MITHRIL_HOME}/mithril.env
 		KES_SECRET_KEY_PATH=${POOL_DIR}/${POOL_HOTKEY_SK_FILENAME}
 		OPERATIONAL_CERTIFICATE_PATH=${POOL_DIR}/${POOL_OPCERT_FILENAME}
@@ -730,8 +730,8 @@ update_mithril_environment_for_signer() {
 		STORE_RETENTION_LIMITS=5
 		ERA_READER_ADAPTER_TYPE=cardano-chain
 		ERA_READER_ADAPTER_PARAMS=$(jq -nc --arg address "$(wget -q -O - "${ERA_READER_ADDRESS}")" --arg verification_key "$(wget -q -O - "${ERA_READER_VKEY}")" '{"address": $address, "verification_key": $verification_key}')
-		ANCILLARY_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/ancillary.vkey)
-		GENESIS_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/genesis.vkey)
+		ANCILLARY_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/ancillary.vkey)
+		GENESIS_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/IntersectMBO/mithril/main/mithril-infra/configuration/${RELEASE}-${NETWORK_NAME,,}/genesis.vkey)
 		PARTY_ID=$(cat ${POOL_DIR}/${POOL_ID_FILENAME}-bech32)
 		SNAPSHOT_DIGEST=latest
 		EOF"


### PR DESCRIPTION
Follow-up to #1910 (which added redirect-following): now that the Mithril repository has moved, this repoints every Mithril GitHub URL from `input-output-hk/mithril` to `IntersectMBO/mithril`:
- `guild-deploy.sh`: the release resolution (`api.github.com`) and the tarball download.
- `mithril.library`: the `networks.json`, verification-key, and era fetches.
- `.github/workflows/mithril-latest.yml`: the release-tracking version-bump lookup.